### PR TITLE
Include short time step arg in compute_network call

### DIFF
--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -289,6 +289,7 @@ def main():
                         param_df_sub.values,
                         qlat_sub.values,
                         q0_sub.values,
+                        assume_short_ts,
                     )
                 )
             results = parallel(jobs)
@@ -312,6 +313,7 @@ def main():
                     param_df_sub.values,
                     qlat_sub.values,
                     q0_sub.values,
+                    assume_short_ts,
                 )
             )
 


### PR DESCRIPTION
Short-time-step argument was not included in the script calls to the compute_network function. 

This PR corrects the omission.

NOTE: Initial testing shows that the output is consistent with our Pocono_TEST2 standard test. The computational error will be corrected in a separate PR.