### PR TITLE
 Change 2.0.2 --> 2.0.3 in v02 network utilities

### DIFF
--- a/src/python_framework_v02/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/nhd_network_utilities_v02.py
@@ -289,7 +289,7 @@ def set_supernetwork_data(
     elif supernetwork == "CONUS_FULL_RES_v20":
 
         ROUTELINK = "RouteLink_NHDPLUS"
-        ModelVer = "nwm.v2.0.2"
+        ModelVer = "nwm.v2.0.3"
         ext = "nc"
         sep = "."
 


### PR DESCRIPTION
See issue #133 
>Needed to change this because version has been updated online. nw,.v2.0.2 no longer exists. Without this change, any existing code that automatically downloads the NHD dataset will not work.

Originally posted by @awlostowski-noaa in #88 (comment)