### PR TITLE
Add subnetwork calculation options

### DIFF
--- a/src/fortran_routing/mc_pylink_v00/MC_singleSeg_singleTS/makefile
+++ b/src/fortran_routing/mc_pylink_v00/MC_singleSeg_singleTS/makefile
@@ -3,7 +3,7 @@ FC := gfortran
 
 # compile flags
 #FCFLAGS = -c -fdefault-real-8 -fno-align-commons -fbounds-check --free-form
-FCFLAGS = -c -O2 -fPIC
+FCFLAGS = -g -c -O2 -fPIC
 # link flags
 FLFLAGS = -static-gfortran -static-libgcc -no-defaultlibs -lgfortran -lgcc
 VPATH = ../Reservoir_singleTS

--- a/src/python_framework_v02/setup.py
+++ b/src/python_framework_v02/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 from distutils.extension import Extension
 import sys
 import numpy as np
@@ -19,7 +19,8 @@ ext = 'pyx' if USE_CYTHON else 'c'
 reach = Extension("troute.network.reach",
         sources = ["troute/network/reach.{}".format(ext)],
         include_dirs=[np.get_include()],
-        extra_objects = [])
+        extra_objects = [],
+        extra_compile_args=['-g'])
 
 package_data = {
     'troute.network':['reach.pxd']
@@ -30,7 +31,7 @@ ext_modules=[
 
 if USE_CYTHON:
     from Cython.Build import cythonize
-    ext_modules = cythonize(ext_modules)
+    ext_modules = cythonize(ext_modules, compiler_directives={"language_level": 3})
 
 setup(
   name = 'Network',

--- a/src/python_framework_v02/troute/nhd_network.py
+++ b/src/python_framework_v02/troute/nhd_network.py
@@ -443,10 +443,10 @@ def build_subnetworks(connections, rconn, min_size, sources=None):
     # if no sources provided, use tailwaters
     if sources is None:
         # identify tailwaters
-        sources = rconn.keys() - chain.from_iterable(rconn.values())
+        sources = headwaters(rconn)
 
     # create a list of all headwaters in the network
-    all_hws = connections.keys() - chain.from_iterable(connections.values())
+    all_hws = headwaters(connections)
 
     subnetwork_master = {}
     for net in sources:
@@ -496,7 +496,7 @@ def build_subnetworks(connections, rconn, min_size, sources=None):
                 # identify downstream connections for segments in this subnetwork
                 c = {key: connections[key] for key in seg}
                 # find apparent headwaters, will include new sources and actual headwaters
-                sub_hws = c.keys() - chain.from_iterable(c.values())
+                sub_hws = headwaters(c)
                 # extract new sources by differencing with list of actual headwaters
                 srcs = sub_hws - all_hws
                 # append list of new sources

--- a/src/python_framework_v02/troute/nhd_network.py
+++ b/src/python_framework_v02/troute/nhd_network.py
@@ -150,7 +150,11 @@ def reachable_network(N, sources=None, targets=None, check_disjoint=True):
 
     """
     reached = reachable(N, sources=sources, targets=targets)
-    if check_disjoint and len(reached) > 1 and reduce(set.intersection, reached.values()):
+    if (
+        check_disjoint
+        and len(reached) > 1
+        and reduce(set.intersection, reached.values())
+    ):
         raise ValueError("Networks not disjoint")
 
     rv = {}
@@ -238,6 +242,7 @@ def dfs_decomposition_depth_tuple(N, path_func, source_nodes=None):
 
     return path_tuples
 
+
 def tuple_with_orders_into_dict(tuple_list, key_idx=0, val_idx=1):
     """
     Append data values from a set of tuples of form (key, data) 
@@ -256,7 +261,8 @@ def tuple_with_orders_into_dict(tuple_list, key_idx=0, val_idx=1):
         load_dict[t[key_idx]].append(t[val_idx])
 
     return load_dict
-    
+
+
 def dfs_decomposition(N, path_func, source_nodes=None):
     """
     Decompose N into a list of simple segments.
@@ -418,8 +424,9 @@ def replace_waterbodies_connections(connections, waterbodies):
             new_conn[n] = connections[n]
     return new_conn
 
+
 def build_subnetworks(connections, rconn, min_size, sources=None):
-    '''
+    """
     Construct subnetworks using a truncated breadth-first-search
     
     Arguments:
@@ -429,12 +436,12 @@ def build_subnetworks(connections, rconn, min_size, sources=None):
         sources
     Returns:
         subnetwork_master
-    '''
+    """
     # if no sources provided, use tailwaters
     if sources is None:
         # identify tailwaters
         sources = rconn.keys() - chain.from_iterable(rconn.values())
-    
+
     # create a list of all headwaters in the network
     all_hws = connections.keys() - chain.from_iterable(connections.values())
 
@@ -448,7 +455,7 @@ def build_subnetworks(connections, rconn, min_size, sources=None):
         while new_sources:
 
             # Build dict object containing reachable nodes within max_depth from each source in new_sources
-            rv = {} 
+            rv = {}
             for h in new_sources:
 
                 reachable = set()
@@ -458,21 +465,21 @@ def build_subnetworks(connections, rconn, min_size, sources=None):
                 stop_depth = 1000000
                 while Q or D:
 
-                    x = Q.popleft() 
+                    x = Q.popleft()
                     y = D.popleft()
                     reachable.add(x)
                     reachable_depth.add(y)
 
                     if len(rconn.get(x, ())) > 1:
-                        us_depth = y+1
+                        us_depth = y + 1
                     else:
                         us_depth = y
-                        
+
                     if len(reachable) > min_size:
                         stop_depth = y
 
                     if us_depth <= stop_depth:
-                        D.extend([us_depth]*len(rconn.get(x, ())))
+                        D.extend([us_depth] * len(rconn.get(x, ())))
                         Q.extend(rconn.get(x, ()))
 
                 # reachable: a list of reachable segments within max_depth from source node h
@@ -483,7 +490,7 @@ def build_subnetworks(connections, rconn, min_size, sources=None):
             for tw, seg in rv.items():
                 # identify downstream connections for segments in this subnetwork
                 c = {key: connections[key] for key in seg}
-                # find apparent headwaters, will include new sources and actual headwaters 
+                # find apparent headwaters, will include new sources and actual headwaters
                 sub_hws = c.keys() - chain.from_iterable(c.values())
                 # extract new sources by differencing with list of actual headwaters
                 srcs = list(set(sub_hws) - set(all_hws))
@@ -500,6 +507,5 @@ def build_subnetworks(connections, rconn, min_size, sources=None):
             group_order += 1
 
         subnetwork_master[net] = subnetworks
-        
+
     return subnetwork_master
-    

--- a/src/python_framework_v02/troute/nhd_network.py
+++ b/src/python_framework_v02/troute/nhd_network.py
@@ -93,12 +93,15 @@ def junctions(N):
 
 
 def headwaters(N):
-    yield from N.keys() - chain.from_iterable(N.values())
+    return N.keys() - chain.from_iterable(N.values())
 
 
 def tailwaters(N):
-    yield from chain.from_iterable(N.values()) - N.keys()
-    yield from (m for m, n in N.items() if not n)
+    tw = chain.from_iterable(N.values()) - N.keys()
+    for m, n in N.items():
+        if not n:
+            tw.add(m)
+    return tw
 
 
 def reachable(N, sources=None, targets=None):

--- a/src/python_framework_v02/troute/nhd_network.py
+++ b/src/python_framework_v02/troute/nhd_network.py
@@ -418,7 +418,7 @@ def replace_waterbodies_connections(connections, waterbodies):
             new_conn[n] = connections[n]
     return new_conn
 
-def build_subnetworks(connections, rconn, max_depth, sources=None):
+def build_subnetworks(connections, rconn, min_size, sources=None):
     '''
     Construct subnetworks using a truncated breadth-first-search
     
@@ -455,6 +455,7 @@ def build_subnetworks(connections, rconn, max_depth, sources=None):
                 reachable_depth = set()
                 Q = deque([h])
                 D = deque([0])
+                stop_depth = 1000000
                 while Q or D:
 
                     x = Q.popleft() 
@@ -466,8 +467,11 @@ def build_subnetworks(connections, rconn, max_depth, sources=None):
                         us_depth = y+1
                     else:
                         us_depth = y
+                        
+                    if len(reachable) > min_size:
+                        stop_depth = y
 
-                    if us_depth <= max_depth:
+                    if us_depth <= stop_depth:
                         D.extend([us_depth]*len(rconn.get(x, ())))
                         Q.extend(rconn.get(x, ()))
 

--- a/src/python_framework_v02/troute/nhd_network.py
+++ b/src/python_framework_v02/troute/nhd_network.py
@@ -500,8 +500,7 @@ def build_subnetworks(connections, rconn, min_size, sources=None):
                 #new_sources_list.extend(srcs)
                 new_sources.update(srcs)
                 # remove new sources from the subnetwork list
-                for src in srcs:
-                    rv[tw].remove(src)
+                rv[tw].difference_update(srcs)
 
             # append master dictionary
             subnetworks[group_order] = rv

--- a/src/python_framework_v02/troute/nhd_network.py
+++ b/src/python_framework_v02/troute/nhd_network.py
@@ -495,7 +495,7 @@ def build_subnetworks(connections, rconn, min_size, sources=None):
                 # find apparent headwaters, will include new sources and actual headwaters
                 sub_hws = c.keys() - chain.from_iterable(c.values())
                 # extract new sources by differencing with list of actual headwaters
-                srcs = list(set(sub_hws) - set(all_hws))
+                srcs = sub_hws - all_hws
                 # append list of new sources
                 #new_sources_list.extend(srcs)
                 new_sources.update(srcs)

--- a/src/python_framework_v02/troute/nhd_network.py
+++ b/src/python_framework_v02/troute/nhd_network.py
@@ -150,7 +150,7 @@ def reachable_network(N, sources=None, targets=None, check_disjoint=True):
 
     """
     reached = reachable(N, sources=sources, targets=targets)
-    if check_disjoint and reduce(set.intersection, reached.values()):
+    if check_disjoint and len(reached) > 1 and reduce(set.intersection, reached.values()):
         raise ValueError("Networks not disjoint")
 
     rv = {}

--- a/src/python_framework_v02/troute/nhd_network.py
+++ b/src/python_framework_v02/troute/nhd_network.py
@@ -463,18 +463,15 @@ def build_subnetworks(connections, rconn, min_size, sources=None):
             for h in new_sources:
 
                 reachable = set()
-                reachable_depth = set()
-                Q = deque([h])
-                D = deque([0])
+                Q = deque([(h, 0)])
                 stop_depth = 1000000
-                while Q or D:
+                while Q:
 
-                    x = Q.popleft()
-                    y = D.popleft()
+                    x, y = Q.popleft()
                     reachable.add(x)
-                    reachable_depth.add(y)
 
-                    if len(rconn.get(x, ())) > 1:
+                    rx = rconn.get(x, ())
+                    if len(rx) > 1:
                         us_depth = y + 1
                     else:
                         us_depth = y
@@ -483,8 +480,7 @@ def build_subnetworks(connections, rconn, min_size, sources=None):
                         stop_depth = y
 
                     if us_depth <= stop_depth:
-                        D.extend([us_depth] * len(rconn.get(x, ())))
-                        Q.extend(rconn.get(x, ()))
+                        Q.extend(zip(rx, [us_depth] * len(rx)))
 
                 # reachable: a list of reachable segments within max_depth from source node h
                 rv[h] = reachable
@@ -500,7 +496,6 @@ def build_subnetworks(connections, rconn, min_size, sources=None):
                 # extract new sources by differencing with list of actual headwaters
                 srcs = sub_hws - all_hws
                 # append list of new sources
-                #new_sources_list.extend(srcs)
                 new_sources.update(srcs)
                 # remove new sources from the subnetwork list
                 rv[tw].difference_update(srcs)

--- a/src/python_framework_v02/troute/nhd_network.py
+++ b/src/python_framework_v02/troute/nhd_network.py
@@ -449,7 +449,8 @@ def build_subnetworks(connections, rconn, min_size, sources=None):
     for net in sources:
 
         # subnetwork creation using a breadth first search restricted by maximum allowable depth
-        new_sources = [net]
+        #new_sources_list = [net]
+        new_sources = set([net])
         subnetworks = {}
         group_order = 0
         while new_sources:
@@ -486,7 +487,8 @@ def build_subnetworks(connections, rconn, min_size, sources=None):
                 rv[h] = reachable
 
             # find headwater segments in reachable groups, these will become the next set of sources
-            new_sources = []
+            #new_sources_list = []
+            new_sources = set()
             for tw, seg in rv.items():
                 # identify downstream connections for segments in this subnetwork
                 c = {key: connections[key] for key in seg}
@@ -495,7 +497,8 @@ def build_subnetworks(connections, rconn, min_size, sources=None):
                 # extract new sources by differencing with list of actual headwaters
                 srcs = list(set(sub_hws) - set(all_hws))
                 # append list of new sources
-                new_sources.extend(srcs)
+                #new_sources_list.extend(srcs)
+                new_sources.update(srcs)
                 # remove new sources from the subnetwork list
                 for src in srcs:
                     rv[tw].remove(src)

--- a/src/python_routing_v02/compiler.sh
+++ b/src/python_routing_v02/compiler.sh
@@ -13,9 +13,13 @@ make install
 #creates troute package
 cd $REPOROOT/src/python_framework_v02
 rm -rf build
-python setup.py --use-cython install
+#python setup.py --use-cython develop
+python setup.py build_ext --inplace
+pip install -e .
 
 #updates troute package with the execution script
 cd $REPOROOT/src/python_routing_v02
 rm -rf build
-python setup.py --use-cython install
+#python setup.py --use-cython develop
+python setup.py build_ext --inplace
+pip install -e .

--- a/src/python_routing_v02/compiler.sh
+++ b/src/python_routing_v02/compiler.sh
@@ -14,12 +14,12 @@ make install
 cd $REPOROOT/src/python_framework_v02
 rm -rf build
 #python setup.py --use-cython develop
-python setup.py build_ext --inplace
+python setup.py build_ext --inplace --use-cython
 pip install -e .
 
 #updates troute package with the execution script
 cd $REPOROOT/src/python_routing_v02
 rm -rf build
 #python setup.py --use-cython develop
-python setup.py build_ext --inplace
+python setup.py build_ext --inplace --use-cython
 pip install -e .

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -417,7 +417,7 @@ def main():
 
         start_para_time = time.time()
         with Parallel(n_jobs=cpu_pool, backend="threading") as parallel:
-        # if 1 == 1:
+            # if 1 == 1:
             results_subn = defaultdict(list)
             flowveldepth_interorder = {}
 
@@ -451,9 +451,9 @@ def main():
                     qlat_sub = qlats.loc[segs].sort_index()
                     q0_sub = q0.loc[segs].sort_index()
                     jobs.append(
-                    delayed(compute_func)(
-                    # results_subn[order].append(
-                    #     compute_func(
+                        delayed(compute_func)(
+                            # results_subn[order].append(
+                            #     compute_func(
                             nts,
                             subn_reach_list,
                             subnetworks[subn_tw],
@@ -473,19 +473,7 @@ def main():
 
                 results_subn[order] = parallel(jobs)
 
-                # # TODO: delete the duplicate results that shouldn't be passed along
-                # # The upstream keys have empty results because they are not part of any reaches
-                # # so we need to delete the null values that return
-                # # There should be no extra results in the uppermost order, so we skip that one
-                # if order < max(reaches_bysubntw.keys()):
-                #     results_to_delete = defaultdict(list)
-                #     for prev_twi, prev_subn_tw in enumerate(
-                #         reaches_bysubntw[order + 1]
-                #     ):
-                #         for twi, subn_tw in enumerate(reaches_bysubntw[order]):
-                #             results_to_delete[subn_tw].append(
-                #                 results_subn[order][twi][0].tolist().index(prev_subn_tw)
-                #             )
+                # Then add code to flowveldepth and test CONUS Full RES
 
                 if order > 0:  # This is not needed for the last rank of subnetworks
                     flowveldepth_interorder = {}
@@ -500,7 +488,7 @@ def main():
                         flowveldepth_interorder[subn_tw]["results"] = results_subn[
                             order
                         ][twi][1][subn_tw_sortposition]
-                        # START HERE #1 -- what will it take to get just the tw FVD values into an array to pass to the next loop?
+                        # what will it take to get just the tw FVD values into an array to pass to the next loop?
                         # There will be an empty array initialized at the top of the loop, then re-populated here.
                         # we don't have to bother with populating it after the last group
 

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -319,13 +319,13 @@ def main():
                 reaches_ordered_bysubntw[order].items(), 1
             ):
                 reaches_ordered_bysubntw_clustered[order][cluster] = {
-                    "r": [],
+                    "segs": [],
                     "upstreams": {},
                     "tw": [],
                     "subn_reach_list": [],
                 }
-                r = list(chain.from_iterable(subn_reach_list))
-                reaches_ordered_bysubntw_clustered[order][cluster]["r"].extend(r)
+                segs = list(chain.from_iterable(subn_reach_list))
+                reaches_ordered_bysubntw_clustered[order][cluster]["segs"].extend(segs)
                 reaches_ordered_bysubntw_clustered[order][cluster]["upstreams"].update(
                     {k: [] for k in subnetworks[subn_tw]}
                 )
@@ -335,7 +335,7 @@ def main():
                 ].extend(subn_reach_list)
 
                 if (
-                    len(reaches_ordered_bysubntw_clustered[order][cluster]["r"])
+                    len(reaches_ordered_bysubntw_clustered[order][cluster]["segs"])
                     >= cluster_threshold * subnetwork_target_size
                 ):
                     cluster += 1
@@ -353,13 +353,13 @@ def main():
                     order
                 ].items():
                     # for twi, (subn_tw, subn_reach_list) in enumerate(reaches_ordered_bysubntw[order].items(), 1):
-                    # r = list(chain.from_iterable(subn_reach_list))
-                    r = clustered_subns["r"]
+                    # segs = list(chain.from_iterable(subn_reach_list))
+                    segs = clustered_subns["segs"]
                     param_df_sub = param_df.loc[
-                        r, ["dt", "bw", "tw", "twcc", "dx", "n", "ncc", "cs", "s0"]
+                        segs, ["dt", "bw", "tw", "twcc", "dx", "n", "ncc", "cs", "s0"]
                     ].sort_index()
-                    qlat_sub = qlats.loc[r].sort_index()
-                    q0_sub = q0.loc[r].sort_index()
+                    qlat_sub = qlats.loc[segs].sort_index()
+                    q0_sub = q0.loc[segs].sort_index()
                     subn_reach_list = clustered_subns["subn_reach_list"]
                     upstreams = clustered_subns["upstreams"]
 
@@ -409,7 +409,7 @@ def main():
                 )
 
         for twi, (tw, reach_list) in enumerate(reaches_bytw.items(), 1):
-            r = list(chain.from_iterable(reach_list))
+            segs = list(chain.from_iterable(reach_list))
 
         if showtiming:
             print("JIT Preprocessing time %s seconds." % (time.time() - start_time))
@@ -426,10 +426,12 @@ def main():
                 for twi, (subn_tw, subn_reach_list) in enumerate(
                     reaches_bysubntw[order].items(), 1
                 ):
-                    r = list(chain.from_iterable(subn_reach_list))
-                    r.extend(list(flowveldepth_interorder.keys()))
+                    # TODO: Confirm that a list here is best -- we are sorting,
+                    # so a set might be sufficient/better
+                    segs = list(chain.from_iterable(subn_reach_list))
+                    segs.extend(list(flowveldepth_interorder.keys()))
                     param_df_sub = param_df.loc[
-                        r, ["dt", "bw", "tw", "twcc", "dx", "n", "ncc", "cs", "s0"]
+                        segs, ["dt", "bw", "tw", "twcc", "dx", "n", "ncc", "cs", "s0"]
                     ].sort_index()
                     if order < max(subnetworks_only_ordered_jit.keys()):
                         for us_subn_tw in flowveldepth_interorder.keys():
@@ -439,8 +441,8 @@ def main():
                             flowveldepth_interorder[us_subn_tw][
                                 "position_index"
                             ] = subn_tw_sortposition
-                    qlat_sub = qlats.loc[r].sort_index()
-                    q0_sub = q0.loc[r].sort_index()
+                    qlat_sub = qlats.loc[segs].sort_index()
+                    q0_sub = q0.loc[segs].sort_index()
                     # jobs.append(
                     # delayed(compute_func)(
                     results_subn[order].append(
@@ -502,12 +504,12 @@ def main():
         with Parallel(n_jobs=cpu_pool, backend="threading") as parallel:
             jobs = []
             for twi, (tw, reach_list) in enumerate(reaches_bytw.items(), 1):
-                r = list(chain.from_iterable(reach_list))
+                segs = list(chain.from_iterable(reach_list))
                 param_df_sub = param_df.loc[
-                    r, ["dt", "bw", "tw", "twcc", "dx", "n", "ncc", "cs", "s0"]
+                    segs, ["dt", "bw", "tw", "twcc", "dx", "n", "ncc", "cs", "s0"]
                 ].sort_index()
-                qlat_sub = qlats.loc[r].sort_index()
-                q0_sub = q0.loc[r].sort_index()
+                qlat_sub = qlats.loc[segs].sort_index()
+                q0_sub = q0.loc[segs].sort_index()
                 jobs.append(
                     delayed(compute_func)(
                         nts,
@@ -525,12 +527,12 @@ def main():
     else:  # Execute in serial
         results = []
         for twi, (tw, reach_list) in enumerate(reaches_bytw.items(), 1):
-            r = list(chain.from_iterable(reach_list))
+            segs = list(chain.from_iterable(reach_list))
             param_df_sub = param_df.loc[
-                r, ["dt", "bw", "tw", "twcc", "dx", "n", "ncc", "cs", "s0"]
+                segs, ["dt", "bw", "tw", "twcc", "dx", "n", "ncc", "cs", "s0"]
             ].sort_index()
-            qlat_sub = qlats.loc[r].sort_index()
-            q0_sub = q0.loc[r].sort_index()
+            qlat_sub = qlats.loc[segs].sort_index()
+            q0_sub = q0.loc[segs].sort_index()
             results.append(
                 compute_func(
                     nts,

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -604,7 +604,7 @@ def main():
         flowveldepth = pd.concat(
             [pd.DataFrame(d, index=i, columns=qvd_columns) for i, d in results],
             copy=False,
-        )
+        ).sort_index()
 
         if csv_output_folder:
             flowveldepth = flowveldepth.sort_index()

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -472,18 +472,19 @@ def main():
                     )
                 # results_subn[order] = parallel(jobs)
 
-                # The upstream keys have empty results because they are not part of any reaches
-                # so we need to delete the null values that return
-                # There will be no extra results in the uppermost order, so we skip that one
-                if order < max(reaches_bysubntw.keys()):
-                    results_to_delete = defaultdict(list)
-                    for prev_twi, prev_subn_tw in enumerate(
-                        reaches_bysubntw[order + 1]
-                    ):
-                        for twi, subn_tw in enumerate(reaches_bysubntw[order]):
-                            results_to_delete[subn_tw].append(
-                                results_subn[order][twi][0].tolist().index(prev_subn_tw)
-                            )
+                # # TODO: delete the duplicate results that shouldn't be passed along
+                # # The upstream keys have empty results because they are not part of any reaches
+                # # so we need to delete the null values that return
+                # # There should be no extra results in the uppermost order, so we skip that one
+                # if order < max(reaches_bysubntw.keys()):
+                #     results_to_delete = defaultdict(list)
+                #     for prev_twi, prev_subn_tw in enumerate(
+                #         reaches_bysubntw[order + 1]
+                #     ):
+                #         for twi, subn_tw in enumerate(reaches_bysubntw[order]):
+                #             results_to_delete[subn_tw].append(
+                #                 results_subn[order][twi][0].tolist().index(prev_subn_tw)
+                #             )
 
                 # if order > 0: #Technically, this is not needed for the last rank of subnetworks
                 # TODO: add logic in mc_reach to avoid collision when passing empty un-needed last-rank
@@ -565,7 +566,6 @@ def main():
             [pd.DataFrame(d, index=i, columns=qvd_columns) for i, d in results],
             copy=False,
         )
-        # TODO: delete the duplicate results that shouldn't be passed along
 
         if csv_output_folder:
             flowveldepth = flowveldepth.sort_index()

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -100,7 +100,7 @@ def _handle_args():
         help="Assign the number of cores to multiprocess across.",
         dest="cpu_pool",
         type=int,
-        default=None,
+        default=-1,
     )
     parser.add_argument(
         "--compute_method",

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -426,8 +426,7 @@ def main():
                     reaches_bysubntw[order].items(), 1
                 ):
                     r = list(chain.from_iterable(subn_reach_list))
-                    r.extend(
-                        list(flowveldepth_interorder.keys()))
+                    r.extend(list(flowveldepth_interorder.keys()))
                     param_df_sub = param_df.loc[
                         r, ["dt", "bw", "tw", "twcc", "dx", "n", "ncc", "cs", "s0"]
                     ].sort_index()
@@ -446,20 +445,25 @@ def main():
                         )
                     )
                 results_subn[order] = parallel(jobs)
-                import pdb; pdb.set_trace()
                 for twi, (subn_tw, subn_reach_list) in enumerate(
                     reaches_bysubntw[order].items()
                 ):
                     # TODO: This index step is necessary because we sort the segment index
                     # TODO: I think there are a number of ways we could remove the sorting step
                     #       -- the binary search could be replaced with an index based on the known topology
-                    subn_tw_sortposition = results_subn[order][twi][0].tolist().index(subn_tw)
+                    subn_tw_sortposition = (
+                        results_subn[order][twi][0].tolist().index(subn_tw)
+                    )
                     flowveldepth_interorder[subn_tw] = results_subn[order][twi][1][
                         subn_tw_sortposition
                     ]
                     # START HERE -- what will it take to get just the tw FVD values into an array to pass to the next loop?
                     # There will be an empty array initialized at the top of the loop, then re-populated here.
                     # we don't have to bother with populating it after the last group
+
+        results = []
+        for order in subnetworks_only_ordered_jit:
+            results.extend(results_subn[order])
 
         if showtiming:
             print("PARALLEL TIME %s seconds." % (time.time() - start_para_time))

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -436,7 +436,7 @@ def main():
                         delayed(compute_func)(
                             nts,
                             subn_reach_list,
-                            {k: [] for k in subnetworks[subn_tw]},
+                            subnetworks[subn_tw],
                             param_df_sub.index.values,
                             param_df_sub.columns.values,
                             param_df_sub.values,

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -418,6 +418,7 @@ def main():
         start_para_time = time.time()
         with Parallel(n_jobs=cpu_pool, backend="threading") as parallel:
             flowveldepth_interorder = {}
+            results_subn = {}
 
             for order, ordered_subn_dict in subnetworks_only_ordered_jit.items():
                 jobs = []
@@ -425,6 +426,8 @@ def main():
                     reaches_bysubntw[order].items(), 1
                 ):
                     r = list(chain.from_iterable(subn_reach_list))
+                    r.extend(
+                        list(flowveldepth_interorder.keys()))
                     param_df_sub = param_df.loc[
                         r, ["dt", "bw", "tw", "twcc", "dx", "n", "ncc", "cs", "s0"]
                     ].sort_index()
@@ -442,15 +445,16 @@ def main():
                             q0_sub.values,
                         )
                     )
-                results = parallel(jobs)
+                results_subn[order] = parallel(jobs)
+                import pdb; pdb.set_trace()
                 for twi, (subn_tw, subn_reach_list) in enumerate(
                     reaches_bysubntw[order].items()
                 ):
                     # TODO: This index step is necessary because we sort the segment index
                     # TODO: I think there are a number of ways we could remove the sorting step
                     #       -- the binary search could be replaced with an index based on the known topology
-                    subn_tw_sortposition = results[twi][0].tolist().index(subn_tw)
-                    flowveldepth_interorder[subn_tw] = results[twi][1][
+                    subn_tw_sortposition = results_subn[order][twi][0].tolist().index(subn_tw)
+                    flowveldepth_interorder[subn_tw] = results_subn[order][twi][1][
                         subn_tw_sortposition
                     ]
                     # START HERE -- what will it take to get just the tw FVD values into an array to pass to the next loop?

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -552,6 +552,11 @@ def main():
             print("PARALLEL TIME %s seconds." % (time.time() - start_para_time))
 
     elif parallel_compute_method == "by-network":
+        if showtiming:
+            print("JIT Preprocessing time %s seconds." % (time.time() - start_time))
+            print("starting Parallel JIT calculation")
+
+        start_para_time = time.time()
         with Parallel(n_jobs=cpu_pool, backend="threading") as parallel:
             jobs = []
             for twi, (tw, reach_list) in enumerate(reaches_bytw.items(), 1):
@@ -574,6 +579,9 @@ def main():
                     )
                 )
             results = parallel(jobs)
+
+        if showtiming:
+            print("PARALLEL TIME %s seconds." % (time.time() - start_para_time))
 
     else:  # Execute in serial
         results = []

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -293,9 +293,8 @@ def main():
                 for subn_tw, subnetwork in subnet_sets.items():
                     subnetworks[subn_tw] = {k: intw[k] for k in subnetwork}
 
-        reaches_ordered_bysubntw = {}
+        reaches_ordered_bysubntw = defaultdict(dict)
         for order, ordered_subn_dict in subnetworks_only_ordered_jit.items():
-            reaches_ordered_bysubntw[order] = {}
             for subn_tw, subnet in ordered_subn_dict.items():
                 conn_subn = {k: connections[k] for k in subnet if k in connections}
                 rconn_subn = {k: rconn[k] for k in subnet if k in rconn}

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -272,6 +272,8 @@ def main():
     cpu_pool = args.cpu_pool
     compute_method = args.compute_method
     subnetwork_target_size = args.subnetwork_target_size
+    if (not subnetwork_target_size) or (subnetwork_target_size <=0): 
+        subnetwork_target_size = 1
 
     if compute_method == "standard cython compute network":
         compute_func = mc_reach.compute_network

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -279,7 +279,9 @@ def main():
         compute_func = mc_reach.compute_network
 
     if parallel_compute_method == "by-subnetwork-jit-clustered":
-        networks_with_subnetworks_ordered_jit = nhd_network.build_subnetworks(connections, rconn, subnetwork_target_size)
+        networks_with_subnetworks_ordered_jit = nhd_network.build_subnetworks(
+            connections, rconn, subnetwork_target_size
+        )
         subnetworks_only_ordered_jit = defaultdict(dict)
         subnetworks = defaultdict(dict)
         for tw, ordered_network in networks_with_subnetworks_ordered_jit.items():
@@ -288,7 +290,9 @@ def main():
                 for subn_tw, subnetwork in subnet_sets.items():
                     for k in independent_networks[tw]:
                         if k in subnetwork:
-                            subnetworks[subn_tw].update({k: independent_networks[tw][k]})
+                            subnetworks[subn_tw].update(
+                                {k: independent_networks[tw][k]}
+                            )
 
         reaches_ordered_bysubntw = {}
         for order, ordered_subn_dict in subnetworks_only_ordered_jit.items():
@@ -297,25 +301,41 @@ def main():
                 conn_subn = {k: connections[k] for k in subnet if k in connections}
                 rconn_subn = {k: rconn[k] for k in subnet if k in rconn}
                 path_func = partial(nhd_network.split_at_junction, rconn_subn)
-                reaches_ordered_bysubntw[order][subn_tw] = nhd_network.dfs_decomposition(rconn_subn, path_func)
+                reaches_ordered_bysubntw[order][
+                    subn_tw
+                ] = nhd_network.dfs_decomposition(rconn_subn, path_func)
 
         cluster_threshold = 0.65  # When a job has a total segment count 65% of the target size, compute it
-                                  # Otherwise, keep adding reaches.
+        # Otherwise, keep adding reaches.
 
         reaches_ordered_bysubntw_clustered = {}
-        
+
         for order in subnetworks_only_ordered_jit:
             cluster = 0
             reaches_ordered_bysubntw_clustered[order] = {}
-            for twi, (subn_tw, subn_reach_list) in enumerate(reaches_ordered_bysubntw[order].items(), 1):
-                reaches_ordered_bysubntw_clustered[order][cluster] = {'r':[], 'upstreams':{}, 'tw':[], 'subn_reach_list':[]}
+            for twi, (subn_tw, subn_reach_list) in enumerate(
+                reaches_ordered_bysubntw[order].items(), 1
+            ):
+                reaches_ordered_bysubntw_clustered[order][cluster] = {
+                    "r": [],
+                    "upstreams": {},
+                    "tw": [],
+                    "subn_reach_list": [],
+                }
                 r = list(chain.from_iterable(subn_reach_list))
-                reaches_ordered_bysubntw_clustered[order][cluster]['r'].extend(r) 
-                reaches_ordered_bysubntw_clustered[order][cluster]['upstreams'].update({k: [] for k in subnetworks[subn_tw]})
-                reaches_ordered_bysubntw_clustered[order][cluster]['tw'].append(subn_tw)
-                reaches_ordered_bysubntw_clustered[order][cluster]['subn_reach_list'].extend(subn_reach_list)
+                reaches_ordered_bysubntw_clustered[order][cluster]["r"].extend(r)
+                reaches_ordered_bysubntw_clustered[order][cluster]["upstreams"].update(
+                    {k: [] for k in subnetworks[subn_tw]}
+                )
+                reaches_ordered_bysubntw_clustered[order][cluster]["tw"].append(subn_tw)
+                reaches_ordered_bysubntw_clustered[order][cluster][
+                    "subn_reach_list"
+                ].extend(subn_reach_list)
 
-                if len(reaches_ordered_bysubntw_clustered[order][cluster]['r']) >= cluster_threshold * subnetwork_target_size:
+                if (
+                    len(reaches_ordered_bysubntw_clustered[order][cluster]["r"])
+                    >= cluster_threshold * subnetwork_target_size
+                ):
                     cluster += 1
 
         if showtiming:
@@ -327,17 +347,19 @@ def main():
 
             for order, ordered_subn_dict in subnetworks_only_ordered_jit.items():
                 jobs = []
-                for cluster, clustered_subns in reaches_ordered_bysubntw_clustered[order].items():
+                for cluster, clustered_subns in reaches_ordered_bysubntw_clustered[
+                    order
+                ].items():
                     # for twi, (subn_tw, subn_reach_list) in enumerate(reaches_ordered_bysubntw[order].items(), 1):
                     # r = list(chain.from_iterable(subn_reach_list))
-                    r = clustered_subns['r']
+                    r = clustered_subns["r"]
                     param_df_sub = param_df.loc[
                         r, ["dt", "bw", "tw", "twcc", "dx", "n", "ncc", "cs", "s0"]
                     ].sort_index()
                     qlat_sub = qlats.loc[r].sort_index()
                     q0_sub = q0.loc[r].sort_index()
-                    subn_reach_list = clustered_subns['subn_reach_list']
-                    upstreams = clustered_subns['upstreams']
+                    subn_reach_list = clustered_subns["subn_reach_list"]
+                    upstreams = clustered_subns["upstreams"]
 
                     jobs.append(
                         delayed(compute_func)(
@@ -358,7 +380,9 @@ def main():
             print("PARALLEL TIME %s seconds." % (time.time() - start_para_time))
 
     elif parallel_compute_method == "by-subnetwork-jit":
-        networks_with_subnetworks_ordered_jit = nhd_network.build_subnetworks(connections, rconn, subnetwork_target_size)
+        networks_with_subnetworks_ordered_jit = nhd_network.build_subnetworks(
+            connections, rconn, subnetwork_target_size
+        )
         subnetworks_only_ordered_jit = defaultdict(dict)
         subnetworks = defaultdict(dict)
         for tw, ordered_network in networks_with_subnetworks_ordered_jit.items():
@@ -367,7 +391,9 @@ def main():
                 for subn_tw, subnetwork in subnet_sets.items():
                     for k in independent_networks[tw]:
                         if k in subnetwork:
-                            subnetworks[subn_tw].update({k: independent_networks[tw][k]})
+                            subnetworks[subn_tw].update(
+                                {k: independent_networks[tw][k]}
+                            )
 
         reaches_bysubntw = {}
         for order, ordered_subn_dict in subnetworks_only_ordered_jit.items():
@@ -376,7 +402,9 @@ def main():
                 conn_subn = {k: connections[k] for k in subnet if k in connections}
                 rconn_subn = {k: rconn[k] for k in subnet if k in rconn}
                 path_func = partial(nhd_network.split_at_junction, rconn_subn)
-                reaches_bysubntw[order][subn_tw] = nhd_network.dfs_decomposition(rconn_subn, path_func)
+                reaches_bysubntw[order][subn_tw] = nhd_network.dfs_decomposition(
+                    rconn_subn, path_func
+                )
 
         for twi, (tw, reach_list) in enumerate(reaches_bytw.items(), 1):
             r = list(chain.from_iterable(reach_list))
@@ -390,7 +418,9 @@ def main():
 
             for order, ordered_subn_dict in subnetworks_only_ordered_jit.items():
                 jobs = []
-                for twi, (subn_tw, subn_reach_list) in enumerate(reaches_bysubntw[order].items(), 1):
+                for twi, (subn_tw, subn_reach_list) in enumerate(
+                    reaches_bysubntw[order].items(), 1
+                ):
                     r = list(chain.from_iterable(subn_reach_list))
                     param_df_sub = param_df.loc[
                         r, ["dt", "bw", "tw", "twcc", "dx", "n", "ncc", "cs", "s0"]

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -420,7 +420,7 @@ def main():
             flowveldepth_interorder = {}
             results_subn = {}
 
-            for order, ordered_subn_dict in subnetworks_only_ordered_jit.items():
+            for order in range(max(subnetworks_only_ordered_jit.keys()), -1, -1):
                 jobs = []
                 for twi, (subn_tw, subn_reach_list) in enumerate(
                     reaches_bysubntw[order].items(), 1

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -445,21 +445,45 @@ def main():
                         )
                     )
                 results_subn[order] = parallel(jobs)
-                for twi, (subn_tw, subn_reach_list) in enumerate(
-                    reaches_bysubntw[order].items()
-                ):
-                    # TODO: This index step is necessary because we sort the segment index
-                    # TODO: I think there are a number of ways we could remove the sorting step
-                    #       -- the binary search could be replaced with an index based on the known topology
-                    subn_tw_sortposition = (
-                        results_subn[order][twi][0].tolist().index(subn_tw)
-                    )
-                    flowveldepth_interorder[subn_tw] = results_subn[order][twi][1][
-                        subn_tw_sortposition
-                    ]
-                    # START HERE -- what will it take to get just the tw FVD values into an array to pass to the next loop?
-                    # There will be an empty array initialized at the top of the loop, then re-populated here.
-                    # we don't have to bother with populating it after the last group
+
+                # The upstream keys have empty results because they are not part of any reaches
+                # so we need to delete the null values that return
+                # There will be no extra results in the uppermost order, so we skip that one
+                if order < max(reaches_bysubntw.keys()):
+                    results_to_delete = defaultdict(list)
+                    for prev_twi, prev_subn_tw in enumerate(
+                        reaches_bysubntw[order + 1]
+                    ):
+                        for twi, subn_tw in enumerate(reaches_bysubntw[order]):
+                            results_to_delete[subn_tw].append(
+                                results_subn[order][twi][0].tolist().index(prev_subn_tw)
+                            )
+                    for twi, subn_tw in enumerate(reaches_bysubntw[order]):
+                        pass
+                        # START HERE #2: This is intended to delete the results that shouldn't be passed along
+                        # BUT, because it is a tuple, it's not modifiable, so we have to make a new object.
+
+                        # results_subn[order][twi][0] = np.delete(
+                        #     results_subn[order][twi][0], [results_to_delete[subn_tw]]
+                        # )
+                        # results_subn[order][twi][1] = np.delete(
+                        #     results_subn[order][twi][1], [results_to_delete[subn_tw]]
+                        # )
+
+                if order > 0:
+                    for twi, subn_tw in enumerate(reaches_bysubntw[order]):
+                        # TODO: This index step is necessary because we sort the segment index
+                        # TODO: I think there are a number of ways we could remove the sorting step
+                        #       -- the binary search could be replaced with an index based on the known topology
+                        subn_tw_sortposition = (
+                            results_subn[order][twi][0].tolist().index(subn_tw)
+                        )
+                        flowveldepth_interorder[subn_tw] = results_subn[order][twi][1][
+                            subn_tw_sortposition
+                        ]
+                        # START HERE #1 -- what will it take to get just the tw FVD values into an array to pass to the next loop?
+                        # There will be an empty array initialized at the top of the loop, then re-populated here.
+                        # we don't have to bother with populating it after the last group
 
         results = []
         for order in subnetworks_only_ordered_jit:

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -487,9 +487,7 @@ def main():
                 #                 results_subn[order][twi][0].tolist().index(prev_subn_tw)
                 #             )
 
-                # if order > 0: #Technically, this is not needed for the last rank of subnetworks
-                # TODO: add logic in mc_reach to avoid collision when passing empty un-needed last-rank
-                if 1 == 1:
+                if order > 0:  # This is not needed for the last rank of subnetworks
                     flowveldepth_interorder = {}
                     for twi, subn_tw in enumerate(reaches_bysubntw[order]):
                         # TODO: This index step is necessary because we sort the segment index

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -468,17 +468,6 @@ def main():
                             results_to_delete[subn_tw].append(
                                 results_subn[order][twi][0].tolist().index(prev_subn_tw)
                             )
-                    for twi, subn_tw in enumerate(reaches_bysubntw[order]):
-                        pass
-                        # START HERE #2: This is intended to delete the results that shouldn't be passed along
-                        # BUT, because it is a tuple, it's not modifiable, so we have to make a new object.
-
-                        # results_subn[order][twi][0] = np.delete(
-                        #     results_subn[order][twi][0], [results_to_delete[subn_tw]]
-                        # )
-                        # results_subn[order][twi][1] = np.delete(
-                        #     results_subn[order][twi][1], [results_to_delete[subn_tw]]
-                        # )
 
                 # if order > 0: #Technically, this is not needed for the last rank of subnetworks
                 # TODO: add logic in mc_reach to avoid collision when passing empty un-needed last-rank
@@ -560,6 +549,7 @@ def main():
             [pd.DataFrame(d, index=i, columns=qvd_columns) for i, d in results],
             copy=False,
         )
+        # TODO: delete the duplicate results that shouldn't be passed along
 
         if csv_output_folder:
             flowveldepth = flowveldepth.sort_index()

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -287,14 +287,11 @@ def main():
         subnetworks_only_ordered_jit = defaultdict(dict)
         subnetworks = defaultdict(dict)
         for tw, ordered_network in networks_with_subnetworks_ordered_jit.items():
+            intw = independent_networks[tw]
             for order, subnet_sets in ordered_network.items():
                 subnetworks_only_ordered_jit[order].update(subnet_sets)
                 for subn_tw, subnetwork in subnet_sets.items():
-                    for k in independent_networks[tw]:
-                        if k in subnetwork:
-                            subnetworks[subn_tw].update(
-                                {k: independent_networks[tw][k]}
-                            )
+                    subnetworks[subn_tw] = {k: intw[k] for k in subnetwork}
 
         reaches_ordered_bysubntw = {}
         for order, ordered_subn_dict in subnetworks_only_ordered_jit.items():

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -416,13 +416,13 @@ def main():
             print("starting Parallel JIT calculation")
 
         start_para_time = time.time()
-        # with Parallel(n_jobs=cpu_pool, backend="threading") as parallel:
-        if 1 == 1:
+        with Parallel(n_jobs=cpu_pool, backend="threading") as parallel:
+        # if 1 == 1:
             results_subn = defaultdict(list)
             flowveldepth_interorder = {}
 
             for order in range(max(subnetworks_only_ordered_jit.keys()), -1, -1):
-                # jobs = []
+                jobs = []
                 for twi, (subn_tw, subn_reach_list) in enumerate(
                     reaches_bysubntw[order].items(), 1
                 ):
@@ -450,10 +450,10 @@ def main():
                             ] = subn_tw_sortposition
                     qlat_sub = qlats.loc[segs].sort_index()
                     q0_sub = q0.loc[segs].sort_index()
-                    # jobs.append(
-                    # delayed(compute_func)(
-                    results_subn[order].append(
-                        compute_func(
+                    jobs.append(
+                    delayed(compute_func)(
+                    # results_subn[order].append(
+                    #     compute_func(
                             nts,
                             subn_reach_list,
                             subnetworks[subn_tw],
@@ -470,7 +470,8 @@ def main():
                             },
                         )
                     )
-                # results_subn[order] = parallel(jobs)
+
+                results_subn[order] = parallel(jobs)
 
                 # # TODO: delete the duplicate results that shouldn't be passed along
                 # # The upstream keys have empty results because they are not part of any reaches

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -416,12 +416,13 @@ def main():
             print("starting Parallel JIT calculation")
 
         start_para_time = time.time()
-        with Parallel(n_jobs=cpu_pool, backend="threading") as parallel:
+        # with Parallel(n_jobs=cpu_pool, backend="threading") as parallel:
+        if 1 == 1:
+            results_subn = defaultdict(list)
             flowveldepth_interorder = {}
-            results_subn = {}
 
             for order in range(max(subnetworks_only_ordered_jit.keys()), -1, -1):
-                jobs = []
+                # jobs = []
                 for twi, (subn_tw, subn_reach_list) in enumerate(
                     reaches_bysubntw[order].items(), 1
                 ):
@@ -440,8 +441,10 @@ def main():
                             ] = subn_tw_sortposition
                     qlat_sub = qlats.loc[r].sort_index()
                     q0_sub = q0.loc[r].sort_index()
-                    jobs.append(
-                        delayed(compute_func)(
+                    # jobs.append(
+                    # delayed(compute_func)(
+                    results_subn[order].append(
+                        compute_func(
                             nts,
                             subn_reach_list,
                             subnetworks[subn_tw],
@@ -454,7 +457,7 @@ def main():
                             flowveldepth_interorder,
                         )
                     )
-                results_subn[order] = parallel(jobs)
+                # results_subn[order] = parallel(jobs)
 
                 # The upstream keys have empty results because they are not part of any reaches
                 # so we need to delete the null values that return

--- a/src/python_routing_v02/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/fast_reach/mc_reach.pyx
@@ -199,6 +199,10 @@ cpdef object compute_network(int nsteps, list reaches, dict connections,
         # print(f"{list(flowveldepth[fill_index])}")
         for idx, val in enumerate(upstream_results[upstream_tw_id]["results"]):
             flowveldepth[fill_index][idx] = val
+        # TODO: Identify a more efficient ways potentially to handle this array filling
+        # The following may be options:
+        # flowveldepth[fill_index] = upstream_results[upstream_tw_id]["results"]
+        # flowveldepth[fill_index, :] = upstream_results[upstream_tw_id]["results"]
         # print(f"Now filled, it contains:")
         # print(f"{list(flowveldepth[fill_index])}")
 

--- a/src/python_routing_v02/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/fast_reach/mc_reach.pyx
@@ -382,9 +382,12 @@ cpdef object compute_network(int nsteps, list reaches, dict connections,
     # delete the duplicate results that shouldn't be passed along
     # The upstream keys have empty results because they are not part of any reaches
     # so we need to delete the null values that return
-    data_idx_ma = [ ix for i, ix in enumerate(data_idx) if i not in fill_index_mask]
-    flowveldepth_ma = [ ix for i, ix in enumerate(flowveldepth) if i not in fill_index_mask]
-    return [np.asarray(data_idx_ma, dtype=np.intp), np.asarray(flowveldepth_ma, dtype='float32')]
+    if len(fill_index_mask) > 0:
+        data_idx_ma = [ix for i, ix in enumerate(data_idx) if i not in fill_index_mask]
+        flowveldepth_ma = [ix for i, ix in enumerate(flowveldepth) if i not in fill_index_mask]
+        return [np.asarray(data_idx_ma, dtype=np.intp), np.asarray(flowveldepth_ma, dtype='float32')]
+    else:
+        return [np.asarray(data_idx, dtype=np.intp), np.asarray(flowveldepth, dtype='float32')]
 
 #---------------------------------------------------------------------------------------------------------------#
 #---------------------------------------------------------------------------------------------------------------#

--- a/src/python_routing_v02/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/fast_reach/mc_reach.pyx
@@ -270,6 +270,16 @@ cpdef object compute_network(int nsteps, list reaches, dict connections,
     cdef int timestep = 0
     cdef int ts_offset
 
+# TODO: Split the compute network function so that the part where we set up
+# all the indices is separate from the call to loop through them.
+# That way, we can refine the functions for preparing the indexes in isolation
+# For example, the actual looping function could start about here in the current
+# function, and might look like the following Psuedocode
+# cpdef(Dataindex):
+    # pull indices and put them in arrays
+    # minimal validation,
+    # Jump straight to nogil.
+
     with nogil:
         while timestep < nsteps:
             ts_offset = timestep * 3

--- a/src/python_routing_v02/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/fast_reach/mc_reach.pyx
@@ -107,13 +107,13 @@ cdef void compute_reach_kernel(float qup, float quc, int nreach, const float[:,:
         output_buf[i, 0] = out.qdc
         output_buf[i, 1] = out.velc
         output_buf[i, 2] = out.depthc
-        
+
         qup = qdp
-        
+
         if assume_short_ts:
             quc = qup
         else:
-            quc = out.qdc        
+            quc = out.qdc
 
 cdef void fill_buffer_column(const Py_ssize_t[:] srows,
     const Py_ssize_t scol,
@@ -140,9 +140,9 @@ cpdef object column_mapper(object src_cols):
     return rv
 
 
-cpdef object compute_network(int nsteps, list reaches, dict connections, 
-    const long[:] data_idx, object[:] data_cols, const float[:,:] data_values, 
-    const float[:, :] qlat_values, const float[:,:] initial_conditions, 
+cpdef object compute_network(int nsteps, list reaches, dict connections,
+    const long[:] data_idx, object[:] data_cols, const float[:,:] data_values,
+    const float[:, :] qlat_values, const float[:,:] initial_conditions,
     # const float[:] wbody_idx, object[:] wbody_cols, const float[:, :] wbody_vals,
     dict upstream_results={},
     bint assume_short_ts=False):
@@ -205,7 +205,7 @@ cpdef object compute_network(int nsteps, list reaches, dict connections,
     cdef:
         Py_ssize_t[:] srows  # Source rows indexes
         Py_ssize_t[:] drows_tmp
-    
+
     # Buffers and buffer views
     # These are C-contiguous.
     cdef float[:, ::1] buf, buf_view
@@ -213,7 +213,7 @@ cpdef object compute_network(int nsteps, list reaches, dict connections,
 
     # Source columns
     cdef Py_ssize_t[:] scols = np.array(column_mapper(data_cols), dtype=np.intp)
-    
+
     # hard-coded column. Find a better way to do this
     cdef int buf_cols = 13
 
@@ -301,31 +301,31 @@ cpdef object compute_network(int nsteps, list reaches, dict connections,
 
                 ireach_cache += 1
                 iusreach_cache += 1
-                
+
                 qup = 0.0
                 quc = 0.0
                 for i in range(usreachlen):
-                    
+
                     '''
                     New logic was added to handle initial conditions:
                     When timestep == 0, the flow from the upstream segments in the previous timestep
-                    are equal to the initial conditions. 
+                    are equal to the initial conditions.
                     '''
-                        
-                    # upstream flow in the current timestep is equal the sum of flows 
+
+                    # upstream flow in the current timestep is equal the sum of flows
                     # in upstream segments, current timestep
                     # Headwater reaches are computed before higher order reaches, so quc can
                     # be evaulated even when the timestep == 0.
                     quc += flowveldepth[usreach_cache[iusreach_cache + i], ts_offset]
-                    
-                    # upstream flow in the previous timestep is equal to the sum of flows 
+
+                    # upstream flow in the previous timestep is equal to the sum of flows
                     # in upstream segments, previous timestep
                     if timestep > 0:
                         qup += flowveldepth[usreach_cache[iusreach_cache + i], ts_offset - 3]
                     else:
                         # sum of qd0 (flow out of each segment) over all upstream reaches
                         qup += initial_conditions[usreach_cache[iusreach_cache + i],1]
-                        
+
                 buf_view = buf[:reachlen, :]
                 out_view = out_buf[:reachlen, :]
                 drows = drows_tmp[:reachlen]
@@ -333,20 +333,20 @@ cpdef object compute_network(int nsteps, list reaches, dict connections,
 
                 """
                 qlat_values may have fewer columns than data_values if qlat data are taken from WRF hydro simulations,
-                which are often run at a coarser timestep than routing models. In the fill_buffer_columns call below, 
+                which are often run at a coarser timestep than routing models. In the fill_buffer_columns call below,
                 the second argument, which defines the column in qlat_values that data should be drawn from, is specified
-                such that qlat values are repeated for each of the finer routing timesteps within a WRF hydro timestep. 
+                such that qlat values are repeated for each of the finer routing timesteps within a WRF hydro timestep.
                 """
-                fill_buffer_column(srows, 
+                fill_buffer_column(srows,
                                    int(timestep/(nsteps/qlat_values.shape[1])),  # adjust timestep to WRF-hydro timestep
-                                   drows, 
-                                   0, 
-                                   qlat_values, 
+                                   drows,
+                                   0,
+                                   qlat_values,
                                    buf_view)
-                
+
                 for i in range(scols.shape[0]):
                         fill_buffer_column(srows, scols[i], drows, i + 1, data_values, buf_view)
-                        
+
                 # fill buffer with qdp, depthp, velp
                 if timestep > 0:
                     fill_buffer_column(srows, ts_offset - 3, drows, 10, flowveldepth, buf_view)
@@ -355,7 +355,7 @@ cpdef object compute_network(int nsteps, list reaches, dict connections,
                 else:
                     '''
                     Changed made to accomodate initial conditions:
-                    when timestep == 0, qdp, and depthp are taken from the initial_conditions array, 
+                    when timestep == 0, qdp, and depthp are taken from the initial_conditions array,
                     using srows to properly index
                     '''
                     for i in range(drows.shape[0]):
@@ -375,7 +375,7 @@ cpdef object compute_network(int nsteps, list reaches, dict connections,
                 # Update indexes to point to next reach
                 ireach_cache += reachlen
                 iusreach_cache += usreachlen
-                
+
             timestep += 1
 
 
@@ -389,9 +389,9 @@ cpdef object compute_network(int nsteps, list reaches, dict connections,
 #---------------------------------------------------------------------------------------------------------------#
 #---------------------------------------------------------------------------------------------------------------#
 #---------------------------------------------------------------------------------------------------------------#
-cpdef object compute_network_multithread(int nsteps, list reaches, dict connections, 
-    const long[:] data_idx, object[:] data_cols, const float[:,:] data_values, 
-    const float[:, :] qlat_values, const float[:,:] initial_conditions, 
+cpdef object compute_network_multithread(int nsteps, list reaches, dict connections,
+    const long[:] data_idx, object[:] data_cols, const float[:,:] data_values,
+    const float[:, :] qlat_values, const float[:,:] initial_conditions,
     const int[:] reach_groups,
     const int[:] reach_group_cache_sizes,
     bint assume_short_ts=False):
@@ -404,7 +404,7 @@ cpdef object compute_network_multithread(int nsteps, list reaches, dict connecti
         data_idx (ndarray): a 1D sorted index for data_values
         data_values (ndarray): a 2D array of data inputs (nodes x variables)
         qlats (ndarray): a 2D array of qlat values (nodes x nsteps). The index must be shared with data_values
-        initial_conditions (ndarray): an n x 3 array of initial conditions. 
+        initial_conditions (ndarray): an n x 3 array of initial conditions.
         assume_short_ts (bool): Assume short time steps (quc = qup)
     Notes:
         Array dimensions are checked as a precondition to this method.
@@ -416,16 +416,16 @@ cpdef object compute_network_multithread(int nsteps, list reaches, dict connecti
         raise ValueError(f"Number of columns (timesteps) in Qlat is incorrect: expected at most ({data_idx.shape[0]}), got ({qlat_values.shape[0]}). The number of columns in Qlat must be equal to or less than the number of routing timesteps")
     if data_values.shape[0] != data_idx.shape[0] or data_values.shape[1] != data_cols.shape[0]:
         raise ValueError(f"data_values shape mismatch")
-    
+
     cdef float[:,::1] flowveldepth = np.zeros((data_idx.shape[0], nsteps * 3), dtype='float32')
-    
+
     cdef:
         Py_ssize_t[:] srows  # Source rows indexes
         Py_ssize_t[:] drows_tmp
-    
+
     # hard-coded column. Find a better way to do this
     cdef int buf_cols = 13
-    
+
     # Buffers and buffer views
     # These are C-contiguous.
     cdef float[:, ::1] buf, buf_view
@@ -433,7 +433,7 @@ cpdef object compute_network_multithread(int nsteps, list reaches, dict connecti
     cdef int maxgrouplen = max(reach_group_cache_sizes)
     buf = np.empty((maxgrouplen, buf_cols), dtype='float32')
     out_buf = np.empty((maxgrouplen, 3), dtype='float32')
-    
+
     # Source columns
     cdef Py_ssize_t[:] scols = np.array(column_mapper(data_cols), dtype=np.intp)
 
@@ -468,14 +468,14 @@ cpdef object compute_network_multithread(int nsteps, list reaches, dict connecti
     # upstream reach cache is ordered 1D view of reaches
     # [-len, item, item, item, -len, item, item, -len, item, item, ...]
     usreach_cache = np.empty(sum(usreach_sizes) + len(usreach_sizes), dtype=np.intp)
-    
+
     # ireach_cache_array
     ireach_cache_array = np.empty(len(reach_sizes), dtype=np.intp)
     iusreach_cache_array = np.empty(len(reach_sizes), dtype=np.intp)
 
     ireach_cache = 0
     iusreach_cache = 0
-    
+
     ireach_cache_array[0] = 0
     iusreach_cache_array[0] = 0
     # copy reaches into an array
@@ -498,32 +498,32 @@ cpdef object compute_network_multithread(int nsteps, list reaches, dict connecti
             for bidx in binary_find(data_idx, connections[reach[0]]):
                 usreach_cache[iusreach_cache] = bidx
                 iusreach_cache += 1
-                
+
         if ireach < max(range(len(reaches))):
             ireach_cache_array[ireach+1] = ireach_cache
             iusreach_cache_array[ireach+1] = iusreach_cache
 
     drows_tmp = np.arange(maxgrouplen, dtype=np.intp)
-    
+
     cdef Py_ssize_t[:] drows
     cdef int timestep = 0
     cdef int ts_offset
 
     cdef int maxgroupsize = max(reach_groups)
     cdef float[:] qu_buf = np.empty(maxgroupsize, dtype = "float32")
-    cdef float[:] quc_view 
+    cdef float[:] quc_view
     cdef float[:] qup_view
     cdef float quc, qup
     cdef int qu_idx
     cdef int buf_idx
     cdef Py_ssize_t[:] srowsgroup_buf = np.empty(maxgrouplen, dtype = np.intp)
     cdef int srows_idx
-    
+
     cdef:
-        Py_ssize_t istart  
+        Py_ssize_t istart
         Py_ssize_t iend
         int r
-    
+
     with nogil:
         while timestep < nsteps:
             ts_offset = timestep * 3
@@ -531,10 +531,10 @@ cpdef object compute_network_multithread(int nsteps, list reaches, dict connecti
             istart = 0
             iend = -1
             for group_i in range(len(reach_group_cache_sizes)):
-                
+
                 # index of final reach entry in reach_cache for this group
                 iend += reach_groups[group_i]
-                
+
                 # prepare group buffers
                 buf_view = buf[:reach_group_cache_sizes[group_i],:]
                 out_view = out_buf[:reach_group_cache_sizes[group_i],:]
@@ -542,19 +542,19 @@ cpdef object compute_network_multithread(int nsteps, list reaches, dict connecti
                 qup_view = qu_buf[:reach_groups[group_i]]
                 srows = srowsgroup_buf[:reach_group_cache_sizes[group_i]]
                 drows = drows_tmp[:reach_group_cache_sizes[group_i]]
-                
+
                 # extract upstream flows and populate srows
                 qu_idx = 0
                 srows_idx = 0
                 for r in range(istart,iend+1):
-                    
+
                     ireach_cache = ireach_cache_array[r]
                     iusreach_cache = iusreach_cache_array[r]
                     reachlen = -reach_cache[ireach_cache]
                     usreachlen = -usreach_cache[iusreach_cache]
                     iusreach_cache += 1
                     ireach_cache += 1
-                    
+
                     quc = 0.0
                     qup = 0.0
                     for i in range(usreachlen):
@@ -563,25 +563,25 @@ cpdef object compute_network_multithread(int nsteps, list reaches, dict connecti
                             qup += flowveldepth[usreach_cache[iusreach_cache + i], ts_offset - 3]
                         else:
                             qup += initial_conditions[usreach_cache[iusreach_cache + i],1]
-                            
+
                     quc_view[qu_idx] = quc
                     qup_view[qu_idx] = qup
                     qu_idx += 1
-                    
+
                     # build srows
                     for i in range(reachlen):
                         srows[srows_idx] = reach_cache[ireach_cache + i]
                         srows_idx += 1
-                             
+
                 # fill buf_view with qlat, parameter and initial conditions data
-                # qlats    
-                fill_buffer_column(srows, 
+                # qlats
+                fill_buffer_column(srows,
                            int(timestep/(nsteps/qlat_values.shape[1])),
-                           drows, 
-                           0, 
-                           qlat_values, 
+                           drows,
+                           0,
+                           qlat_values,
                            buf_view)
-            
+
                 # parameters
                 for i in range(scols.shape[0]):
                     fill_buffer_column(srows, scols[i], drows, i + 1, data_values, buf_view)
@@ -596,15 +596,15 @@ cpdef object compute_network_multithread(int nsteps, list reaches, dict connecti
                         buf_view[drows[i], 10] = initial_conditions[srows[i],1]
                         buf_view[drows[i], 11] = 0.0
                         buf_view[drows[i], 12] = initial_conditions[srows[i],2]
-                
+
                 # ------ !!!!! MULTITHREAD LOOP !!!!! ------ #
                 # compute each reach
                 for r in prange(istart,iend+1):
-                    
+
                     # reach length for reach r of group
                     ireach_cache = ireach_cache_array[r]
                     reachlen = -reach_cache[ireach_cache]
-                    
+
                     # total reach length of reaches preceeding reach r in group
                     if r > istart:
                         prevreachlen = 0
@@ -612,33 +612,33 @@ cpdef object compute_network_multithread(int nsteps, list reaches, dict connecti
                             prevreachlen = prevreachlen + -reach_cache[ireach_cache_array[(r-(i+1))]]
                     else:
                         prevreachlen = 0
-                            
+
                     # compute reach routing
-                    if assume_short_ts:    
-                        compute_reach_kernel(qup_view[r-istart], 
+                    if assume_short_ts:
+                        compute_reach_kernel(qup_view[r-istart],
                                              quc_view[r-istart], # quc = qup
-                                             reachlen, 
+                                             reachlen,
                                              buf_view[prevreachlen:prevreachlen+reachlen,:],
                                              out_view[prevreachlen:prevreachlen+reachlen,:],
                                              assume_short_ts)
-                        
+
                     else:
-                        compute_reach_kernel(qup_view[r-istart], 
-                                             quc_view[r-istart], 
-                                             reachlen, 
+                        compute_reach_kernel(qup_view[r-istart],
+                                             quc_view[r-istart],
+                                             reachlen,
                                              buf_view[prevreachlen:prevreachlen+reachlen,:],
                                              out_view[prevreachlen:prevreachlen+reachlen,:],
                                              assume_short_ts)
                 # END ------ !!!!! MULTITHREAD LOOP !!!!! ------ #
-                        
-                        
+
+
                 # place out_view results into flowveldepth
                 for i in range(3):
                     fill_buffer_column(drows, i, srows, ts_offset + i, out_view, flowveldepth)
-                
-                    
+
+
                 istart = istart + reach_groups[group_i]
-                
+
             timestep += 1
 
     return np.asarray(data_idx, dtype=np.intp), np.asarray(flowveldepth, dtype='float32')

--- a/src/python_routing_v02/setup.py
+++ b/src/python_routing_v02/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 from distutils.extension import Extension
 import sys
 import numpy as np
@@ -19,14 +19,16 @@ ext = 'pyx' if USE_CYTHON else 'c'
 
 reach = Extension("reach",
         sources = ["fast_reach/reach.{}".format(ext)],
-        extra_objects = ['fast_reach/mc_single_seg.o', 'fast_reach/pymc_single_seg.o' ])
+        extra_objects = ['fast_reach/mc_single_seg.o', 'fast_reach/pymc_single_seg.o' ],
+        extra_compile_args=['-g'])
 
 mc_reach = Extension("mc_reach",
           sources = ["fast_reach/mc_reach.{}".format(ext)],
           include_dirs = [np.get_include()],
           libraries=[],
           library_dirs=[],
-          extra_objects=[])
+          extra_objects=[],
+          extra_compile_args=['-g'])
 
 ext_modules=[
     reach, mc_reach
@@ -34,7 +36,7 @@ ext_modules=[
 
 if USE_CYTHON:
     from Cython.Build import cythonize
-    ext_modules = cythonize(ext_modules)
+    ext_modules = cythonize(ext_modules, compiler_directives={'language_level': 3})
 
 setup(
   name = 'compute_network_mc',


### PR DESCRIPTION
The idea of parallelizing by reaches is attractive but the opportunity for parallelism is more than offset by the in-efficiency of reducing the calculation to such small chunks as are found in individual reaches. This PR provides initial code to break the network into groups of subordinate reaches, "subnetworks". Only preliminary attempts at connecting these subnetworks have been made in the PR as it stands now -- more changes will be needed in the `compute_network` code to allow for additional values in the `flowveldepth` array, from which the upstream inflow values are obtained to provide boundary conditions for each call to the `compute_reach_kernel`. The subnetworks are passed to the compute subnetwork function just-in-time, so that upstream subnetworks are compute just prior to computation of their downstream dependencies, hence, the commandline flag is `by-subnetwork-jit`

The following command-line demonstrates the call for parallel execution with subnetworks using subnets of at least 2 segments each:
 ipython compute_nhd_routing_SingleSeg_v02.py -- -v --debuglevel 1 --parallel by-subnetwork-jit --subnet-size 2 --nts 2

A second option, `by-subnetwork-jit-clustered`, builds on the previous idea, but also attempts to group onto a single thread subnetworks that are very small -- this becomes very important in the full-resolution routing networks. @awlostowski-noaa -- we might see if we can include here a few of the distribution plots. 