### PR TITLE
Masking updates in mc_reach

### DIFF
--- a/src/python_routing_v02/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/fast_reach/mc_reach.pyx
@@ -198,6 +198,8 @@ cpdef object compute_network(
     cdef Py_ssize_t fill_index
     cdef long upstream_tw_id
     cdef dict tmp
+    
+    # cdef set fill_index_mask = set()
     # fill_index_mask is filled in the explicit loop below, which is
     # identical to the following comprehension. But we use the explicit loop, because it
     # is more transparent (and therefore optimizable) to cython.

--- a/src/python_routing_v02/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/fast_reach/mc_reach.pyx
@@ -191,41 +191,15 @@ cpdef object compute_network(
         # # FlowVelDepth[fill_index]['flow'] = UpstreamOutflows[upstream_tw_id]['flow']
         # # FlowVelDepth[fill_index]['depth'] = UpstreamOutflows[upstream_tw_id]['depth']
 
-    # for ts in flowveldepth:
-        # print(f"{list(ts)}")
-
     fill_index_mask = np.ones_like(data_idx, dtype=bool)
     cdef dict tmp
-    
-    # cdef set fill_index_mask = set()
-    # fill_index_mask is filled in the explicit loop below, which is
-    # identical to the following comprehension. But we use the explicit loop, because it
-    # is more transparent (and therefore optimizable) to cython.
-    # cdef set fill_index_mask = set([upstream_results[upstream_tw_id]["position_index"] for upstream_tw_id in upstream_results])
-    #print(f"{fill_index_mask}")
 
     for upstream_tw_id in upstream_results:
         tmp = upstream_results[upstream_tw_id]
         fill_index = tmp["position_index"]
         fill_index_mask[fill_index] = False
-#         flowveldepth[fill_index] = tmp["results"]
         for idx, val in enumerate(tmp["results"]):
             flowveldepth[fill_index][idx] = val
-    
-#     for upstream_tw_id in upstream_results:
-#         fill_index = upstream_results[upstream_tw_id]["position_index"]
-#         fill_index_mask.add(upstream_results[upstream_tw_id]["position_index"])
-#         # print(f"{upstream_results[upstream_tw_id]['results']}")
-#         # print(f"filling the {fill_index} row:")
-#         # print(f"{list(flowveldepth[fill_index])}")
-#         for idx, val in enumerate(upstream_results[upstream_tw_id]["results"]):
-#             flowveldepth[fill_index][idx] = val
-#         # TODO: Identify a more efficient ways potentially to handle this array filling
-#         # The following may be options:
-#         # flowveldepth[fill_index] = upstream_results[upstream_tw_id]["results"]
-#         # flowveldepth[fill_index, :] = upstream_results[upstream_tw_id]["results"]
-#         # print(f"Now filled, it contains:")
-#         # print(f"{list(flowveldepth[fill_index])}")
 
     cdef:
         Py_ssize_t[:] srows  # Source rows indexes
@@ -406,14 +380,6 @@ cpdef object compute_network(
     # delete the duplicate results that shouldn't be passed along
     # The upstream keys have empty results because they are not part of any reaches
     # so we need to delete the null values that return
-    # TO DO: Reconfigure with boolean mask
-#     if len(fill_index_mask) > 0:
-#         data_idx_ma = [ix for i, ix in enumerate(data_idx) if i not in fill_index_mask]
-#         flowveldepth_ma = [ix for i, ix in enumerate(flowveldepth) if i not in fill_index_mask]
-#         return np.asarray(data_idx_ma, dtype=np.intp), np.asarray(flowveldepth_ma, dtype='float32')
-#     else:
-#         return np.asarray(data_idx, dtype=np.intp), np.asarray(flowveldepth, dtype='float32')
-    
     if np.size(fill_index_mask) - np.count_nonzero(fill_index_mask) > 0:        
         return np.asarray(data_idx, dtype=np.intp)[fill_index_mask], np.asarray(flowveldepth, dtype='float32')[fill_index_mask]
     else:

--- a/src/python_routing_v02/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/fast_reach/mc_reach.pyx
@@ -381,11 +381,6 @@ cpdef object compute_network(
     # The upstream keys have empty results because they are not part of any reaches
     # so we need to delete the null values that return
     return np.asarray(data_idx, dtype=np.intp)[fill_index_mask], np.asarray(flowveldepth, dtype='float32')[fill_index_mask]
-    
-#     if np.size(fill_index_mask) - np.count_nonzero(fill_index_mask) > 0:        
-#         return np.asarray(data_idx, dtype=np.intp)[fill_index_mask], np.asarray(flowveldepth, dtype='float32')[fill_index_mask]
-#     else:
-#         return [np.asarray(data_idx, dtype=np.intp), np.asarray(flowveldepth, dtype='float32')]
 
 #---------------------------------------------------------------------------------------------------------------#
 #---------------------------------------------------------------------------------------------------------------#

--- a/src/python_routing_v02/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/fast_reach/mc_reach.pyx
@@ -380,10 +380,12 @@ cpdef object compute_network(
     # delete the duplicate results that shouldn't be passed along
     # The upstream keys have empty results because they are not part of any reaches
     # so we need to delete the null values that return
-    if np.size(fill_index_mask) - np.count_nonzero(fill_index_mask) > 0:        
-        return np.asarray(data_idx, dtype=np.intp)[fill_index_mask], np.asarray(flowveldepth, dtype='float32')[fill_index_mask]
-    else:
-        return [np.asarray(data_idx, dtype=np.intp), np.asarray(flowveldepth, dtype='float32')]
+    return np.asarray(data_idx, dtype=np.intp)[fill_index_mask], np.asarray(flowveldepth, dtype='float32')[fill_index_mask]
+    
+#     if np.size(fill_index_mask) - np.count_nonzero(fill_index_mask) > 0:        
+#         return np.asarray(data_idx, dtype=np.intp)[fill_index_mask], np.asarray(flowveldepth, dtype='float32')[fill_index_mask]
+#     else:
+#         return [np.asarray(data_idx, dtype=np.intp), np.asarray(flowveldepth, dtype='float32')]
 
 #---------------------------------------------------------------------------------------------------------------#
 #---------------------------------------------------------------------------------------------------------------#

--- a/src/python_routing_v02/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/fast_reach/mc_reach.pyx
@@ -194,7 +194,10 @@ cpdef object compute_network(
     # for ts in flowveldepth:
         # print(f"{list(ts)}")
 
-    cdef set fill_index_mask = set()
+    cdef bint[:] fill_index_mask = np.ones_like(data_idx, dtype=bool)
+    cdef Py_ssize_t fill_index
+    cdef long upstream_tw_id
+    cdef dict tmp
     # fill_index_mask is filled in the explicit loop below, which is
     # identical to the following comprehension. But we use the explicit loop, because it
     # is more transparent (and therefore optimizable) to cython.
@@ -202,19 +205,25 @@ cpdef object compute_network(
     #print(f"{fill_index_mask}")
 
     for upstream_tw_id in upstream_results:
-        fill_index = upstream_results[upstream_tw_id]["position_index"]
-        fill_index_mask.add(upstream_results[upstream_tw_id]["position_index"])
-        # print(f"{upstream_results[upstream_tw_id]['results']}")
-        # print(f"filling the {fill_index} row:")
-        # print(f"{list(flowveldepth[fill_index])}")
-        for idx, val in enumerate(upstream_results[upstream_tw_id]["results"]):
-            flowveldepth[fill_index][idx] = val
-        # TODO: Identify a more efficient ways potentially to handle this array filling
-        # The following may be options:
-        # flowveldepth[fill_index] = upstream_results[upstream_tw_id]["results"]
-        # flowveldepth[fill_index, :] = upstream_results[upstream_tw_id]["results"]
-        # print(f"Now filled, it contains:")
-        # print(f"{list(flowveldepth[fill_index])}")
+        tmp = upstream_results[upstream_tw_id]
+        fill_index = tmp["position_index"]
+        fill_index_mask[fill_index] = False
+        flowveldepth[fill_index] = tmp["results"]
+    
+#     for upstream_tw_id in upstream_results:
+#         fill_index = upstream_results[upstream_tw_id]["position_index"]
+#         fill_index_mask.add(upstream_results[upstream_tw_id]["position_index"])
+#         # print(f"{upstream_results[upstream_tw_id]['results']}")
+#         # print(f"filling the {fill_index} row:")
+#         # print(f"{list(flowveldepth[fill_index])}")
+#         for idx, val in enumerate(upstream_results[upstream_tw_id]["results"]):
+#             flowveldepth[fill_index][idx] = val
+#         # TODO: Identify a more efficient ways potentially to handle this array filling
+#         # The following may be options:
+#         # flowveldepth[fill_index] = upstream_results[upstream_tw_id]["results"]
+#         # flowveldepth[fill_index, :] = upstream_results[upstream_tw_id]["results"]
+#         # print(f"Now filled, it contains:")
+#         # print(f"{list(flowveldepth[fill_index])}")
 
     cdef:
         Py_ssize_t[:] srows  # Source rows indexes

--- a/src/python_routing_v02/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/fast_reach/mc_reach.pyx
@@ -396,6 +396,7 @@ cpdef object compute_network(
     # delete the duplicate results that shouldn't be passed along
     # The upstream keys have empty results because they are not part of any reaches
     # so we need to delete the null values that return
+    # TO DO: Reconfigure with boolean mask
     if len(fill_index_mask) > 0:
         data_idx_ma = [ix for i, ix in enumerate(data_idx) if i not in fill_index_mask]
         flowveldepth_ma = [ix for i, ix in enumerate(flowveldepth) if i not in fill_index_mask]

--- a/src/python_routing_v02/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/fast_reach/mc_reach.pyx
@@ -194,9 +194,7 @@ cpdef object compute_network(
     # for ts in flowveldepth:
         # print(f"{list(ts)}")
 
-    cdef bint[:] fill_index_mask = np.ones_like(data_idx, dtype=bool)
-    cdef Py_ssize_t fill_index
-    cdef long upstream_tw_id
+    fill_index_mask = np.ones_like(data_idx, dtype=bool)
     cdef dict tmp
     
     # cdef set fill_index_mask = set()
@@ -415,9 +413,9 @@ cpdef object compute_network(
 #     else:
 #         return np.asarray(data_idx, dtype=np.intp), np.asarray(flowveldepth, dtype='float32')
     
-    if fill_index_mask.count(False) > 1:
-         return np.asarray(data_idx[fill_index_mask], dtype=np.intp), np.asarray(flowveldepth_ma[fill_index_mask], dtype='float32')
-    else
+    if np.size(fill_index_mask) - np.count_nonzero(fill_index_mask) > 0:
+         return np.asarray(data_idx[fill_index_mask], dtype=np.intp), np.asarray(flowveldepth[fill_index_mask], dtype='float32')
+    else:
          return [np.asarray(data_idx, dtype=np.intp), np.asarray(flowveldepth, dtype='float32')]
 
 #---------------------------------------------------------------------------------------------------------------#

--- a/src/python_routing_v02/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/fast_reach/mc_reach.pyx
@@ -406,12 +406,17 @@ cpdef object compute_network(
     # The upstream keys have empty results because they are not part of any reaches
     # so we need to delete the null values that return
     # TO DO: Reconfigure with boolean mask
-    if len(fill_index_mask) > 0:
-        data_idx_ma = [ix for i, ix in enumerate(data_idx) if i not in fill_index_mask]
-        flowveldepth_ma = [ix for i, ix in enumerate(flowveldepth) if i not in fill_index_mask]
-        return np.asarray(data_idx_ma, dtype=np.intp), np.asarray(flowveldepth_ma, dtype='float32')
-    else:
-        return np.asarray(data_idx, dtype=np.intp), np.asarray(flowveldepth, dtype='float32')
+#     if len(fill_index_mask) > 0:
+#         data_idx_ma = [ix for i, ix in enumerate(data_idx) if i not in fill_index_mask]
+#         flowveldepth_ma = [ix for i, ix in enumerate(flowveldepth) if i not in fill_index_mask]
+#         return np.asarray(data_idx_ma, dtype=np.intp), np.asarray(flowveldepth_ma, dtype='float32')
+#     else:
+#         return np.asarray(data_idx, dtype=np.intp), np.asarray(flowveldepth, dtype='float32')
+    
+    if fill_index_mask.count(False) > 1:
+         return np.asarray(data_idx[fill_index_mask], dtype=np.intp), np.asarray(flowveldepth_ma[fill_index_mask], dtype='float32')
+    else
+         return [np.asarray(data_idx, dtype=np.intp), np.asarray(flowveldepth, dtype='float32')]
 
 #---------------------------------------------------------------------------------------------------------------#
 #---------------------------------------------------------------------------------------------------------------#

--- a/src/python_routing_v02/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/fast_reach/mc_reach.pyx
@@ -191,8 +191,12 @@ cpdef object compute_network(
         # # FlowVelDepth[fill_index]['flow'] = UpstreamOutflows[upstream_tw_id]['flow']
         # # FlowVelDepth[fill_index]['depth'] = UpstreamOutflows[upstream_tw_id]['depth']
 
-    fill_index_mask = np.ones_like(data_idx, dtype=bool)
+    cdef np.ndarray fill_index_mask = np.ones_like(data_idx, dtype=bool)
+    cdef Py_ssize_t fill_index
+    cdef long upstream_tw_id
     cdef dict tmp
+    cdef int idx
+    cdef float val
 
     for upstream_tw_id in upstream_results:
         tmp = upstream_results[upstream_tw_id]

--- a/src/python_routing_v02/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/fast_reach/mc_reach.pyx
@@ -208,7 +208,9 @@ cpdef object compute_network(
         tmp = upstream_results[upstream_tw_id]
         fill_index = tmp["position_index"]
         fill_index_mask[fill_index] = False
-        flowveldepth[fill_index] = tmp["results"]
+#         flowveldepth[fill_index] = tmp["results"]
+        for idx, val in enumerate(tmp["results"]):
+            flowveldepth[fill_index][idx] = val
     
 #     for upstream_tw_id in upstream_results:
 #         fill_index = upstream_results[upstream_tw_id]["position_index"]
@@ -401,7 +403,6 @@ cpdef object compute_network(
 
             timestep += 1
 
-
     # delete the duplicate results that shouldn't be passed along
     # The upstream keys have empty results because they are not part of any reaches
     # so we need to delete the null values that return
@@ -413,10 +414,10 @@ cpdef object compute_network(
 #     else:
 #         return np.asarray(data_idx, dtype=np.intp), np.asarray(flowveldepth, dtype='float32')
     
-    if np.size(fill_index_mask) - np.count_nonzero(fill_index_mask) > 0:
-         return np.asarray(data_idx[fill_index_mask], dtype=np.intp), np.asarray(flowveldepth[fill_index_mask], dtype='float32')
+    if np.size(fill_index_mask) - np.count_nonzero(fill_index_mask) > 0:        
+        return np.asarray(data_idx, dtype=np.intp)[fill_index_mask], np.asarray(flowveldepth, dtype='float32')[fill_index_mask]
     else:
-         return [np.asarray(data_idx, dtype=np.intp), np.asarray(flowveldepth, dtype='float32')]
+        return [np.asarray(data_idx, dtype=np.intp), np.asarray(flowveldepth, dtype='float32')]
 
 #---------------------------------------------------------------------------------------------------------------#
 #---------------------------------------------------------------------------------------------------------------#


### PR DESCRIPTION
Minor changes bringing efficiency improvements to the process of masking out upstream dependencies in the flowveldepth array, when running "by-subnetwork-jit-clustered" simulation

1. Simplify pre-filling of flowveldepth with upstream dependencies
```python
    cdef np.ndarray fill_index_mask = np.ones_like(data_idx, dtype=bool)
    cdef Py_ssize_t fill_index
    cdef long upstream_tw_id
    cdef dict tmp
    cdef int idx
    cdef float val

    for upstream_tw_id in upstream_results:
        tmp = upstream_results[upstream_tw_id]
        fill_index = tmp["position_index"]
        fill_index_mask[fill_index] = False
        for idx, val in enumerate(tmp["results"]):
            flowveldepth[fill_index][idx] = val
```
2. Simplify mask application in return statements
```python
return np.asarray(data_idx, dtype=np.intp)[fill_index_mask], np.asarray(flowveldepth, dtype='float32')[fill_index_mask]
```

# TESTING these changes
```bash
cd t-route/src/python_routing_v02
./compile.sh
python compute_nhd_routing_SingleSeg_v02.py --test pocono1 -v --parallel by-subnetwork-jit-clustered
```


addressing #205 