### PR TITLE
Subnetwork final + Model Version 2.0 alpha2

### DIFF
--- a/src/fortran_routing/mc_pylink_v00/MC_singleSeg_singleTS/makefile
+++ b/src/fortran_routing/mc_pylink_v00/MC_singleSeg_singleTS/makefile
@@ -3,7 +3,7 @@ FC := gfortran
 
 # compile flags
 #FCFLAGS = -c -fdefault-real-8 -fno-align-commons -fbounds-check --free-form
-FCFLAGS = -c -O2 -fPIC
+FCFLAGS = -g -c -O2 -fPIC
 # link flags
 FLFLAGS = -static-gfortran -static-libgcc -no-defaultlibs -lgfortran -lgcc
 VPATH = ../Reservoir_singleTS

--- a/src/python_framework_v02/setup.py
+++ b/src/python_framework_v02/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 from distutils.extension import Extension
 import sys
 import numpy as np
@@ -19,7 +19,9 @@ ext = 'pyx' if USE_CYTHON else 'c'
 reach = Extension("troute.network.reach",
         sources = ["troute/network/reach.{}".format(ext)],
         include_dirs=[np.get_include()],
-        extra_objects = [])
+        extra_objects = [],
+        extra_compile_args = ['-g'],
+        )
 
 package_data = {
     'troute.network':['reach.pxd']
@@ -30,7 +32,7 @@ ext_modules=[
 
 if USE_CYTHON:
     from Cython.Build import cythonize
-    ext_modules = cythonize(ext_modules)
+    ext_modules = cythonize(ext_modules, compiler_directives={"language_level": 3})
 
 setup(
   name = 'Network',

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -79,7 +79,7 @@ def replace_downstreams(data, downstream_col, terminal_code):
 def read_waterbody_df(waterbody_parameters, waterbodies_values, wbtype="level_pool"):
     """
     General waterbody dataframe reader. At present, only level-pool
-    capability exists. 
+    capability exists.
     """
     if wbtype == "level_pool":
         wb_params = waterbody_parameters[wbtype]
@@ -94,14 +94,14 @@ def read_level_pool_waterbody_df(
     parm_file, lake_index_field="lake_id", lake_id_mask=None
 ):
     """
-    Reads LAKEPARM file and prepares a dataframe, filtered 
+    Reads LAKEPARM file and prepares a dataframe, filtered
     to the relevant reservoirs, to provide the parameters
     for level-pool reservoir computation.
 
     Completely replaces the read_waterbody_df function from prior versions
     of the v02 routing code.
 
-    Prior version filtered the dataframe as opposed to the dataset as in this version. 
+    Prior version filtered the dataframe as opposed to the dataset as in this version.
     with xr.open_dataset(parm_file) as ds:
         df1 = ds.to_dataframe()
     df1 = df1.set_index(lake_index_field).sort_index(axis="index")
@@ -138,7 +138,9 @@ def read_qlat(path):
     return get_ql_from_csv(path)
 
 
-def get_ql_from_wrf_hydro_mf(qlat_files, index_col="station_id", value_col="q_lateral", filter_list=None):
+def get_ql_from_wrf_hydro_mf(
+    qlat_files, index_col="station_id", value_col="q_lateral", filter_list=None
+):
     """
     qlat_files: globbed list of CHRTOUT files containing desired lateral inflows
     index_col: column/field in the CHRTOUT files with the segment/link id
@@ -184,18 +186,18 @@ def get_ql_from_wrf_hydro_mf(qlat_files, index_col="station_id", value_col="q_la
     #       Assuming the bug is resolved at some point, the 'by_coords'
     #       method should be better for all cases.
     if len(qlat_files) == 1:
-        with xr.open_mfdataset(qlat_files, combine='nested', concat_dim='time') as ds:
+        with xr.open_mfdataset(qlat_files, combine="nested", concat_dim="time") as ds:
             if not filter_list:
                 df1 = ds[value_col].to_dataframe()
             else:
-                df1 = ds.sel({index_col:filter_list})[value_col].to_dataframe()
+                df1 = ds.sel({index_col: filter_list})[value_col].to_dataframe()
 
-    else: # Assumes > 1
-        with xr.open_mfdataset(qlat_files, combine='by_coords') as ds:
+    else:  # Assumes > 1
+        with xr.open_mfdataset(qlat_files, combine="by_coords") as ds:
             if not filter_list:
                 df1 = ds[value_col].to_dataframe()
             else:
-                df1 = ds.sel({index_col:filter_list})[value_col].to_dataframe()
+                df1 = ds.sel({index_col: filter_list})[value_col].to_dataframe()
 
     mod = df1.reset_index()
     ql = mod.pivot(index=index_col, columns="time", values=value_col)

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -53,6 +53,7 @@ def read_custom_input(custom_input_file):
     restart_parameters = data.get("restart_parameters", {})
     output_parameters = data.get("output_parameters", {})
     run_parameters = data.get("run_parameters", {})
+    parity_parameters = data.get("parity_parameters", {})
     # TODO: add error trapping for potentially missing files
     return (
         supernetwork_parameters,
@@ -61,6 +62,7 @@ def read_custom_input(custom_input_file):
         restart_parameters,
         output_parameters,
         run_parameters,
+        parity_parameters,
     )
 
 
@@ -136,7 +138,7 @@ def read_qlat(path):
     return get_ql_from_csv(path)
 
 
-def get_ql_from_wrf_hydro_mf(qlat_files, index_col="station_id", value_col="q_lateral"):
+def get_ql_from_wrf_hydro_mf(qlat_files, index_col="station_id", value_col="q_lateral", filter_list=None):
     """
     qlat_files: globbed list of CHRTOUT files containing desired lateral inflows
     index_col: column/field in the CHRTOUT files with the segment/link id

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -185,10 +185,17 @@ def get_ql_from_wrf_hydro_mf(qlat_files, index_col="station_id", value_col="q_la
     #       method should be better for all cases.
     if len(qlat_files) == 1:
         with xr.open_mfdataset(qlat_files, combine='nested', concat_dim='time') as ds:
-            df1 = ds[value_col].to_dataframe()
+            if not filter_list:
+                df1 = ds[value_col].to_dataframe()
+            else:
+                df1 = ds.sel({index_col:filter_list})[value_col].to_dataframe()
+
     else: # Assumes > 1
         with xr.open_mfdataset(qlat_files, combine='by_coords') as ds:
-            df1 = ds[value_col].to_dataframe()
+            if not filter_list:
+                df1 = ds[value_col].to_dataframe()
+            else:
+                df1 = ds.sel({index_col:filter_list})[value_col].to_dataframe()
 
     mod = df1.reset_index()
     ql = mod.pivot(index=index_col, columns="time", values=value_col)
@@ -213,7 +220,7 @@ def get_ql_from_wrf_hydro(qlat_files, index_col="station_id", value_col="q_later
 
     for filename in qlat_files:
         with xr.open_dataset(filename) as ds:
-            df1 = ds.to_dataframe()
+            df1 = ds[value_col].to_dataframe()
 
         li.append(df1)
 

--- a/src/python_framework_v02/troute/nhd_network.py
+++ b/src/python_framework_v02/troute/nhd_network.py
@@ -93,12 +93,15 @@ def junctions(N):
 
 
 def headwaters(N):
-    yield from N.keys() - chain.from_iterable(N.values())
+    return N.keys() - chain.from_iterable(N.values())
 
 
 def tailwaters(N):
-    yield from chain.from_iterable(N.values()) - N.keys()
-    yield from (m for m, n in N.items() if not n)
+    tw = chain.from_iterable(N.values()) - N.keys()
+    for m, n in N.items():
+        if not n:
+            tw.add(m)
+    return tw
 
 
 def reachable(N, sources=None, targets=None):

--- a/src/python_framework_v02/troute/nhd_network.py
+++ b/src/python_framework_v02/troute/nhd_network.py
@@ -452,7 +452,7 @@ def build_subnetworks(connections, rconn, min_size, sources=None):
     for net in sources:
 
         # subnetwork creation using a breadth first search restricted by maximum allowable depth
-        #new_sources_list = [net]
+        # new_sources_list = [net]
         new_sources = set([net])
         subnetworks = {}
         group_order = 0
@@ -486,7 +486,7 @@ def build_subnetworks(connections, rconn, min_size, sources=None):
                 rv[h] = reachable
 
             # find headwater segments in reachable groups, these will become the next set of sources
-            #new_sources_list = []
+            # new_sources_list = []
             new_sources = set()
             for tw, seg in rv.items():
                 # identify downstream connections for segments in this subnetwork

--- a/src/python_framework_v02/troute/nhd_network.py
+++ b/src/python_framework_v02/troute/nhd_network.py
@@ -153,7 +153,11 @@ def reachable_network(N, sources=None, targets=None, check_disjoint=True):
 
     """
     reached = reachable(N, sources=sources, targets=targets)
-    if check_disjoint and reduce(set.intersection, reached.values()):
+    if (
+        check_disjoint
+        and len(reached) > 1
+        and reduce(set.intersection, reached.values())
+    ):
         raise ValueError("Networks not disjoint")
 
     rv = {}

--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -484,7 +484,7 @@ def build_qlateral_array(forcing_parameters, connections_keys, nts):
         )
         qlat_file_value_col = forcing_parameters.get("qlat_file_value_col", "q_lateral")
         qlat_files = glob.glob(qlat_input_folder + qlat_file_pattern_filter)
-        qlat_df = nhd_io.get_ql_from_wrf_hydro(
+        qlat_df = nhd_io.get_ql_from_wrf_hydro_mf(
             qlat_files=qlat_files,
             index_col=qlat_file_index_col,
             value_col=qlat_file_value_col,

--- a/src/python_routing_v02/build_tests.py
+++ b/src/python_routing_v02/build_tests.py
@@ -170,7 +170,7 @@ def parity_check(parity_parameters, nts, dt, results):
         validation_files,
         parity_parameters["parity_check_file_index_col"],
         parity_parameters["parity_check_file_value_col"],
-        [compare_node],
+        # [compare_node],
     )
 
     wrf_time = validation_data.columns.astype("datetime64[ns]")

--- a/src/python_routing_v02/build_tests.py
+++ b/src/python_routing_v02/build_tests.py
@@ -131,6 +131,10 @@ def build_test_parameters(
         # dt = 300
         # dt_routing = pd.Timedelta(str(dt) + 'seconds')
 
+        # run_parameters["dt"] = dt
+        # run_parameters["nts"] = round(sim_duration / dt_routing)
+        # run_parameters["qts_subdivisions"] = dt_wrf/dt_routing
+
         run_parameters["dt"] = 300
         run_parameters["nts"] = 288
         run_parameters["qts_subdivisions"] = 12

--- a/src/python_routing_v02/build_tests.py
+++ b/src/python_routing_v02/build_tests.py
@@ -33,17 +33,19 @@ if ENV_IS_CL:
 elif not ENV_IS_CL:
     root = pathlib.Path("../..").resolve()
 
-def build_test_parameters(test_name,
-                        supernetwork_parameters, 
-                        run_parameters, 
-                        output_parameters, 
-                        restart_parameters, 
-                        forcing_parameters,
-                        parity_parameters
-                    ):
-    
+
+def build_test_parameters(
+    test_name,
+    supernetwork_parameters,
+    run_parameters,
+    output_parameters,
+    restart_parameters,
+    forcing_parameters,
+    parity_parameters,
+):
+
     if test_name == "pocono1":
-        
+
         print("running test case for Pocono_TEST1 domain - NO RESERVOIRS")
 
         # File path to WRF Hydro data
@@ -55,13 +57,13 @@ def build_test_parameters(test_name,
         routelink_file = os.path.join(
             NWM_test_path, "primary_domain", "DOMAIN", "Route_Link.nc",
         )
-        
+
         # Speficify WRF hydro restart file, name and destination
         time_string = "2017-12-31_06-00_DOMAIN1"
         wrf_hydro_restart_file = os.path.join(
             NWM_test_path, "example_RESTART", "HYDRO_RST." + time_string
         )
-        
+
         # specify supernetwork parameters
         supernetwork_parameters = {
             "title_string": "Custom Input Example (using Pocono Test Example datafile)",
@@ -86,26 +88,22 @@ def build_test_parameters(test_name,
             "driver_string": "NetCDF",
             "layer_string": 0,
         }
-        
+
         # specity output parameters
         output_parameters["csv_output"] = None
         output_parameters["nc_output_folder"] = None
-        
+
         # specify restart parameters
         restart_parameters["wrf_hydro_channel_restart_file"] = wrf_hydro_restart_file
         restart_parameters["wrf_hydro_channel_ID_crosswalk_file"] = routelink_file
-        restart_parameters[
-            "wrf_hydro_channel_ID_crosswalk_file_field_name"
-        ] = "link"
+        restart_parameters["wrf_hydro_channel_ID_crosswalk_file_field_name"] = "link"
         restart_parameters[
             "wrf_hydro_channel_restart_upstream_flow_field_name"
         ] = "qlink1"
         restart_parameters[
             "wrf_hydro_channel_restart_downstream_flow_field_name"
         ] = "qlink2"
-        restart_parameters[
-            "wrf_hydro_channel_restart_depth_flow_field_name"
-        ] = "hlink"
+        restart_parameters["wrf_hydro_channel_restart_depth_flow_field_name"] = "hlink"
 
         # specify restart parameters
         forcing_parameters["qlat_input_folder"] = os.path.join(
@@ -115,30 +113,30 @@ def build_test_parameters(test_name,
         forcing_parameters["qlat_file_pattern_filter"] = "/*.CHRTOUT_DOMAIN1"
         forcing_parameters["qlat_file_index_col"] = "feature_id"
         forcing_parameters["qlat_file_value_col"] = "q_lateral"
-        
+
         # construct time domain (run_parameters)
-        #qlat_files = glob.glob(
-            #forcing_parameters["qlat_input_folder"] + forcing_parameters["qlat_file_pattern_filter"], 
-            #recursive=True
-        #)
-        #ql = nhd_io.get_ql_from_wrf_hydro_mf(
-            #qlat_files,
-            #forcing_parameters["qlat_file_index_col"]
-        #)
-        
-        #wrf_time = ql.columns.astype("datetime64[ns]")
-        #dt_wrf = (wrf_time[1] - wrf_time[0])
-        #sim_duration = (wrf_time[-1] + dt_wrf) - wrf_time[0]
-        
-        #dt = 300
-        #dt_routing = pd.Timedelta(str(dt) + 'seconds')
-        
+        # qlat_files = glob.glob(
+        # forcing_parameters["qlat_input_folder"] + forcing_parameters["qlat_file_pattern_filter"],
+        # recursive=True
+        # )
+        # ql = nhd_io.get_ql_from_wrf_hydro_mf(
+        # qlat_files,
+        # forcing_parameters["qlat_file_index_col"]
+        # )
+
+        # wrf_time = ql.columns.astype("datetime64[ns]")
+        # dt_wrf = (wrf_time[1] - wrf_time[0])
+        # sim_duration = (wrf_time[-1] + dt_wrf) - wrf_time[0]
+
+        # dt = 300
+        # dt_routing = pd.Timedelta(str(dt) + 'seconds')
+
         run_parameters["dt"] = 300
         run_parameters["nts"] = 288
-        run_parameters["qts_subdivisions"] = 12 
-        
+        run_parameters["qts_subdivisions"] = 12
+
         run_parameters["assume_short_ts"] = True
-        
+
         parity_parameters["parity_check_input_folder"] = os.path.join(
             root,
             "test/input/geo/NWM_2.1_Sample_Datasets/Pocono_TEST1/example_CHRTOUT/",
@@ -147,13 +145,22 @@ def build_test_parameters(test_name,
         parity_parameters["parity_check_file_index_col"] = "feature_id"
         parity_parameters["parity_check_file_value_col"] = "streamflow"
         parity_parameters["parity_check_compare_node"] = 4186169
-        
-    return supernetwork_parameters, run_parameters, output_parameters, restart_parameters, forcing_parameters, parity_parameters
+
+    return (
+        supernetwork_parameters,
+        run_parameters,
+        output_parameters,
+        restart_parameters,
+        forcing_parameters,
+        parity_parameters,
+    )
+
 
 def parity_check(parity_parameters, nts, dt, results):
     validation_files = glob.glob(
-        parity_parameters["parity_check_input_folder"] + parity_parameters["parity_check_file_pattern_filter"], 
-        recursive=True
+        parity_parameters["parity_check_input_folder"]
+        + parity_parameters["parity_check_file_pattern_filter"],
+        recursive=True,
     )
 
     compare_node = parity_parameters["parity_check_compare_node"]
@@ -167,31 +174,41 @@ def parity_check(parity_parameters, nts, dt, results):
     )
 
     wrf_time = validation_data.columns.astype("datetime64[ns]")
-    dt_wrf = (wrf_time[1] - wrf_time[0])
+    dt_wrf = wrf_time[1] - wrf_time[0]
     sim_duration = (wrf_time[-1] + dt_wrf) - wrf_time[0]
-        
+
     # construct a dataframe of simulated flows
     fdv_columns = pd.MultiIndex.from_product([range(nts), ["q", "v", "d"]])
     flowveldepth = pd.concat(
         [pd.DataFrame(d, index=i, columns=fdv_columns) for i, d in results], copy=False
     )
     flowveldepth = flowveldepth.sort_index()
-    
+
     flows = flowveldepth.loc[:, (slice(None), "q")]
-    flows = flows.T.reset_index(level = [0,1])
-    flows.rename(columns = {"level_0": "Timestep", "level_1": "Parameter"}, inplace = True)
-    flows['Time (d)'] = ((flows.Timestep + 1) * dt)/(24*60*60)
-    flows = flows.set_index('Time (d)')    
-    
+    flows = flows.T.reset_index(level=[0, 1])
+    flows.rename(columns={"level_0": "Timestep", "level_1": "Parameter"}, inplace=True)
+    flows["Time (d)"] = ((flows.Timestep + 1) * dt) / (24 * 60 * 60)
+    flows = flows.set_index("Time (d)")
+
     # specify simulation calendar time
-    dt_routing = pd.Timedelta(str(dt) + 'seconds')
-    time_routing = pd.period_range((wrf_time[0]-dt_wrf+dt_routing), periods=nts, freq=dt_routing).astype("datetime64[ns]")
-    time_wrf = validation_data.columns.values    
-    
+    dt_routing = pd.Timedelta(str(dt) + "seconds")
+    time_routing = pd.period_range(
+        (wrf_time[0] - dt_wrf + dt_routing), periods=nts, freq=dt_routing
+    ).astype("datetime64[ns]")
+    time_wrf = validation_data.columns.values
+
     # construct comparable dataframes
-    trt = pd.DataFrame(flows.loc[:,compare_node ].values, index = time_routing, columns = ["flow, t-route (cms)"])
-    wrf = pd.DataFrame(validation_data.loc[compare_node ,:].values, index = time_wrf, columns = ["flow, wrf (cms)"])
-        
+    trt = pd.DataFrame(
+        flows.loc[:, compare_node].values,
+        index=time_routing,
+        columns=["flow, t-route (cms)"],
+    )
+    wrf = pd.DataFrame(
+        validation_data.loc[compare_node, :].values,
+        index=time_wrf,
+        columns=["flow, wrf (cms)"],
+    )
+
     # compare dataframes
-    compare = pd.concat([wrf, trt], axis=1, sort=False, join = 'inner')
+    compare = pd.concat([wrf, trt], axis=1, sort=False, join="inner")
     print(compare)

--- a/src/python_routing_v02/compiler.sh
+++ b/src/python_routing_v02/compiler.sh
@@ -13,9 +13,16 @@ make install
 #creates troute package
 cd $REPOROOT/src/python_framework_v02
 rm -rf build
-python setup.py --use-cython install
+#python setup.py --use-cython install
+#python setup.py --use-cython develop
+python setup.py build_ext --inplace --use-cython
+pip install -e .
 
 #updates troute package with the execution script
 cd $REPOROOT/src/python_routing_v02
 rm -rf build
-python setup.py --use-cython install
+#python setup.py --use-cython install
+#python setup.py --use-cython develop
+python setup.py build_ext --inplace --use-cython
+pip install -e .
+

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -867,19 +867,16 @@ def main():
         print("... in %s seconds." % (time.time() - start_time))
         
     
-    if "validation_data" in parity_parameters:
+    if "parity_check_input_folder" in parity_parameters:
         
         if verbose:
             print("conducting parity check, comparing t-route results against WRF Hydro results")
             
         build_tests.parity_check(
-            parity_parameters["wrf_time"],
-            parity_parameters["dt_wrf"],
+            parity_parameters,
             run_parameters["nts"],
             run_parameters["dt"],
-            parity_parameters["validation_data"],
             results,
-            parity_parameters["compare_node"]
         )
         
 

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -871,7 +871,7 @@ def main():
 
         if verbose:
             print(
-                "conducting parity check, comparing t-route results against WRF Hydro results"
+                "conducting parity check, comparing WRF Hydro results against t-route results"
             )
 
         build_tests.parity_check(

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -77,15 +77,15 @@ def _handle_args():
         default=144,
         type=int,
     )
-    
+
     # change this so after --test, the user enters a test choice
     parser.add_argument(
         "--test",
-        help = "Select a test case, routing results will be compared against WRF hydro for parity",
+        help="Select a test case, routing results will be compared against WRF hydro for parity",
         choices=["pocono1"],
-        dest = "test_case"
+        dest="test_case",
     )
-    
+
     parser.add_argument(
         "--sts",
         "--assume-short-ts",
@@ -283,7 +283,7 @@ def constant_qlats(index_dataset, nsteps, qlat):
 
 
 def compute_nhd_routing_v02(
-    connections, 
+    connections,
     rconn,
     reaches_bytw,
     compute_func,
@@ -367,7 +367,7 @@ def compute_nhd_routing_v02(
                         "subn_reach_list": [],
                     }
 
-        if 1==1:
+        if 1 == 1:
             print("JIT Preprocessing time %s seconds." % (time.time() - start_time))
             print("starting Parallel JIT calculation")
 
@@ -455,7 +455,7 @@ def compute_nhd_routing_v02(
         for order in subnetworks_only_ordered_jit:
             results.extend(results_subn[order])
 
-        if 1==1:
+        if 1 == 1:
             print("PARALLEL TIME %s seconds." % (time.time() - start_para_time))
 
     elif parallel_compute_method == "by-subnetwork-jit":
@@ -481,7 +481,7 @@ def compute_nhd_routing_v02(
                     subn_tw
                 ] = nhd_network.dfs_decomposition(rconn_subn, path_func)
 
-        if 1==1:
+        if 1 == 1:
             print("JIT Preprocessing time %s seconds." % (time.time() - start_time))
             print("starting Parallel JIT calculation")
 
@@ -563,7 +563,7 @@ def compute_nhd_routing_v02(
         for order in subnetworks_only_ordered_jit:
             results.extend(results_subn[order])
 
-        if 1==1:
+        if 1 == 1:
             print("PARALLEL TIME %s seconds." % (time.time() - start_para_time))
 
     elif parallel_compute_method == "by-network":
@@ -624,7 +624,7 @@ def compute_nhd_routing_v02(
 def _input_handler():
 
     args = _handle_args()
-    
+
     custom_input_file = args.custom_input_file
     supernetwork_parameters = None
     waterbody_parameters = {}
@@ -642,7 +642,7 @@ def _input_handler():
             restart_parameters,
             output_parameters,
             run_parameters,
-            parity_parameters
+            parity_parameters,
         ) = nhd_io.read_custom_input(custom_input_file)
         run_parameters["debuglevel"] *= -1
 
@@ -652,34 +652,34 @@ def _input_handler():
         run_parameters["subnetwork_target_size "] = args.subnetwork_target_size
         run_parameters["cpu_pool"] = args.cpu_pool
         run_parameters["showtiming"] = args.showtiming
-        
+
         run_parameters["debuglevel"] = debuglevel = -1 * args.debuglevel
         run_parameters["verbose"] = verbose = args.verbose
 
         test_folder = pathlib.Path(root, "test")
         geo_input_folder = test_folder.joinpath("input", "geo")
-        
+
         test_case = args.test_case
-        
+
         if test_case:
-            
+
             # call test case assemble function
             (
-                supernetwork_parameters, 
-                run_parameters, 
-                output_parameters, 
-                restart_parameters, 
+                supernetwork_parameters,
+                run_parameters,
+                output_parameters,
+                restart_parameters,
                 forcing_parameters,
                 parity_parameters,
-            )  = build_tests.build_test_parameters( 
-                                                    test_case, 
-                                                    supernetwork_parameters, 
-                                                    run_parameters, 
-                                                    output_parameters, 
-                                                    restart_parameters, 
-                                                    forcing_parameters,
-                                                    parity_parameters
-                                                    )
+            ) = build_tests.build_test_parameters(
+                test_case,
+                supernetwork_parameters,
+                run_parameters,
+                output_parameters,
+                restart_parameters,
+                forcing_parameters,
+                parity_parameters,
+            )
 
         else:
             run_parameters["dt"] = args.dt
@@ -740,6 +740,7 @@ def _input_handler():
         run_parameters,
         parity_parameters,
     )
+
 
 def main():
 
@@ -865,20 +866,18 @@ def main():
         print("ordered reach computation complete")
     if showtiming:
         print("... in %s seconds." % (time.time() - start_time))
-        
-    
+
     if "parity_check_input_folder" in parity_parameters:
-        
+
         if verbose:
-            print("conducting parity check, comparing t-route results against WRF Hydro results")
-            
+            print(
+                "conducting parity check, comparing t-route results against WRF Hydro results"
+            )
+
         build_tests.parity_check(
-            parity_parameters,
-            run_parameters["nts"],
-            run_parameters["dt"],
-            results,
+            parity_parameters, run_parameters["nts"], run_parameters["dt"], results,
         )
-        
+
 
 if __name__ == "__main__":
     main()

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -199,6 +199,7 @@ def _handle_args():
         help="Name of the column providing the depth of flow at the beginning of the simulation.",
         default="hlink",
     )
+    # TODO: Refine exclusivity of ql args (currently not going to accept more than one arg; more than one is needed for qlw, for instance.)
     ql_arg_group = parser.add_mutually_exclusive_group()
     ql_arg_group.add_argument(
         "--qlc",
@@ -241,14 +242,6 @@ def _handle_args():
         default="q_lateral",
     )
     parser.add_argument("--ql", help="QLat input data", dest="ql", default=None)
-    # TODO: uncomment custominput file
-    # supernetwork_arg_group = parser.add_mutually_exclusive_group()
-    # supernetwork_arg_group.add_argument(
-    #     "-f",
-    #     "--custom-input-file",
-    #     dest="custom_input_file",
-    #     help="OR... please enter the path of a .yaml or .json file containing a custom supernetwork information. See for example test/input/yaml/CustomInput.yaml and test/input/json/CustomInput.json.",
-    # )
     return parser.parse_args()
 
 
@@ -267,7 +260,7 @@ import troute.nhd_network_utilities_v02 as nnu
 import mc_reach
 import troute.nhd_network as nhd_network
 import troute.nhd_io as nhd_io
-import build_tests
+import build_tests  # TODO: Determine whether and how to incorporate this into setup.py
 
 
 def writetoFile(file, writeString):

--- a/src/python_routing_v02/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/fast_reach/mc_reach.pyx
@@ -153,6 +153,7 @@ cpdef object compute_network(
     # const float[:] wbody_idx,
     # object[:] wbody_cols,
     # const float[:, :] wbody_vals,
+    dict upstream_results={},
     bint assume_short_ts=False,
     ):
     """
@@ -168,6 +169,8 @@ cpdef object compute_network(
         assume_short_ts (bool): Assume short time steps (quc = qup)
     Notes:
         Array dimensions are checked as a precondition to this method.
+        data_idx inc. flowveldepth -- sorted numerically
+        Reach_buffer -- sorted topologically
     """
     # Check shapes
     if qlat_values.shape[0] != data_idx.shape[0]:
@@ -181,6 +184,37 @@ cpdef object compute_network(
     # columns: flow (qdc), velocity (velc), and depth (depthc) for each timestep
     # rows: indexed by data_idx
     cdef float[:,::1] flowveldepth = np.zeros((data_idx.shape[0], nsteps * 3), dtype='float32')
+
+    # Pseudocode: LOOP ON Upstream Inflowers
+        # to pre-fill FlowVelDepth
+        # fill_index = list_of_all_segments_sorted -- .i.e, data_idx -- .index(upstream_tw_id)
+        # # FlowVelDepth[fill_index]['flow'] = UpstreamOutflows[upstream_tw_id]['flow']
+        # # FlowVelDepth[fill_index]['depth'] = UpstreamOutflows[upstream_tw_id]['depth']
+
+    # for ts in flowveldepth:
+        # print(f"{list(ts)}")
+
+    cdef set fill_index_mask = set()
+    # fill_index_mask is filled in the explicit loop below, which is
+    # identical to the following comprehension. But we use the explicit loop, because it
+    # is more transparent (and therefore optimizable) to cython.
+    # cdef set fill_index_mask = set([upstream_results[upstream_tw_id]["position_index"] for upstream_tw_id in upstream_results])
+    #print(f"{fill_index_mask}")
+
+    for upstream_tw_id in upstream_results:
+        fill_index = upstream_results[upstream_tw_id]["position_index"]
+        fill_index_mask.add(upstream_results[upstream_tw_id]["position_index"])
+        # print(f"{upstream_results[upstream_tw_id]['results']}")
+        # print(f"filling the {fill_index} row:")
+        # print(f"{list(flowveldepth[fill_index])}")
+        for idx, val in enumerate(upstream_results[upstream_tw_id]["results"]):
+            flowveldepth[fill_index][idx] = val
+        # TODO: Identify a more efficient ways potentially to handle this array filling
+        # The following may be options:
+        # flowveldepth[fill_index] = upstream_results[upstream_tw_id]["results"]
+        # flowveldepth[fill_index, :] = upstream_results[upstream_tw_id]["results"]
+        # print(f"Now filled, it contains:")
+        # print(f"{list(flowveldepth[fill_index])}")
 
     cdef:
         Py_ssize_t[:] srows  # Source rows indexes
@@ -258,6 +292,16 @@ cpdef object compute_network(
     cdef float qup, quc
     cdef int timestep = 0
     cdef int ts_offset
+
+# TODO: Split the compute network function so that the part where we set up
+# all the indices is separate from the call to loop through them.
+# That way, we can refine the functions for preparing the indexes in isolation
+# For example, the actual looping function could start about here in the current
+# function, and might look like the following Psuedocode
+# cpdef(Dataindex):
+    # pull indices and put them in arrays
+    # minimal validation,
+    # Jump straight to nogil.
 
     with nogil:
         while timestep < nsteps:
@@ -348,7 +392,16 @@ cpdef object compute_network(
 
             timestep += 1
 
-    return np.asarray(data_idx, dtype=np.intp), np.asarray(flowveldepth, dtype='float32')
+
+    # delete the duplicate results that shouldn't be passed along
+    # The upstream keys have empty results because they are not part of any reaches
+    # so we need to delete the null values that return
+    if len(fill_index_mask) > 0:
+        data_idx_ma = [ix for i, ix in enumerate(data_idx) if i not in fill_index_mask]
+        flowveldepth_ma = [ix for i, ix in enumerate(flowveldepth) if i not in fill_index_mask]
+        return [np.asarray(data_idx_ma, dtype=np.intp), np.asarray(flowveldepth_ma, dtype='float32')]
+    else:
+        return [np.asarray(data_idx, dtype=np.intp), np.asarray(flowveldepth, dtype='float32')]
 
 #---------------------------------------------------------------------------------------------------------------#
 #---------------------------------------------------------------------------------------------------------------#

--- a/src/python_routing_v02/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/fast_reach/mc_reach.pyx
@@ -399,9 +399,9 @@ cpdef object compute_network(
     if len(fill_index_mask) > 0:
         data_idx_ma = [ix for i, ix in enumerate(data_idx) if i not in fill_index_mask]
         flowveldepth_ma = [ix for i, ix in enumerate(flowveldepth) if i not in fill_index_mask]
-        return [np.asarray(data_idx_ma, dtype=np.intp), np.asarray(flowveldepth_ma, dtype='float32')]
+        return np.asarray(data_idx_ma, dtype=np.intp), np.asarray(flowveldepth_ma, dtype='float32')
     else:
-        return [np.asarray(data_idx, dtype=np.intp), np.asarray(flowveldepth, dtype='float32')]
+        return np.asarray(data_idx, dtype=np.intp), np.asarray(flowveldepth, dtype='float32')
 
 #---------------------------------------------------------------------------------------------------------------#
 #---------------------------------------------------------------------------------------------------------------#

--- a/src/python_routing_v02/setup.py
+++ b/src/python_routing_v02/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 from distutils.extension import Extension
 import sys
 import numpy as np
@@ -19,14 +19,16 @@ ext = 'pyx' if USE_CYTHON else 'c'
 
 reach = Extension("reach",
         sources = ["fast_reach/reach.{}".format(ext)],
-        extra_objects = ['fast_reach/mc_single_seg.o', 'fast_reach/pymc_single_seg.o' ])
+        extra_objects = ['fast_reach/mc_single_seg.o', 'fast_reach/pymc_single_seg.o' ],
+        extra_compile_args=['-g'])
 
 mc_reach = Extension("mc_reach",
           sources = ["fast_reach/mc_reach.{}".format(ext)],
           include_dirs = [np.get_include()],
           libraries=[],
           library_dirs=[],
-          extra_objects=[])
+          extra_objects=[],
+          extra_compile_args=['-g'])
 
 ext_modules=[
     reach, mc_reach
@@ -34,7 +36,7 @@ ext_modules=[
 
 if USE_CYTHON:
     from Cython.Build import cythonize
-    ext_modules = cythonize(ext_modules)
+    ext_modules = cythonize(ext_modules, compiler_directives={'language_level': 3})
 
 setup(
   name = 'compute_network_mc',

--- a/src/python_routing_v02/setup.py
+++ b/src/python_routing_v02/setup.py
@@ -9,36 +9,38 @@ This setup can use if if passed the --use-cython flag, otherwise it looks for th
 and builds using distutils.
 """
 
-if '--use-cython' in sys.argv:
+if "--use-cython" in sys.argv:
     USE_CYTHON = True
-    sys.argv.remove('--use-cython')
+    sys.argv.remove("--use-cython")
 else:
     USE_CYTHON = False
 
-ext = 'pyx' if USE_CYTHON else 'c'
+ext = "pyx" if USE_CYTHON else "c"
 
-reach = Extension("reach",
-        sources = ["fast_reach/reach.{}".format(ext)],
-        extra_objects = ['fast_reach/mc_single_seg.o', 'fast_reach/pymc_single_seg.o' ],
-        extra_compile_args=['-g'])
+reach = Extension(
+    "reach",
+    sources=["fast_reach/reach.{}".format(ext)],
+    extra_objects=["fast_reach/mc_single_seg.o", "fast_reach/pymc_single_seg.o"],
+    extra_compile_args=["-g"],
+)
 
-mc_reach = Extension("mc_reach",
-          sources = ["fast_reach/mc_reach.{}".format(ext)],
-          include_dirs = [np.get_include()],
-          libraries=[],
-          library_dirs=[],
-          extra_objects=[],
-          extra_compile_args=['-g'])
+mc_reach = Extension(
+    "mc_reach",
+    sources=["fast_reach/mc_reach.{}".format(ext)],
+    include_dirs=[np.get_include()],
+    libraries=[],
+    library_dirs=[],
+    extra_objects=[],
+    extra_compile_args=["-g"],
+)
 
-ext_modules=[
-    reach, mc_reach
-    ]
+ext_modules = [reach, mc_reach]
 
 if USE_CYTHON:
     from Cython.Build import cythonize
-    ext_modules = cythonize(ext_modules, compiler_directives={'language_level': 3})
+
+    ext_modules = cythonize(ext_modules, compiler_directives={"language_level": 3})
 
 setup(
-  name = 'compute_network_mc',
-  ext_modules = ext_modules,
+    name="compute_network_mc", ext_modules=ext_modules,
 )

--- a/test/input/json/CustomInput.json
+++ b/test/input/json/CustomInput.json
@@ -86,5 +86,13 @@
         "wrf_hydro_waterbody_ID_crosswalk_file_field_name": "lake_id",
         "wrf_hydro_waterbody_crosswalk_filter_file": "../../test/input/geo/NWM_2.1_Sample_Datasets/Pocono_TEST1/primary_domain/DOMAIN/Route_Link.nc",
         "wrf_hydro_waterbody_crosswalk_filter_file_field_name": "NHDWaterbodyComID"
+    },
+    "parity_parameters":
+    {
+        "parity_check_input_folder": "../../test/input/geo/NWM_2.1_Sample_Datasets/Pocono_TEST1/example_CHRTOUT/",
+        "parity_check_file_pattern_filter": "/*.CHRTOUT_DOMAIN1",
+        "parity_check_file_index_col": "feature_id",
+        "parity_check_file_value_col": "streamflow",
+        "parity_check_compare_node": 4186169
     }
 }

--- a/test/input/yaml/CustomInput.yaml
+++ b/test/input/yaml/CustomInput.yaml
@@ -94,4 +94,10 @@ restart_parameters:
     #WRF-Hydro waterbody crosswalk filter file
     wrf_hydro_waterbody_crosswalk_filter_file: "../../test/input/geo/NWM_2.1_Sample_Datasets/Pocono_TEST1/primary_domain/DOMAIN/Route_Link.nc"
     wrf_hydro_waterbody_crosswalk_filter_file_field_name: NHDWaterbodyComID
+parity_parameters:
+    parity_check_input_folder: "../../test/input/geo/NWM_2.1_Sample_Datasets/Pocono_TEST1/example_CHRTOUT/"
+    parity_check_file_pattern_filter: "/*.CHRTOUT_DOMAIN1"
+    parity_check_file_index_col: feature_id
+    parity_check_file_value_col: streamflow
+    parity_check_compare_node: 4186169
 


### PR DESCRIPTION
__TL; DR:__ Major Update -- basically all features of T-Route V 2.0 except for Reservoirs, Data Assimilation, and Output control. Test features of this PR with the following commands: 
- micro test of all features: `python compute_nhd_routing_SingleSeg_v02.py -f ../../test/input/yaml/CustomInput.yaml`; 
- a bigger dataset with no WRF-Hydro input: `python compute_nhd_routing_SingleSeg_v02.py -n Mainstems_CONUS -tv --nts 288 --parallel by-subnetwork-jit-clustered --subnet-size 150 --debuglevel 1`
- __New Issue/PR:__ Add Falls Lake Florence Event (requires not-yet-available input datasets + input file) 
- __New Issue/PR:__ Add CONUS Benchmark Test (currently only works on Cheyenne; requires input file)
<br>__Important__ This PR Replaces #166 and #175 and is the follow-on for #185
# Summary
This PR includes 
1. __a new function `build_subnetworks`__ that takes the subnet creation function of the 'subnetwork_creation' branch and pushes those subnetworks through a threaded call to the compute_network script. A number of upgrades implemented here reduce the most critical performance bottlenecks so that CONUS Full Resolution simulation is now feasible.  
2. Ability to execute based on an __input .json or .yaml file defining all other input parameters__ or data file locations. As inputs and model controls become more complex, this ability permits more efficient input 
3. Integrated capability for __reading channel warm states from WRF-Hydro restart files__. Code for reservoir warm states is present but should be brought on-line and tested in another PR. 
4. Integrated capability for __comparing the t-route output to the Wrf-Hydro output__ for the same set of input qlaterals and restart files. This builds on capability introduced as part of #185 and is a key tool for demonstrating parity with existing NWM functions.
5. Reorganization of the v02 execution and compile scripts (organization, dev option for package install, blacking, additional cli options...)

This is the next level of the version 2.0 _alpha_ of our framework (see #185 initial alpha). When the reservoir and Data Assimilation capabilities are incorporated with the capabilities in this PR, that should represent the full _beta_. Delivered as such, with any appropriate testing and minor performance or feature upgrades, the framework will be able to replace all relevant functions of the existing channel routing capability within the NWM framework. In addition to reservoir and DA integration, standardization of outputs to match the current NWM, and incorporation of more appropriate logging are two important elements of the final delivery.

# Explanation
## 1) build_subnetworks 

With this PR, four execution modes are availble: `serial` (default), `--parallel by-network`; `--parallel by-subnetwork-jit`; and `--parallel by-subnetwork-jit-clustered`

Tests:
```
python compute_nhd_routing_SingleSeg_v02.py -n Mainstems_CONUS -tv --nts 288 --debuglevel 1
python compute_nhd_routing_SingleSeg_v02.py -n Mainstems_CONUS -tv --nts 288 --parallel --debuglevel 1
python compute_nhd_routing_SingleSeg_v02.py -n Mainstems_CONUS -tv --nts 288 --parallel by-subnetwork-jit --subnet-size 150 --debuglevel 1
python compute_nhd_routing_SingleSeg_v02.py -n Mainstems_CONUS -tv --nts 288 --parallel by-subnetwork-jit-clustered --subnet-size 150 --debuglevel 1
```
On a workstation with 36 cores (which are all used by default under the parallel scheme with no `--cpu-pool` option specified), this runs in 92, 42, 24, and 24 seconds, respectively -- not a full linear scaling, but a clear improvement. These simulations use a constant qlateral at all segments and a warm state of 0.

__New Issue/PR:__ The output shown with the debuglevel is sorted differently for the serial vs. parallel tests above... fix this. <br>

The scaling is sensitive to the subnet-size. Choosing a too-large subnet-size reduces the potential parallelizability of the problem; a too-small subnet-size incurs significant overhead because the GIL must be reacquired, as presently configured, in between each level of subnetwork.

__New Issue/PR:__ Encapsulate the entire build_subnetwork capability into a function -- currently, the output requires further processing before it can be used in the `compute_network` routing engine.<br>

The test has also been executed with the `CONUS_FULL_RES_v20` network. Execution on the full-resolution dataset exposes an important limitation of our subnetwork development process. When the network is extremely dense (as in the case of the full-resolution NHD-based NWM hydrofabric), the subnetwork generation algorithm produces many small subnetworks at the 'leaves' of the traversal (i.e., near the headwaters). If these are simulated individually, they use the parallel pool resources very inefficiently. The workaround presented here is to cluster the small subnetworks together and include them with other subnetworks so that the computational load is more evenly distributed across threads. While there are a number of ways this could be improved, my recommendation is that we look at two in the near term (see below.)
```
# Standard serial execution
  
# Standard by-network parallelization
ipython compute_nhd_routing_SingleSeg_v02.py -- -t -n CONUS_FULL_RES_v20 -v --debuglevel 1 --parallel --nts 100 --cpu-pool 12
_JIT Preprocessing time_ 0 seconds.
_PARALLEL TIME = total time_  seconds

# Just-in-time Subnetwork parallelization _with no_ clustering
ipython compute_nhd_routing_SingleSeg_v02.py -- -t -n CONUS_FULL_RES_v20 -v --debuglevel 1 --parallel by-subnetwork-jit --subnet-size 15000 --nts 100 --cpu-pool 12
_JIT Preprocessing time_  seconds.
_PARALLEL TIME_  seconds.
_Total time_  seconds.

# Just-in-time Subnetwork parallelization _with_ clustering
ipython compute_nhd_routing_SingleSeg_v02.py -- -t -n CONUS_FULL_RES_v20 -v --debuglevel 1 --parallel by-subnetwork-jit-clustered --subnet-size 15000 --nts 100 --cpu-pool 12
_JIT Preprocessing time_  seconds.
_PARALLEL TIME_  seconds.
_Total time_  seconds.
```

### Just-In-Time parallelization
The "Just-in-Time" or _JIT_ idea is explained further in our [AGU poster](https://agu2020fallmeeting-agu.ipostersessions.com/Default.aspx?s=3B-5C-F9-F6-F6-5F-E3-AC-C6-38-7F-8B-14-48-F7-37&pdfprint=true&guestview=true): 

__New Issue/PR:__ Get the AGU content into a Markdown file in this Git repository. (Also consider publishing via ORCID.)

* Calculate first the headwater reaches of edges of the longest network...
* Followed by all reaches below headwaters, etc.
* Orchestrating the computation so each dependency is computed just before it is needed downstream (hence "Just-in-time") provides best theoretical potential speedup.
* Practical efficiencies are obtained by grouping the reaches into cascading orders of subnetworks.

![image](https://user-images.githubusercontent.com/53343824/100478576-3450fe80-30b1-11eb-86ec-fa38973fda79.png)
_Caption: Grouping the reaches into subnetworks balances the practical impact of many parallel calls. An optimal subnetwork size is small enough to permit sufficient parallelism and large enough to ensure that parallel overhead is not burdensome. Colors denote subnetworks of common reverse network order. Higher order subnetworks are computed prior to lower order subnetworks in order to maintain topological dependencies._

### Opportunistic Parallelization
Using a very similar analysis of the network, but ordering instead from the headwaters, we could identify all the subnetworks that could execute simultaneously in a first pass, and so on down to the bottom. While this seems like a nuanced difference from the JIT (which calculates any given subnetwork only just before it is needed by the downstream neighbors; or in other words, the precedents to each subnetwork are guaranteed to be part of the calculation immediately preceding it), the Opportunistic parallelization approach with uniformly sized subnetworks actually guarantees a pretty significant bottleneck towards the end of a very large network (i.e., the Mississippi), when only a single series of reaches or subnetworks remains. Undoubtedly, there are approaches to laying out the subnetworks to minimize the difficulty... 

### Options for improving the subnetwork creation
Per comment above, these are two most likely candidates for improving the subnetwork algorithm: 
1) __New Issue/PR:__ Implement a subnetwork construction scheme that generates even-sized networks (might need heuristics?; expands on above TODO to compact/refactor build_subnetwork); 
2) __New Issue/PR:__ Experiment with and document computational performance impacts of thinning the network.

A number of other possibilities include the following:
- For parallel execution path between the network-based parallelization and the subnetwork-based parallelization, it seems like the the function we need to imitate is `reachable_network`, which produces the `independent_networks` object, as they are called in this branch. `reachable_network` calls the `reachable` function, which I propose could be adapted to accept option inputs to specify split points (__see note below__)
- The return from reachable_network could include additional "remainder" sets specifying the next upstream elements from what was reached in the BFS traversal -- if the traversal continues to the leaves of the network, the "remainder" set would be empty and if the traversal is split somehow, the remainder would be a set of new subnetwork tailwaters to continue tracing upstream.
- The split points could be specified by any of the following (not an exhaustive list of options):
    - reservoir inlets and outlets
    - a maximum number of segments or junctions (the tracing algorithm would have to step backward after passing the threshold)
    - a minimum number of segments or junctions (the tracing algorithm would have to continue one step forward after passing the threshold; __this is what is currently implemented in `build_subnetworks`.__
    - any arbitrary list of junction segments
    - a number of subnetworks to target (would require additional functions to count and divide into one of the more elemental subdivision types.)

_Also_... While not strictly necessary for execution, we are choosing to require that the subdivision must always split at junctions. This greatly simplifies the logic to connect between the cascading subnetworks.

## 2) Yaml/Json input control
Reading a custom input file was introduced incrementally in pull requests #149 #137 #90 and is moved forward an additional level with this PR.

A full (though very small) test of the input capability is available by running the CustomInput file:
```
#Identical output achieved with `python compute_nhd_routing_SingleSeg_v02.py -f ../../test/input/yaml/CustomInput.yaml`
python compute_nhd_routing_SingleSeg_v02.py -f ../../test/input/json/CustomInput.json
creating supernetwork connections set
supernetwork connections set complete
... in 0.09403371810913086 seconds.
organizing connections into reaches ...
reach organization complete
... in 0.0011286735534667969 seconds.
setting channel initial states ...
channel initial states complete
... in 0.027464866638183594 seconds.
creating qlateral array ...
qlateral array complete
... in 0.6489253044128418 seconds.
executing routing computation ...
           (0, q)    (0, v)    (0, d)    (1, q)    (1, v)    (1, d)    (2, q)    (2, v)    (2, d)    (3, q)  ...  (284, d)  (285, q)  (285, v)  (285, d)  (286, q)  (286, v)  (286, d)  (287, q)  (287, v)  (287, d)
4185209  0.012739  0.173687  0.041693  0.012738  0.173681  0.041691  0.012737  0.173677  0.041689  0.012736  ...  0.041409  0.012595  0.172934  0.041409  0.012595  0.172933  0.041409  0.012595  0.172933  0.041409
4185221  0.037830  0.254202  0.062983  0.037826  0.254193  0.062979  0.037823  0.254185  0.062976  0.037820  ...  0.062349  0.037196  0.252580  0.062348  0.037195  0.252577  0.062347  0.037194  0.252575  0.062346
4185223  0.002712  0.013621  0.165343  0.002712  0.013621  0.165340  0.002712  0.013621  0.165337  0.002712  ...  0.164396  0.002686  0.013578  0.164393  0.002686  0.013578  0.164390  0.002686  0.013578  0.164387
4185225  0.005960  0.077459  0.034619  0.005960  0.077458  0.034618  0.005959  0.077458  0.034618  0.005959  ...  0.034494  0.005924  0.077278  0.034494  0.005924  0.077277  0.034493  0.005924  0.077277  0.034493
4185231  0.015957  0.170060  0.029026  0.015957  0.170060  0.029026  0.015957  0.170060  0.029026  0.015957  ...  0.028984  0.015918  0.169898  0.028984  0.015918  0.169897  0.028983  0.015918  0.169896  0.028983
...           ...       ...       ...       ...       ...       ...       ...       ...       ...       ...  ...       ...       ...       ...       ...       ...       ...       ...       ...       ...       ...
4153682  0.023992  0.029227  0.585429  0.023991  0.023443  0.387796  0.023990  0.029227  0.585419  0.023989  ...  0.583662  0.023707  0.023357  0.385194  0.023706  0.029180  0.583649  0.023705  0.023356  0.385174
4153684  0.025567  0.180425  0.063529  0.025566  0.180423  0.063528  0.025565  0.180420  0.063526  0.025565  ...  0.063075  0.025262  0.179609  0.063073  0.025261  0.179605  0.063071  0.025260  0.179603  0.063070
4153688  0.009095  0.138854  0.042681  0.009094  0.138850  0.042679  0.009094  0.138847  0.042678  0.009093  ...  0.042333  0.008972  0.138133  0.042332  0.008972  0.138132  0.042331  0.008971  0.138130  0.042331
4153804  0.000872  0.166968  0.005594  0.000872  0.166956  0.005594  0.000872  0.166951  0.005594  0.000872  ...  0.005555  0.000863  0.166195  0.005555  0.000863  0.166195  0.005555  0.000863  0.166195  0.005555
4153806  0.004806  0.015872  0.212524  0.004805  0.015872  0.212517  0.004805  0.015872  0.212511  0.004805  ...  0.210802  0.004739  0.015802  0.210796  0.004738  0.015802  0.210791  0.004738  0.015802  0.210785

[336 rows x 864 columns]
ordered reach computation complete
... in 1.156254529953003 seconds.
conducting parity check, comparing WRF Hydro results against t-route results
                     flow, wrf (cms)  flow, t-route (cms)
2018-01-01 02:00:00         0.873438             0.873438
2018-01-01 03:00:00         0.873347             0.873347
2018-01-01 04:00:00         0.873250             0.873250
2018-01-01 05:00:00         0.873148             0.873148
2018-01-01 06:00:00         0.873040             0.873040
2018-01-01 07:00:00         0.872928             0.872928
2018-01-01 08:00:00         0.872810             0.872810
2018-01-01 09:00:00         0.872687             0.872687
2018-01-01 10:00:00         0.872559             0.872558
2018-01-01 11:00:00         0.872425             0.872425
2018-01-01 12:00:00         0.872288             0.872288
2018-01-01 13:00:00         0.872145             0.872145
2018-01-01 14:00:00         0.871998             0.871998
2018-01-01 15:00:00         0.871845             0.871845
2018-01-01 16:00:00         0.871689             0.871688
2018-01-01 17:00:00         0.871527             0.871527
2018-01-01 18:00:00         0.871361             0.871361
2018-01-01 19:00:00         0.871191             0.871191
2018-01-01 20:00:00         0.871015             0.871016
2018-01-01 21:00:00         0.870836             0.870837
2018-01-01 22:00:00         0.870653             0.870653
2018-01-01 23:00:00         0.870465             0.870465
2018-01-02 00:00:00         0.870273             0.870273
2018-01-02 01:00:00         0.870077             0.870077
```

__New Issue/PR:__ (maybe) a minor issue introduced by converting this to v02 format is that the custom input file format no longer works with the v01 script. If we wish, we could adjust the v01 scripts to use the named-columns. 

## 3) WRF-Hydro Warm States Read
The ability to ingest a warm state dataframe has been present for a while. This simply uses the already-built v01 function to read warm states and passes them into the proper dataframe in v02. 

__New Issue/PR:__ As visible in the above output from the CustomInput.json simulation, the is *almost* identical (values on 10, 16, 20, an 21 differ by .000001...). It would be good to be absolutely clear on the reason for the deviations since we have proven that correlation can be binary identical if the inputs are identical --- I suspect that there is a difference in the precision of the stored warm states vs. their internal value when used by WRF-Hydro. 

## 4) Test capability
The test capability is triggered by including the following elements in the custom input file (populated with the default test data in the repository): 
```
parity_parameters:
    parity_check_input_folder: "../../test/input/geo/NWM_2.1_Sample_Datasets/Pocono_TEST1/example_CHRTOUT/"
    parity_check_file_pattern_filter: "/*.CHRTOUT_DOMAIN1"
    parity_check_file_index_col: feature_id
    parity_check_file_value_col: streamflow
    parity_check_compare_node: 4186169
```

__New Issue/PR:__ Add identical command-line flags in a command group. 
__New Issue/PR:__ Rebuild the time-step flexible capabilities in the original --test pocono1 

## 5) Miscellaneous
This series of updates includes a number of refinements ultimately leading to being able to execute a CONUS-wide parity test and benchmark run. What we learned in heading that direction is that we have significant work to do to handle I/O more effectively. 

__New Issue/PR:__ Create self-looping capability to allow simulations of arbitrary length; for instance, the 8-year benchmark simulation would take quite a long time to load, if it loaded at all, and would likely far exceed any reasonable memory limit during execution.