### PR TITLE
removed space that breaks arg call

### DIFF
--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -649,7 +649,7 @@ def _input_handler():
     else:
         run_parameters["assume_short_ts"] = args.assume_short_ts
         run_parameters["parallel_compute_method"] = args.parallel_compute_method
-        run_parameters["subnetwork_target_size "] = args.subnetwork_target_size
+        run_parameters["subnetwork_target_size"] = args.subnetwork_target_size
         run_parameters["cpu_pool"] = args.cpu_pool
         run_parameters["showtiming"] = args.showtiming
 


### PR DESCRIPTION
run_parameters["subnetwork_target_size "] = args.subnetwork_target_size  to run_parameters["subnetwork_target_size"] = args.subnetwork_target_size 