### PR TITLE
Quick v02 parity test against Pocono test data STALE

### DIFF
--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -468,6 +468,8 @@ def main():
         qlat_file_pattern_filter = "/*.CHRTOUT_DOMAIN1"
         qlat_file_index_col = "feature_id"
         qlat_file_value_col = "q_lateral"
+        
+        # get wrf-simulated flows
 
     if verbose:
         print("creating supernetwork connections set")


### PR DESCRIPTION
This pull request includes a simple comparison between t-route and WRF-simulated flows for the Pocono1 Test case. When the Pocono1 test is run in `compute_nhd_network_SingleSeg_v02.py` the output will be automatically checked against WRF hydro channel flow simulations. 