### PR TITLE
Bugfix csv nc write

### DIFF
--- a/src/python_routing_v01/compute_nhd_routing_SingleSeg.py
+++ b/src/python_routing_v01/compute_nhd_routing_SingleSeg.py
@@ -82,7 +82,7 @@ def _handle_args():
         nargs="?",
         help="Write csv output files to this folder (omit flag for no csv writing)",
         dest="csv_output_folder",
-        const="../../test/input/text",
+        const="../../test/output/text",
     )
     parser.add_argument(
         "-onc",
@@ -90,7 +90,7 @@ def _handle_args():
         nargs="?",
         help="Write netcdf output files to this folder (omit flag for no netcdf writing)",
         dest="nc_output_folder",
-        const="../../test/input/nc",
+        const="../../test/output/nc",
     )
     parser.add_argument(
         "--dt",

--- a/src/python_routing_v01/compute_nhd_routing_SingleSeg.py
+++ b/src/python_routing_v01/compute_nhd_routing_SingleSeg.py
@@ -79,16 +79,18 @@ def _handle_args():
     parser.add_argument(
         "-ocsv",
         "--write-output-csv",
+        nargs="?",
         help="Write csv output files to this folder (omit flag for no csv writing)",
         dest="csv_output_folder",
-        action="store_true",
+        const="../../test/input/text",
     )
     parser.add_argument(
         "-onc",
         "--write-output-nc",
+        nargs="?",
         help="Write netcdf output files to this folder (omit flag for no netcdf writing)",
         dest="nc_output_folder",
-        action="store_true",
+        const="../../test/input/nc",
     )
     parser.add_argument(
         "--dt",
@@ -1198,7 +1200,10 @@ def main():
         verbose = args.verbose
         showtiming = args.showtiming
         do_network_analysis_only = args.do_network_analysis_only
-        csv_output = {"csv_output_folder": args.csv_output_folder}
+        if args.csv_output_folder:
+            csv_output = {"csv_output_folder": args.csv_output_folder}
+        else:
+            csv_output = None
         nc_output_folder = args.nc_output_folder
         assume_short_ts = args.assume_short_ts
         parallel_compute = args.parallel_compute
@@ -1387,7 +1392,9 @@ def main():
         waterbodies_df = nio.read_waterbody_df(
             waterbody_parameters, waterbodies_values,
         )
-        waterbodies_df = waterbodies_df.sort_index(axis="index").sort_index(axis="columns")
+        waterbodies_df = waterbodies_df.sort_index(axis="index").sort_index(
+            axis="columns"
+        )
 
         nru.order_networks(connections, networks, connections_tailwaters)
 


### PR DESCRIPTION
Correcting the CSV and NC write capabilities, which were broken with #137 

The input handler was passing `{"csv_output_folder":None}` and should instead have been passing simply `None`

This was corrected by better logic in the input handler as well as a slight change to the arg parser to provide a default value if the `-ocsv` or `-onc` flags are provided with no arguments. (The argument they accept is a custom path; the default paths are `../../test/output/csv` and `../../test/output/nc` )