### PR TITLE
Structured network compute

### DIFF
--- a/src/python_framework_v02/troute/network/reach.pxd
+++ b/src/python_framework_v02/troute/network/reach.pxd
@@ -1,4 +1,7 @@
 cimport numpy as np
+"""
+FIXME add some significant inline documentation
+"""
 
 cdef class Segment():
   """
@@ -14,12 +17,29 @@ cdef class MC_Segment(Segment):
   """
   #TODO document these attributes
   cdef readonly float dt, dx, bw, tw, twcc, n, ncc, cs, s0
-  cdef float qdp, velp, depthp
+  cdef readonly float qdp, velp, depthp
+
+cdef struct _MC_Segment:
+
+  long id
+  float dt, dx, bw, tw, twcc, n, ncc, cs, s0
+  float qdp, velp, depthp
+
+cdef struct _MC_Reach:
+  _MC_Segment* _segments
+  int _num_segments
+  long* _upstream_ids
+  int _num_upstream_ids
 
 cdef class MC_Reach():
   """
     A muskingcung reach -> collection of ordered MC_Segments
   """
+  cdef _MC_Segment* _segments
+  cdef int _num_segments # C only accessible
+  cdef readonly num_segments #Python accessible, readonly outside class
+  cdef int _num_upstream_ids
+  cdef _MC_Reach _reach
   cdef readonly list segments
   cdef readonly np.ndarray upstream_ids
   cdef route(self)

--- a/src/python_framework_v02/troute/network/reach.pyx
+++ b/src/python_framework_v02/troute/network/reach.pyx
@@ -69,8 +69,42 @@ cdef class MC_Reach():
   #cdef readonly np.ndarray upstream_ids
 
   def __init__(self, segments, long[::1] upstream_ids):
+    self._num_segments = len(segments)
+    self._num_upstream_ids = len(upstream_ids)
+
+    self._segments = <_MC_Segment*> malloc(sizeof(_MC_Segment)*(self._num_segments))
+    for i, segment in enumerate(segments):
+      self._segments[i].id = segment.id
+      self._segments[i].dt = segment.dt
+      self._segments[i].dx = segment.dx
+      self._segments[i].bw = segment.bw
+      self._segments[i].tw = segment.tw
+      self._segments[i].twcc = segment.twcc
+      self._segments[i].n = segment.n
+      self._segments[i].ncc = segment.ncc
+      self._segments[i].cs = segment.cs
+      self._segments[i].s0 = segment.s0
+      self._segments[i].qdp = segment.qdp
+      self._segments[i].velp = segment.velp
+      self._segments[i].depthp = segment.depthp
+
     self.segments = segments
     self.upstream_ids = np.asarray(upstream_ids)
+    #init the C struct
+    self._reach._segments = self._segments
+    self._reach._num_segments = self._num_segments
+    self.num_segments = self._num_segments
+    self._reach._upstream_ids = <long*>malloc(sizeof(long)*self._num_upstream_ids)
+    self._reach._num_upstream_ids = self._num_upstream_ids
+    for i in range(self._num_upstream_ids):
+      self._reach._upstream_ids[i] = upstream_ids[i]
+
+  def __dealloc__(self):
+    """
+
+    """
+    free(self._segments)
+    free(self._reach._upstream_ids)
 
   cdef route(self):
     """

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -33,6 +33,13 @@ def _handle_args():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
     parser.add_argument(
+        "--nts",
+        "--number-of-qlateral-timesteps",
+        help="Set the number of timesteps to execute. If used with ql_file or ql_folder, nts must be less than len(ql) x qN.",
+        dest="nts",
+        default=144,
+    )
+    parser.add_argument(
         "--debuglevel",
         help="Set the debuglevel",
         dest="debuglevel",

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -33,21 +33,6 @@ def _handle_args():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
     parser.add_argument(
-        "-ocsv",
-        "--write-output-csv",
-        nargs="?",
-        help="Write csv output files to this folder (omit flag for no csv writing)",
-        dest="csv_output_folder",
-        const="../../test/output/text",
-    )
-    parser.add_argument(
-        "--nts",
-        "--number-of-qlateral-timesteps",
-        help="Set the number of timesteps to execute. If used with ql_file or ql_folder, nts must be less than len(ql) x qN.",
-        dest="nts",
-        default=144,
-    )
-    parser.add_argument(
         "--debuglevel",
         help="Set the debuglevel",
         dest="debuglevel",

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -33,6 +33,14 @@ def _handle_args():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
     parser.add_argument(
+        "-ocsv",
+        "--write-output-csv",
+        nargs="?",
+        help="Write csv output files to this folder (omit flag for no csv writing)",
+        dest="csv_output_folder",
+        const="../../test/output/text",
+    )
+    parser.add_argument(
         "--nts",
         "--number-of-qlateral-timesteps",
         help="Set the number of timesteps to execute. If used with ql_file or ql_folder, nts must be less than len(ql) x qN.",

--- a/src/python_routing_v02/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/fast_reach/mc_reach.pyx
@@ -7,8 +7,11 @@ from numpy cimport ndarray
 from array import array
 cimport numpy as np
 cimport cython
+from libc.stdlib cimport malloc, free
+#Note may get slightly better performance using cython mem module (pulls from python's heap)
+#from cpython.mem cimport PyMem_Malloc, PyMem_Free
+from troute.network.reach cimport MC_Segment, MC_Reach, _MC_Segment, _MC_Reach
 from cython.parallel import prange
-
 #import cProfile
 #pr = cProfile.Profile()
 #NJF For whatever reason, when cimporting muskingcunge from reach, the linker breaks in weird ways
@@ -800,3 +803,164 @@ cpdef object compute_network_structured_obj(int nsteps, list reaches, dict conne
     #pr.disable()
     #pr.print_stats(sort='time')
     return np.asarray(data_idx, dtype=np.intp), np.asarray(flowveldepth.reshape(flowveldepth.shape[0], -1), dtype='float32')
+
+
+cpdef object compute_network_structured(int nsteps, list reaches, dict connections,
+    const long[:] data_idx, object[:] data_cols, const float[:,:] data_values,
+    const float[:, :] qlat_values, const float[:,:] initial_conditions,
+    # const float[:] wbody_idx, object[:] wbody_cols, const float[:, :] wbody_vals,
+    bint assume_short_ts=False):
+    """
+    Compute network
+    Args:
+        nsteps (int): number of time steps
+        reaches (list): List of reaches
+        connections (dict): Network
+        data_idx (ndarray): a 1D sorted index for data_values
+        data_values (ndarray): a 2D array of data inputs (nodes x variables)
+        qlats (ndarray): a 2D array of qlat values (nodes x nsteps). The index must be shared with data_values
+        initial_conditions (ndarray): an n x 3 array of initial conditions. n = nodes, column 1 = qu0, column 2 = qd0, column 3 = h0
+        assume_short_ts (bool): Assume short time steps (quc = qup)
+    Notes:
+        Array dimensions are checked as a precondition to this method.
+        This version creates python objects for segments and reaches,
+        but then uses only the C structures and access for efficiency
+    """
+    # Check shapes
+    if qlat_values.shape[0] != data_idx.shape[0]:
+        raise ValueError(f"Number of rows in Qlat is incorrect: expected ({data_idx.shape[0]}), got ({qlat_values.shape[0]})")
+    if qlat_values.shape[1] > nsteps:
+        raise ValueError(f"Number of columns (timesteps) in Qlat is incorrect: expected at most ({data_idx.shape[0]}), got ({qlat_values.shape[0]}). The number of columns in Qlat must be equal to or less than the number of routing timesteps")
+    if data_values.shape[0] != data_idx.shape[0] or data_values.shape[1] != data_cols.shape[0]:
+        raise ValueError(f"data_values shape mismatch")
+    #define an intialize the final output array
+    cdef np.ndarray[float, ndim=3] flowveldepth_nd = np.zeros((data_idx.shape[0], nsteps, 3), dtype='float32')
+    #Make ndarrays from the mem views for convience of indexing...may be a better method
+    cdef np.ndarray[float, ndim=2] data_array = np.asarray(data_values)
+    cdef np.ndarray[float, ndim=2] init_array = np.asarray(initial_conditions)
+    cdef np.ndarray[float, ndim=2] qlat_array = np.asarray(qlat_values)
+    ###### Declare/type variables #####
+    cdef Py_ssize_t max_buff_size = 0
+    #lists to hold reach definitions, i.e. list of ids
+    cdef list reach
+    cdef list upstream_reach
+    #lists to hold segment ids
+    cdef list segment_ids
+    cdef list upstream_ids
+    #flow accumulation variables
+    cdef float upstream_flows, previous_upstream_flows
+    #starting timestep, shifted by 1 to account for initial conditions
+    cdef int timestep = 1
+    #buffers to pass to compute_reach_kernel
+    cdef float[:,:] buf_view
+    cdef float[:,:] out_buf
+    cdef float[:] lateral_flowsr
+    # list of reach objects to operate on
+    cdef list reach_objects = []
+    cdef list segment_objects
+    #pre compute the qlat resample fraction
+    cdef double qlat_resample = (nsteps)/qlat_values.shape[1]
+
+    cdef long sid
+    cdef _MC_Segment segment
+    #pr.enable()
+    #Preprocess the raw reaches, creating MC_Reach/MC_Segments
+    for reach in reaches:
+      upstream_reach = connections.get(reach[0], ())
+      segment_ids = binary_find(data_idx, reach)
+
+      if len(upstream_reach) > 0:
+        upstream_ids = binary_find(data_idx, upstream_reach)
+      else:
+        upstream_ids = []
+
+      #Set the initial condtions before running loop
+      flowveldepth_nd[segment_ids, 0] = init_array[segment_ids]
+      #Using the segment/reach classes essentially as factory methods to create the lower level C structs
+      #This loop isn't intensive, so the python list overhead is minimal
+      #Could move to more direct creation/use for fine tuned optimization
+      segment_objects = []
+      #Find the max reach size, used to create buffer for compute_reach_kernel
+      if len(segment_ids) > max_buff_size:
+        max_buff_size=len(segment_ids)
+
+      for sid in segment_ids:
+        #FIXME data_array order is important, column_mapper might help with this
+        segment_objects.append(
+            MC_Segment(sid, *data_array[sid], *init_array[sid])
+            )
+
+      reach_objects.append(
+          MC_Reach(segment_objects, array('l',upstream_ids))
+          )
+
+    #Init buffers
+    lateral_flows = np.zeros( max_buff_size, dtype='float32' )
+    buf_view = np.zeros( (max_buff_size, 13), dtype='float32')
+    out_buf = np.full( (max_buff_size, 3), -1, dtype='float32')
+
+    cdef int num_reaches = len(reach_objects)
+    #Dynamically allocate a C array of reach structs
+    cdef _MC_Reach* reach_structs = <_MC_Reach*>malloc(sizeof(_MC_Reach)*num_reaches)
+    #Populate the above array with the structs contained in each reach object
+    for i in range(num_reaches):
+      reach_structs[i] = (<MC_Reach>reach_objects[i])._reach
+
+    #reach iterator
+    cdef _MC_Reach r
+    #create a memory view of the ndarray
+    cdef float[:,:,::1] flowveldepth = flowveldepth_nd
+    #Run time
+    with nogil:
+      while timestep < nsteps:
+        #for r in reach_objects:
+        for i in range(num_reaches):
+              r = reach_structs[i]
+              #Need to get quc and qup
+              upstream_flows = 0.0
+              previous_upstream_flows = 0.0
+              for _i in range(r._num_upstream_ids):#Explicit loop reduces some overhead
+                id = r._upstream_ids[_i]
+                upstream_flows += flowveldepth[id, timestep, 0]
+                previous_upstream_flows += flowveldepth[id, timestep-1, 0]
+              #Index of segments required to process this reach
+              #segment_ids = []#[segment.id for segment in r._segments]
+
+              if assume_short_ts:
+                  upstream_flows = previous_upstream_flows
+              #Create compute reach kernel input buffer
+              #for i, segment in enumerate(r.segments):
+              for i in range(r._num_segments):
+                segment = r._segments[i]
+                buf_view[i][0] = qlat_array[ segment.id, <int>(timestep/qlat_resample)]
+                buf_view[i][1] = segment.dt
+                buf_view[i][2] = segment.dx
+                buf_view[i][3] = segment.bw
+                buf_view[i][4] = segment.tw
+                buf_view[i][5] = segment.twcc
+                buf_view[i][6] = segment.n
+                buf_view[i][7] = segment.ncc
+                buf_view[i][8] = segment.cs
+                buf_view[i][9] = segment.s0
+                buf_view[i][10] = flowveldepth[segment.id, timestep-1, 0]
+                buf_view[i][11] = flowveldepth[segment.id, timestep-1, 1]
+                buf_view[i][12] = flowveldepth[segment.id, timestep-1, 2]
+
+              compute_reach_kernel(previous_upstream_flows, upstream_flows,
+                                   r._num_segments, buf_view,
+                                   out_buf,
+                                   assume_short_ts)
+              #Copy the output out
+              for i in range(r._num_segments):
+                flowveldepth[r._segments[i].id, timestep, 0] = out_buf[i, 0]
+                flowveldepth[r._segments[i].id, timestep, 1] = out_buf[i, 1]
+                flowveldepth[r._segments[i].id, timestep, 2] = out_buf[i, 2]
+
+        timestep += 1
+    #copy t1 to t0 to be consistent
+    flowveldepth[:,0,:] = flowveldepth[:,1,:]
+    #pr.disable()
+    #pr.print_stats(sort='time')
+    #IMPORTANT, free the dynamic array created
+    free(reach_structs)
+    return np.asarray(data_idx, dtype=np.intp), np.asarray(flowveldepth.base.reshape(flowveldepth.shape[0], -1), dtype='float32')

--- a/src/python_routing_v02/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/fast_reach/mc_reach.pyx
@@ -4,10 +4,13 @@ import numpy as np
 from itertools import chain
 from operator import itemgetter
 from numpy cimport ndarray
+from array import array
 cimport numpy as np
 cimport cython
 from cython.parallel import prange
 
+#import cProfile
+#pr = cProfile.Profile()
 #NJF For whatever reason, when cimporting muskingcunge from reach, the linker breaks in weird ways
 #the mc_reach.so will have an undefined symbol _muskingcunge, and reach.so will have a ____pyx_f_5reach_muskingcunge
 #if you cimport reach, then call explicitly reach.muskingcung, then mc_reach.so maps to the correct module symbol
@@ -659,3 +662,141 @@ cpdef object compute_network_multithread(int nsteps, list reaches, dict connecti
             timestep += 1
 
     return np.asarray(data_idx, dtype=np.intp), np.asarray(flowveldepth, dtype='float32')
+
+cpdef object compute_network_structured_obj(int nsteps, list reaches, dict connections,
+    const long[:] data_idx, object[:] data_cols, const float[:,:] data_values,
+    const float[:, :] qlat_values, const float[:,:] initial_conditions,
+    # const float[:] wbody_idx, object[:] wbody_cols, const float[:, :] wbody_vals,
+    bint assume_short_ts=False):
+    """
+    Compute network
+    Args:
+        nsteps (int): number of time steps
+        reaches (list): List of reaches
+        connections (dict): Network
+        data_idx (ndarray): a 1D sorted index for data_values
+        data_values (ndarray): a 2D array of data inputs (nodes x variables)
+        qlats (ndarray): a 2D array of qlat values (nodes x nsteps). The index must be shared with data_values
+        initial_conditions (ndarray): an n x 3 array of initial conditions. n = nodes, column 1 = qu0, column 2 = qd0, column 3 = h0
+        assume_short_ts (bool): Assume short time steps (quc = qup)
+    Notes:
+        Array dimensions are checked as a precondition to this method.
+        This version uses only the cdef python object interface, and is a little slower
+        It is left here for reference, not reccomended for use
+    """
+    # Check shapes
+    if qlat_values.shape[0] != data_idx.shape[0]:
+        raise ValueError(f"Number of rows in Qlat is incorrect: expected ({data_idx.shape[0]}), got ({qlat_values.shape[0]})")
+    if qlat_values.shape[1] > nsteps:
+        raise ValueError(f"Number of columns (timesteps) in Qlat is incorrect: expected at most ({data_idx.shape[0]}), got ({qlat_values.shape[0]}). The number of columns in Qlat must be equal to or less than the number of routing timesteps")
+    if data_values.shape[0] != data_idx.shape[0] or data_values.shape[1] != data_cols.shape[0]:
+        raise ValueError(f"data_values shape mismatch")
+    #define an intialize the final output array
+    cdef np.ndarray[float, ndim=3] flowveldepth = np.zeros((data_idx.shape[0], nsteps, 3), dtype='float32')
+    #Make ndarrays from the mem views for convience of indexing...may be a better method
+    cdef np.ndarray[float, ndim=2] data_array = np.asarray(data_values)
+    cdef np.ndarray[float, ndim=2] init_array = np.asarray(initial_conditions)
+    cdef np.ndarray[float, ndim=2] qlat_array = np.asarray(qlat_values)
+    ###### Declare/type variables #####
+    cdef Py_ssize_t max_buff_size = 0
+    #lists to hold reach definitions, i.e. list of ids
+    cdef list reach
+    cdef list upstream_reach
+    #lists to hold segment ids
+    cdef list segment_ids
+    cdef list upstream_ids
+    #flow accumulation variables
+    cdef float upstream_flows, previous_upstream_flows
+    #starting timestep, shifted by 1 to account for initial conditions
+    cdef int timestep = 1
+    #buffers to pass to compute_reach_kernel
+    cdef float[:,:] buf_view
+    cdef float[:,:] out_buf
+    cdef float[:] lateral_flows
+    #reach iterator
+    cdef MC_Reach r
+    # list of reach objects to operate on
+    cdef list reach_objects = []
+    cdef list segment_objects
+    #pre compute the qlat resample fraction
+    cdef double qlat_resample = (nsteps)/qlat_values.shape[1]
+
+    cdef long sid
+    cdef MC_Segment segment
+    #pr.enable()
+    #Preprocess the raw reaches, creating MC_Reach/MC_Segments
+    for reach in reaches:
+      upstream_reach = connections.get(reach[0], ())
+      segment_ids = binary_find(data_idx, reach)
+      upstream_ids = binary_find(data_idx, upstream_reach)
+
+      #Set the initial condtions before running loop
+      flowveldepth[segment_ids, 0] = init_array[segment_ids]
+      segment_objects = []
+      #Find the max reach size, used to create buffer for compute_reach_kernel
+      if len(segment_ids) > max_buff_size:
+        max_buff_size=len(segment_ids)
+
+      for sid in segment_ids:
+        #FIXME data_array order is important, column_mapper might help with this
+        segment_objects.append(
+            MC_Segment(sid, *data_array[sid], *init_array[sid])
+            )
+
+      reach_objects.append(
+          MC_Reach(segment_objects, array('l',upstream_ids))
+          )
+
+    #Init buffers
+    lateral_flows = np.zeros( max_buff_size, dtype='float32' )
+    buf_view = np.zeros( (max_buff_size, 13), dtype='float32')
+    out_buf = np.full( (max_buff_size, 3), -1, dtype='float32')
+
+    #Run time
+    while timestep < nsteps:
+      for r in reach_objects:
+            #Need to get quc and qup
+            upstream_flows = 0.0
+            previous_upstream_flows = 0.0
+            for id in r.upstream_ids: #Explicit loop reduces some overhead
+              upstream_flows += flowveldepth[id, timestep, 0]
+              previous_upstream_flows += flowveldepth[id, timestep-1, 0]
+            #Index of segments required to process this reach
+            segment_ids = []
+
+            if assume_short_ts:
+                upstream_flows = previous_upstream_flows
+            #Create compute reach kernel input buffer
+            for i in range(r.num_segments):
+              segment = r.segments[i]
+              segment_ids.append(segment.id)
+              buf_view[i][0] = qlat_array[ segment.id, int(timestep/qlat_resample)]
+              buf_view[i][1] = segment.dt
+              buf_view[i][2] = segment.dx
+              buf_view[i][3] = segment.bw
+              buf_view[i][4] = segment.tw
+              buf_view[i][5] = segment.twcc
+              buf_view[i][6] = segment.n
+              buf_view[i][7] = segment.ncc
+              buf_view[i][8] = segment.cs
+              buf_view[i][9] = segment.s0
+              buf_view[i][10] = flowveldepth[segment.id, timestep-1, 0]
+              buf_view[i][11] = flowveldepth[segment.id, timestep-1, 1]
+              buf_view[i][12] = flowveldepth[segment.id, timestep-1, 2]
+
+            compute_reach_kernel(previous_upstream_flows, upstream_flows,
+                                 len(r.segments), buf_view,
+                                 out_buf,
+                                 assume_short_ts)
+            #Copy the output out
+            for i, id in enumerate(segment_ids):
+              flowveldepth[id, timestep, 0] = out_buf[i, 0]
+              flowveldepth[id, timestep, 1] = out_buf[i, 1]
+              flowveldepth[id, timestep, 2] = out_buf[i, 2]
+
+      timestep += 1
+    #copy t1 to t0 to be consistent
+    flowveldepth[:,0,:] = flowveldepth[:,1,:]
+    #pr.disable()
+    #pr.print_stats(sort='time')
+    return np.asarray(data_idx, dtype=np.intp), np.asarray(flowveldepth.reshape(flowveldepth.shape[0], -1), dtype='float32')


### PR DESCRIPTION
Will add to this documentation in the near future, just wanted to get this up.  Ping me if I forget to fill it in.

## Additions

-

## Changes

-

## Testing
Below are profiles of the compute functions taken from MAINSTEMS_CONUS_FULL_RES_v20.  Note that one of the biggest differences is in some calls to `numpy.array` in `compute_network_structured` that I think could be worked around, but the numpy arrays were used for the ease of indexing by a list of indicies outside the main timestep iterations.

Profiling of `compute_network`:
```
[2729077 rows x 432 columns]
         414083126 function calls in 485.252 seconds
   Ordered by: internal time
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    14351  395.304    0.028  484.189    0.034 mc_reach.pyx:147(compute_network)
 78051906   35.625    0.000   72.515    0.000 stringsource:403(__getitem__)
 78051906   14.263    0.000   19.332    0.000 stringsource:393(get_item_pointer)
  3089699   12.688    0.000   85.182    0.000 mc_reach.pyx:23(binary_find)
 78051906   11.580    0.000   11.580    0.000 stringsource:666(_unellipsify)
 78037555    5.977    0.000    5.977    0.000 stringsource:979(convert_item_to_object)
 78051906    5.070    0.000    5.070    0.000 stringsource:910(pybuffer_index)
  3132752    1.701    0.000    2.353    0.000 stringsource:999(memoryview_fromslice)
  3304964    0.594    0.000    0.594    0.000 stringsource:345(__cinit__)
  3247560    0.503    0.000    0.503    0.000 stringsource:372(__dealloc__)
  3104050    0.247    0.000    0.247    0.000 stringsource:976(__dealloc__)
  3132752    0.238    0.000    0.238    0.000 stringsource:559(__get__)
  3089699    0.235    0.000    0.235    0.000 stringsource:605(__len__)
```

Profiling of `compute_network_structured`:
```[2729077 rows x 432 columns]
         417714121 function calls in 510.209 seconds
   Ordered by: internal time
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    14351  407.508    0.028  509.088    0.035 mc_reach.pyx:750(compute_network_structured)
 77908396   36.308    0.000   74.122    0.000 stringsource:403(__getitem__)
 77908396   14.357    0.000   19.538    0.000 stringsource:393(get_item_pointer)
  3089699   13.281    0.000   87.649    0.000 mc_reach.pyx:23(binary_find)
 77908396   12.109    0.000   12.109    0.000 stringsource:666(_unellipsify)
  2181448    8.093    0.000    8.101    0.000 {built-in method numpy.array}
 77908396    6.168    0.000    6.168    0.000 stringsource:979(convert_item_to_object)
 77908396    5.181    0.000    5.181    0.000 stringsource:910(pybuffer_index)
  3161454    2.807    0.000    3.802    0.000 stringsource:999(memoryview_fromslice)
  3290613    0.879    0.000    0.879    0.000 stringsource:345(__cinit__)
  3261911    0.786    0.000    0.786    0.000 stringsource:372(__dealloc__)
  2181448    0.778    0.000    8.880    0.000 _asarray.py:14(asarray)
  3161454    0.268    0.000    0.268    0.000 stringsource:559(__get__)
  3147103    0.253    0.000    0.253    0.000 stringsource:976(__dealloc__)
  3089699    0.246    0.000    0.246    0.000 stringsource:605(__len__)
```


## Notes

-

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [x] Linux
- [x] MacOS



