### PR TITLE
Enable Courant metric outputs in v02

### DIFF
--- a/src/fortran_routing/mc_pylink_v00/MC_singleSeg_singleTS/pyMCsingleSegStime_NoLoop.f90
+++ b/src/fortran_routing/mc_pylink_v00/MC_singleSeg_singleTS/pyMCsingleSegStime_NoLoop.f90
@@ -6,17 +6,14 @@ use muskingcunge_module, only: muskingcungenwm
 implicit none
 contains
 subroutine c_muskingcungenwm(dt, qup, quc, qdp, ql, dx, bw, tw, twcc,&
-    n, ncc, cs, s0, velp, depthp, qdc, velc, depthc) bind(c)
+    n, ncc, cs, s0, velp, depthp, qdc, velc, depthc, ck, cn, X) bind(c)
 
     real(c_float), intent(in) :: dt
     real(c_float), intent(in) :: qup, quc, qdp, ql
     real(c_float), intent(in) :: dx, bw, tw, twcc, n, ncc, cs, s0
     real(c_float), intent(in) :: velp, depthp
     real(c_float), intent(out) :: qdc, velc, depthc
-    real(c_float) :: ck, cn, X
-    !TODO: Incorporate ck, cn, X into v02 output;
-    ! these are currently dropped silently from
-    ! the interface output.
+    real(c_float), intent(out) :: ck, cn, X
 
     call muskingcungenwm(dt, qup, quc, qdp, ql, dx, bw, tw, twcc,&
     n, ncc, cs, s0, velp, depthp, qdc, velc, depthc, ck, cn, X)

--- a/src/python_routing_v02/build_tests.py
+++ b/src/python_routing_v02/build_tests.py
@@ -184,7 +184,7 @@ def parity_check(parity_parameters, nts, dt, results):
     # construct a dataframe of simulated flows
     fdv_columns = pd.MultiIndex.from_product([range(nts), ["q", "v", "d"]])
     flowveldepth = pd.concat(
-        [pd.DataFrame(d, index=i, columns=fdv_columns) for i, d in results], copy=False
+        [pd.DataFrame(d, index=i, columns=fdv_columns) for i, d, c in results], copy=False
     )
     flowveldepth = flowveldepth.sort_index()
 

--- a/src/python_routing_v02/build_tests.py
+++ b/src/python_routing_v02/build_tests.py
@@ -66,7 +66,7 @@ def build_test_parameters(
 
         # specify supernetwork parameters
         supernetwork_parameters = {
-            "title_string": "Custom Input Example (using Pocono Test Example datafile)",
+            "title_string": "Pocono1_TEST",
             "geo_file_path": routelink_file,
             "columns": {
                 "key": "link",
@@ -90,7 +90,6 @@ def build_test_parameters(
         }
 
         # specity output parameters
-        output_parameters["csv_output"] = None
         output_parameters["nc_output_folder"] = None
 
         # specify restart parameters
@@ -160,7 +159,7 @@ def build_test_parameters(
     )
 
 
-def parity_check(parity_parameters, nts, dt, results):
+def parity_check(parity_parameters, run_parameters, nts, dt, results):
     validation_files = glob.glob(
         parity_parameters["parity_check_input_folder"]
         + parity_parameters["parity_check_file_pattern_filter"],
@@ -183,9 +182,14 @@ def parity_check(parity_parameters, nts, dt, results):
 
     # construct a dataframe of simulated flows
     fdv_columns = pd.MultiIndex.from_product([range(nts), ["q", "v", "d"]])
-    flowveldepth = pd.concat(
-        [pd.DataFrame(d, index=i, columns=fdv_columns) for i, d, c in results], copy=False
-    )
+    if run_parameters.get("return_courant", False):
+        flowveldepth = pd.concat(
+            [pd.DataFrame(d, index=i, columns=fdv_columns) for i, d, c in results], copy=False
+        )
+    else:
+        flowveldepth = pd.concat(
+            [pd.DataFrame(d, index=i, columns=fdv_columns) for i, d in results], copy=False
+        )
     flowveldepth = flowveldepth.sort_index()
 
     flows = flowveldepth.loc[:, (slice(None), "q")]

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -863,8 +863,10 @@ def main():
 
         if csv_output_folder:
             flowveldepth = flowveldepth.sort_index()
+            courant = courant.sort_index()
             output_path = pathlib.Path(csv_output_folder).resolve()
             flowveldepth.to_csv(output_path.joinpath(f"{args.supernetwork}.csv"))
+            courant.to_csv(output_path.joinpath(f"{args.supernetwork}.csv"))
 
         if debuglevel <= -1:
             print(flowveldepth)

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -27,7 +27,6 @@ from joblib import delayed, Parallel
 from itertools import chain, islice
 from operator import itemgetter
 
-
 def _handle_args():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -844,7 +844,7 @@ def main():
         run_parameters.get("assume_short_ts", False),
     )
 
-    csv_output_folder = output_parameters.get("csv_output_folder", None)
+    csv_output_folder = output_parameters["csv_output"].get("csv_output_folder", None)
     if (debuglevel <= -1) or csv_output_folder:
         qvd_columns = pd.MultiIndex.from_product(
             [range(nts), ["q", "v", "d"]]
@@ -862,12 +862,21 @@ def main():
         )
 
         if csv_output_folder:
-            flowveldepth = flowveldepth.sort_index()
-            courant = courant.sort_index()
+            # create filenames
+            #TO DO: create more descriptive filenames
+            if supernetwork_parameters["title_string"]:
+                filename_fvd = "flowveldepth_" + supernetwork_parameters["title_string"] + ".csv"
+                filename_courant = "courant_" + supernetwork_parameters["title_string"] + ".csv"
+            elif arg.supernetwork:
+                filename_fvd = "flowveldepth_" + arg.supernetwork + ".csv"
+                filename_courant = "courant_" + arg.supernetwork + ".csv"
+            
             output_path = pathlib.Path(csv_output_folder).resolve()
-            flowveldepth.to_csv(output_path.joinpath(f"{args.supernetwork}.csv"))
-            courant.to_csv(output_path.joinpath(f"{args.supernetwork}.csv"))
-
+            flowveldepth = flowveldepth.sort_index()
+            flowveldepth.to_csv(output_path.joinpath(filename_fvd))
+            courant = courant.sort_index()
+            courant.to_csv(output_path.joinpath(filename_courant))
+            
         if debuglevel <= -1:
             print(flowveldepth)
 

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -617,7 +617,7 @@ def compute_nhd_routing_v02(
                     assume_short_ts,
                 )
             )
-
+    
     return results
 
 
@@ -850,7 +850,14 @@ def main():
             [range(nts), ["q", "v", "d"]]
         ).to_flat_index()
         flowveldepth = pd.concat(
-            [pd.DataFrame(d, index=i, columns=qvd_columns) for i, d in results],
+            [pd.DataFrame(d, index=i, columns=qvd_columns) for i, d, c in results],
+            copy=False,
+        )
+        courant_columns = pd.MultiIndex.from_product(
+            [range(nts), ["cn", "ck", "X"]]
+        ).to_flat_index()
+        courant = pd.concat(
+            [pd.DataFrame(c, index=i, columns=courant_columns) for i, d, c in results],
             copy=False,
         )
 

--- a/src/python_routing_v02/fast_reach/fortran_wrappers.pxd
+++ b/src/python_routing_v02/fast_reach/fortran_wrappers.pxd
@@ -34,5 +34,8 @@ cdef extern from "pyMCsingleSegStime_NoLoop.h":
                                   float *depthp,
                                   float *qdc,
                                   float *velc,
+                                  float *ck,
+                                  float *cn,
+                                  float *X,
                                   float *depthc) nogil;
 

--- a/src/python_routing_v02/fast_reach/fortran_wrappers.pxd
+++ b/src/python_routing_v02/fast_reach/fortran_wrappers.pxd
@@ -34,8 +34,8 @@ cdef extern from "pyMCsingleSegStime_NoLoop.h":
                                   float *depthp,
                                   float *qdc,
                                   float *velc,
+                                  float *depthc,
                                   float *ck,
                                   float *cn,
-                                  float *X,
-                                  float *depthc) nogil;
+                                  float *X) nogil;
 

--- a/src/python_routing_v02/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/fast_reach/mc_reach.pyx
@@ -193,6 +193,7 @@ cpdef object compute_network(
     
     # courant is a 2D float array that holds courant results
     # columns: courant number (cn), kinematic celerity (ck), x parameter(X) for each timestep
+    # rows: indexed by data_idx
     cdef float[:,::1] courant = np.zeros((data_idx.shape[0], nsteps * 3), dtype='float32')
 
     # Pseudocode: LOOP ON Upstream Inflowers
@@ -284,7 +285,7 @@ cpdef object compute_network(
 
     cdef int maxreachlen = max(reach_sizes)
     buf = np.empty((maxreachlen, buf_cols), dtype='float32')
-    out_buf = np.empty((maxreachlen, 3), dtype='float32')
+    out_buf = np.empty((maxreachlen, 6), dtype='float32')
 
     drows_tmp = np.arange(maxreachlen, dtype=np.intp)
     cdef Py_ssize_t[:] drows

--- a/src/python_routing_v02/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/fast_reach/mc_reach.pyx
@@ -56,7 +56,7 @@ cpdef object binary_find(object arr, object els):
 
 
 @cython.boundscheck(False)
-cdef void compute_reach_kernel(float qup, float quc, int nreach, const float[:,:] input_buf, float[:, :] output_buf, bint assume_short_ts) nogil:
+cdef void compute_reach_kernel(float qup, float quc, int nreach, const float[:,:] input_buf, float[:, :] output_buf, bint assume_short_ts, bint return_courant=False) nogil:
     """
     Kernel to compute reach.
     Input buffer is array matching following description:
@@ -113,9 +113,11 @@ cdef void compute_reach_kernel(float qup, float quc, int nreach, const float[:,:
         output_buf[i, 0] = out.qdc
         output_buf[i, 1] = out.velc
         output_buf[i, 2] = out.depthc
-        output_buf[i, 3] = out.cn
-        output_buf[i, 4] = out.ck
-        output_buf[i, 5] = out.X
+        
+        if return_courant:
+            output_buf[i, 3] = out.cn
+            output_buf[i, 4] = out.ck
+            output_buf[i, 5] = out.X
 
         qup = qdp
 
@@ -164,6 +166,7 @@ cpdef object compute_network(
     # const float[:, :] wbody_vals,
     dict upstream_results={},
     bint assume_short_ts=False,
+    bint return_courant=False,
     ):
     """
     Compute network
@@ -288,7 +291,11 @@ cpdef object compute_network(
 
     cdef int maxreachlen = max(reach_sizes)
     buf = np.empty((maxreachlen, buf_cols), dtype='float32')
-    out_buf = np.empty((maxreachlen, 6), dtype='float32')
+    
+    if return_courant:
+        out_buf = np.empty((maxreachlen, 6), dtype='float32')
+    else:
+        out_buf = np.empty((maxreachlen, 3), dtype='float32') 
 
     drows_tmp = np.arange(maxreachlen, dtype=np.intp)
     cdef Py_ssize_t[:] drows
@@ -383,15 +390,16 @@ cpdef object compute_network(
                 if assume_short_ts:
                     quc = qup
 
-                compute_reach_kernel(qup, quc, reachlen, buf_view, out_view, assume_short_ts)
+                compute_reach_kernel(qup, quc, reachlen, buf_view, out_view, assume_short_ts, return_courant)
 
                 # copy out_buf results back to flowdepthvel
                 for i in range(3):
                     fill_buffer_column(drows, i, srows, ts_offset + i, out_view, flowveldepth)
                     
-                # copy out_buf results back to flowdepthvel
-                for i in range(3,6):
-                    fill_buffer_column(drows, i, srows, ts_offset + (i-3), out_view, courant)
+                # copy out_buf results back to courant
+                if return_courant:
+                    for i in range(3,6):
+                        fill_buffer_column(drows, i, srows, ts_offset + (i-3), out_view, courant)
 
                 # Update indexes to point to next reach
                 ireach_cache += reachlen
@@ -402,7 +410,10 @@ cpdef object compute_network(
     # delete the duplicate results that shouldn't be passed along
     # The upstream keys have empty results because they are not part of any reaches
     # so we need to delete the null values that return
-    return np.asarray(data_idx, dtype=np.intp)[fill_index_mask], np.asarray(flowveldepth, dtype='float32')[fill_index_mask], np.asarray(courant, dtype='float32')[fill_index_mask]
+    if return_courant:
+        return np.asarray(data_idx, dtype=np.intp)[fill_index_mask], np.asarray(flowveldepth, dtype='float32')[fill_index_mask], np.asarray(courant, dtype='float32')[fill_index_mask]
+    else:
+        return np.asarray(data_idx, dtype=np.intp)[fill_index_mask], np.asarray(flowveldepth, dtype='float32')[fill_index_mask]
 
 #---------------------------------------------------------------------------------------------------------------#
 #---------------------------------------------------------------------------------------------------------------#

--- a/src/python_routing_v02/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/fast_reach/mc_reach.pyx
@@ -113,6 +113,9 @@ cdef void compute_reach_kernel(float qup, float quc, int nreach, const float[:,:
         output_buf[i, 0] = out.qdc
         output_buf[i, 1] = out.velc
         output_buf[i, 2] = out.depthc
+        output_buf[i, 3] = out.cn
+        output_buf[i, 4] = out.ck
+        output_buf[i, 5] = out.X
 
         qup = qdp
 

--- a/src/python_routing_v02/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/fast_reach/mc_reach.pyx
@@ -391,7 +391,7 @@ cpdef object compute_network(
                     
                 # copy out_buf results back to flowdepthvel
                 for i in range(3,6):
-                    fill_buffer_column(drows, i, srows, ts_offset + i, out_view, flowveldepth)
+                    fill_buffer_column(drows, i, srows, ts_offset + (i-3), out_view, courant)
 
                 # Update indexes to point to next reach
                 ireach_cache += reachlen
@@ -402,7 +402,7 @@ cpdef object compute_network(
     # delete the duplicate results that shouldn't be passed along
     # The upstream keys have empty results because they are not part of any reaches
     # so we need to delete the null values that return
-    return np.asarray(data_idx, dtype=np.intp)[fill_index_mask], np.asarray(flowveldepth, dtype='float32')[fill_index_mask]
+    return np.asarray(data_idx, dtype=np.intp)[fill_index_mask], np.asarray(flowveldepth, dtype='float32')[fill_index_mask], np.asarray(courant, dtype='float32')[fill_index_mask]
 
 #---------------------------------------------------------------------------------------------------------------#
 #---------------------------------------------------------------------------------------------------------------#

--- a/src/python_routing_v02/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/fast_reach/mc_reach.pyx
@@ -108,7 +108,7 @@ cdef void compute_reach_kernel(float qup, float quc, int nreach, const float[:,:
                     velp,
                     depthp,
                     out)
-
+        
 #        output_buf[i, 0] = quc = out.qdc # this will ignore short TS assumption at seg-to-set scale?
         output_buf[i, 0] = out.qdc
         output_buf[i, 1] = out.velc
@@ -190,6 +190,10 @@ cpdef object compute_network(
     # columns: flow (qdc), velocity (velc), and depth (depthc) for each timestep
     # rows: indexed by data_idx
     cdef float[:,::1] flowveldepth = np.zeros((data_idx.shape[0], nsteps * 3), dtype='float32')
+    
+    # courant is a 2D float array that holds courant results
+    # columns: courant number (cn), kinematic celerity (ck), x parameter(X) for each timestep
+    cdef float[:,::1] courant = np.zeros((data_idx.shape[0], nsteps * 3), dtype='float32')
 
     # Pseudocode: LOOP ON Upstream Inflowers
         # to pre-fill FlowVelDepth

--- a/src/python_routing_v02/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/fast_reach/mc_reach.pyx
@@ -388,6 +388,10 @@ cpdef object compute_network(
                 # copy out_buf results back to flowdepthvel
                 for i in range(3):
                     fill_buffer_column(drows, i, srows, ts_offset + i, out_view, flowveldepth)
+                    
+                # copy out_buf results back to flowdepthvel
+                for i in range(3,6):
+                    fill_buffer_column(drows, i, srows, ts_offset + i, out_view, flowveldepth)
 
                 # Update indexes to point to next reach
                 ireach_cache += reachlen

--- a/src/python_routing_v02/fast_reach/pyMCsingleSegStime_NoLoop.h
+++ b/src/python_routing_v02/fast_reach/pyMCsingleSegStime_NoLoop.h
@@ -15,4 +15,7 @@ extern void c_muskingcungenwm(float *dt,
                               float *depthp,
                               float *qdc,
                               float *velc,
-                              float *depthc);
+                              float *depthc,
+                              float *ck,
+                              float *cn,
+                              float *X);

--- a/src/python_routing_v02/fast_reach/reach.pxd
+++ b/src/python_routing_v02/fast_reach/reach.pxd
@@ -2,6 +2,9 @@ cdef struct QVD:
     float qdc
     float velc
     float depthc
+    float cn
+    float ck
+    float X
 
 
 cdef void muskingcunge(float dt,

--- a/src/python_routing_v02/fast_reach/reach.pyx
+++ b/src/python_routing_v02/fast_reach/reach.pyx
@@ -18,10 +18,10 @@ cdef void muskingcunge(float dt,
         float s0,
         float velp,
         float depthp,
+        QVD *rv,
         float ck,
         float cn,
-        float X,
-        QVD *rv) nogil:
+        float X) nogil:
     cdef:
         float qdc = 0.0
         float depthc = 0.0

--- a/src/python_routing_v02/fast_reach/reach.pyx
+++ b/src/python_routing_v02/fast_reach/reach.pyx
@@ -50,9 +50,15 @@ cdef void muskingcunge(float dt,
         &ck,
         &cn,
         &X)
+    
     rv.qdc = qdc
     rv.depthc = depthc
     rv.velc = velc
+    
+    # to do: make these additional variable's conditional, somehow
+    rv.ck = ck
+    rv.cn = cn
+    rv.X = X
 
 cpdef dict compute_reach_kernel(float dt,
         float qup,

--- a/src/python_routing_v02/fast_reach/reach.pyx
+++ b/src/python_routing_v02/fast_reach/reach.pyx
@@ -18,6 +18,9 @@ cdef void muskingcunge(float dt,
         float s0,
         float velp,
         float depthp,
+        float ck,
+        float cn,
+        float X,
         QVD *rv) nogil:
     cdef:
         float qdc = 0.0

--- a/src/python_routing_v02/fast_reach/reach.pyx
+++ b/src/python_routing_v02/fast_reach/reach.pyx
@@ -42,7 +42,10 @@ cdef void muskingcunge(float dt,
         &depthp,
         &qdc,
         &velc,
-        &depthc)
+        &depthc,
+        &ck,
+        &cn,
+        &X)
     rv.qdc = qdc
     rv.depthc = depthc
     rv.velc = velc

--- a/src/python_routing_v02/fast_reach/reach.pyx
+++ b/src/python_routing_v02/fast_reach/reach.pyx
@@ -18,14 +18,15 @@ cdef void muskingcunge(float dt,
         float s0,
         float velp,
         float depthp,
-        QVD *rv,
-        float ck,
-        float cn,
-        float X) nogil:
+        QVD *rv) nogil:
+    
     cdef:
         float qdc = 0.0
         float depthc = 0.0
         float velc = 0.0
+        float ck = 0.0
+        float cn = 0.0
+        float X = 0.0
 
     c_muskingcungenwm(
         &dt,

--- a/test/input/yaml/CustomInput.yaml
+++ b/test/input/yaml/CustomInput.yaml
@@ -10,6 +10,7 @@ run_parameters:
     qts_subdivisions: 12
     dt: 300
     nts: 288
+    return_courant: true
     #Use the parallel computation engine (omit flag for serial computation)
     #Verbose output (leave blank for quiet output)
     #Set the showtiming (omit flag for no timing information)

--- a/test/input/yaml/CustomInput.yaml
+++ b/test/input/yaml/CustomInput.yaml
@@ -30,7 +30,7 @@ output_parameters:
     nc_output_folder: "../../test/output/text"
 #data column assignment inside supernetwork_parameters
 supernetwork_parameters:
-    title_string: Custom Input Example (using Pocono Test Example datafile)
+    title_string: "Pocono1"
     geo_file_path: "../../test/input/geo/NWM_2.1_Sample_Datasets/Pocono_TEST1/primary_domain/DOMAIN/Route_Link.nc"
     mask_file_path: "../../test/input/geo/Channels/masks/Pocono_mask.csv"
     mask_layer_string: ""


### PR DESCRIPTION
**This pull request makes Courant metrics available for output in the v02 framework**. While the Fortran Muskingum-Cunge routing subroutine `muskingcungenwm` in `MCsingleSegStime_f2py_NOLOOP.f90` calculates and outputs Courant metrics (`cn`, `ck`, and `X`), these variables are silently dropped in the subroutine `c_muskingcungenwm` in `pyMCsingleSegStime_NoLoop.f90`. 

linked issue #225 