### PR TITLE
Close file after writing

### DIFF
--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg.py
@@ -53,12 +53,8 @@ import nhd_network_utilities as nnu
 import nhd_reach_utilities as nru
 
 
-if WRITE_OUTPUT:
-    # write to file 
-    def writetoFile(file, writeString):
-        file.write(writeString + '\n')
-        file.flush()
-        os.fsync(file.fileno())
+def writetoFile(file, writeString):
+    file.write(writeString + '\n')
 
 
 def compute_network(
@@ -249,7 +245,9 @@ def compute_mc_reach_up2down(
         if verbose: print(f'{current_segment} --> {next_segment}\n')
         current_segment = next_segment
         next_segment = connections[current_segment]['downstream']
-        # end loop initialized the MC vars 
+        # end loop initialized the MC vars
+    if WRITE_OUTPUT:
+        file.close()
 
 
 def singlesegment(

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg.py
@@ -54,7 +54,8 @@ import nhd_reach_utilities as nru
 
 
 def writetoFile(file, writeString):
-    file.write(writeString + '\n')
+    file.write(writeString)
+    file.write('\n')
 
 
 def compute_network(


### PR DESCRIPTION
This change addresses two issues:
1. Closes an opened file handle that wasn't closed otherwise. This automatically flushes the file.
2. Removes a costly fsync on every write.

On my machine this results in the default test case runtime dropping to from 6.8s to 0.2s.

Ping: @jameshalgren 
