### PR TITLE
Add print waterbody downstreams

### DIFF
--- a/src/python_framework/networkbuilder.py
+++ b/src/python_framework/networkbuilder.py
@@ -391,6 +391,8 @@ def main():
     print("")
     print("Executing Test")
     # Test data
+    debuglevel = -3
+    verbose = True
     test_rows = [
         [50, 178, 51, 0],
         [51, 178, 50, 0],
@@ -450,8 +452,8 @@ def main():
         mask_set={row[test_key_col] for row in test_rows},
         downstream_col=test_downstream_col,
         length_col=test_length_col,
-        verbose=True,
-        debuglevel=-2,
+        verbose=verbose,
+        debuglevel=debuglevel,
     )
 
     (
@@ -464,8 +466,8 @@ def main():
     ) = determine_keys(
         connections=test_connections,
         terminal_code=test_terminal_code,
-        verbose=True,
-        debuglevel=-2,
+        verbose=verbose,
+        debuglevel=debuglevel,
     )
 
     (
@@ -479,8 +481,8 @@ def main():
         terminal_code=test_terminal_code,
         headwater_keys=test_headwater_keys,
         terminal_keys=test_terminal_keys,
-        verbose=True,
-        debuglevel=-2,
+        verbose=verbose,
+        debuglevel=debuglevel,
     )
 
     # TODO: Set/pass/identify a proper flag value
@@ -496,8 +498,8 @@ def main():
             terminal_code=test_terminal_code,
             waterbody_col=test_waterbody_col,
             waterbody_null_code=test_waterbody_null_code,
-            verbose=True,
-            debuglevel=-2,
+            verbose=verbose,
+            debuglevel=debuglevel,
         )
 
     recursive_print.print_connections(
@@ -507,7 +509,7 @@ def main():
         terminal_code=test_terminal_code,
         terminal_keys=test_terminal_keys,
         terminal_ref_keys=test_terminal_ref_keys,
-        debuglevel=-2,
+        debuglevel=debuglevel,
     )
 
     recursive_print.print_basic_network_info(
@@ -516,8 +518,8 @@ def main():
         junction_keys=test_junction_keys,
         terminal_keys=test_terminal_keys,
         terminal_code=test_terminal_code,
-        verbose=True,
-        debuglevel=-2,
+        verbose=verbose,
+        debuglevel=debuglevel,
     )
 
 

--- a/src/python_framework/networkbuilder.py
+++ b/src/python_framework/networkbuilder.py
@@ -95,6 +95,20 @@ def get_waterbody_segments(
         print("waterbody_outlet_set complete")
 
     if verbose:
+        print("waterbody_downstream_set ...")
+    waterbody_downstream_set = set()
+    for outlet_segment in waterbody_outlet_set:
+        waterbody_downstream_set.add(connections[outlet_segment][downstream_key])
+    if debuglevel <= -1:
+        print(
+            f"found {len(waterbody_downstream_set)} segments that are below outlets of a waterbody"
+        )
+    if debuglevel <= -3:
+        print(waterbody_downstream_set)
+    if verbose:
+        print("waterbody_downstream_set complete")
+
+    if verbose:
         print("waterbody_upstreams_set ...")
     waterbody_upstreams_set = set()
     for waterbody_segment in waterbody_segments:
@@ -118,6 +132,7 @@ def get_waterbody_segments(
         waterbody_segments,
         waterbody_outlet_set,
         waterbody_upstreams_set,
+        waterbody_downstream_set,
     )
 
 
@@ -475,6 +490,7 @@ def main():
             test_waterbody_segments,
             test_waterbody_outlet_set,
             test_waterbody_upstreams_set,
+            test_waterbody_downstream_set,
         ) = get_waterbody_segments(
             connections=test_connections,
             terminal_code=test_terminal_code,

--- a/src/python_framework/nhd_network_utilities.py
+++ b/src/python_framework/nhd_network_utilities.py
@@ -183,6 +183,7 @@ def build_connections_object(
     waterbody_segments = None
     waterbody_outlet_set = None
     waterbody_upstreams_set = None
+    waterbody_downstream_set = None
 
     # TODO: Set/pass/identify a proper flag value
     if waterbody_col is not None:
@@ -191,6 +192,7 @@ def build_connections_object(
             waterbody_segments,
             waterbody_outlet_set,
             waterbody_upstreams_set,
+            waterbody_downstream_set,
         ) = networkbuilder.get_waterbody_segments(
             connections=connections,
             terminal_code=terminal_code,
@@ -219,6 +221,7 @@ def build_connections_object(
         waterbody_segments,
         waterbody_outlet_set,
         waterbody_upstreams_set,
+        waterbody_downstream_set,
     )
 
 

--- a/src/python_framework/nhd_network_utilities.py
+++ b/src/python_framework/nhd_network_utilities.py
@@ -125,6 +125,7 @@ def get_geo_file_table_rows(
     return geo_file_rows
 
 
+#TODO: Give this function a more appropriate general name (it does more that build connections)
 def build_connections_object(
     geo_file_rows=None,
     mask_set=None,
@@ -627,6 +628,7 @@ def set_supernetwork_data(
         return data
 
 
+#TODO: confirm that this function is not used, and if so, consider removing it
 def set_networks(supernetwork="", geo_input_folder=None, verbose=True, debuglevel=0):
 
     supernetwork_data = set_supernetwork_data(


### PR DESCRIPTION
To assist with determining points of connection between waterbodies and associated downstream segments/reaches/networks, this function adds a set designating the segments that are downstream of waterbodies -- i.e., the upstream-most segments of networks below a water body. 

The main work of this function occurs in networkbuilder.py in the function `get_waterbody_segments`. The various sets generated by the get_waterbody_segments are returned as part of the tuple handled by the `get_nhd_connections`  in nhd_network_utilities.py. 

The result of this change is observed by directly executing networkbuilder.py:
```
python networkbuilder.py
``` 
... or by calling the function with one of the example networks in the network traversal tool, setting the debuglevel to 3 to get a full printout of the waterbody sets, as in:
```
python nhd_network_traversal.py -w -n Pocono_TEST1 --debuglevel 3
```