### PR TITLE
Move Path manipulation to pathlib

### DIFF
--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -13,7 +13,7 @@ def read_netcdf(geo_file_path):
 
 
 def read_csv(geo_file_path, header="infer", layer_string=None):
-    if geo_file_path.endswith(".zip"):
+    if geo_file_path.suffix == ".zip":
         if layer_string is None:
             raise ValueError("layer_string is needed if reading from compressed csv")
         with zipfile.ZipFile(geo_file_path, "r") as zcsv:
@@ -28,7 +28,7 @@ def read_geopandas(geo_file_path, layer_string=None, driver_string=None):
 
 
 def read(geo_file_path, layer_string=None, driver_string=None):
-    if geo_file_path.endswith(".nc"):
+    if geo_file_path.suffix == ".nc":
         return read_netcdf(geo_file_path)
     else:
         return read_geopandas(

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -137,9 +137,7 @@ def read_qlat(path):
     return get_ql_from_csv(path)
 
 
-def get_ql_from_wrf_hydro_mf(
-    qlat_files, index_col="feature_id", value_col="q_lateral"
-):
+def get_ql_from_wrf_hydro_mf(qlat_files, index_col="feature_id", value_col="q_lateral"):
     """
     qlat_files: globbed list of CHRTOUT files containing desired lateral inflows
     index_col: column/field in the CHRTOUT files with the segment/link id

--- a/src/python_framework_v02/troute/nhd_network_augment.py
+++ b/src/python_framework_v02/troute/nhd_network_augment.py
@@ -12,8 +12,9 @@ import json
 from tqdm import tqdm
 import time
 
+
 root = pathlib.Path("../../../").resolve()
-sys.path.append(os.path.join(root, "src", "python_framework_v01"))
+sys.path.append(str(pathlib.Path(root, "src", "python_framework_v01").resolve()))
 
 import nhd_network_utilities_v02 as nnu
 import nhd_network
@@ -82,8 +83,8 @@ def _handle_args():
 def get_network_data(network_name):
 
     # Create directory path variable for test/input/geo, where NHD data and masks are stored
-    test_folder = os.path.join(root, r"test")
-    geo_input_folder = os.path.join(test_folder, r"input", r"geo")
+    test_folder = pathlib.Path(root, r"test").resolve()
+    geo_input_folder = pathlib.Path(test_folder, r"input", r"geo").resolve()
 
     # Load network meta data for the Cape Fear Basin
     supernetwork = network_name
@@ -92,8 +93,8 @@ def get_network_data(network_name):
     )
 
     # if the NHDPlus RouteLink file does not exist, download it.
-    if not os.path.exists(network_data["geo_file_path"]):
-        filename = os.path.basename(network_data["geo_file_path"])
+    if not network_data["geo_file_path"].is_file:
+        filename = network_data["geo_file_path"].name
         network_dl.download(network_data["geo_file_path"], network_data["data_link"])
 
     # read-in NHD data, retain copies for viz- and full network analysis purposes
@@ -848,25 +849,25 @@ def main():
         "exporting RouteLink file:",
         filename,
         "to",
-        os.path.join(root, "test", "input", "geo", "Channels"),
+        pathlib.Path(root, "test", "input", "geo", "Channels").resolve(),
     )
 
-    dir_path = os.path.join(root, "test", "input", "geo", "Channels", dirname)
-    if not os.path.isdir(dir_path):
-        os.mkdir(dir_path)
+    dir_path = pathlib.Path(root, "test", "input", "geo", "Channels", dirname).resolve()
+    if not pathlib.Path.is_dir(dir_path):
+        pathlib.Path.mkdir(dir_path)
 
     # save RouteLink data as shapefile
     RouteLink_edit = RouteLink_edit.drop(columns=["time", "gages"])
-    RouteLink_edit.to_file(os.path.join(dir_path, filename))
+    RouteLink_edit.to_file(pathlib.Path(dir_path, filename).resolve())
 
     # save cross walk as json
     print(
         "exporting CrossWalk file:",
         filename_cw,
         "to",
-        os.path.join(root, "test", "input", "geo", "Channels"),
+        pathlib.Path(root, "test", "input", "geo", "Channels").resolve(),
     )
-    with open(os.path.join(dir_path, filename_cw), "w") as outfile:
+    with open(pathlib.Path(dir_path, filename_cw).resolve(), "w") as outfile:
         json.dump(qlat_destinations, outfile)
 
     # export original data
@@ -877,12 +878,14 @@ def main():
             "exporting unmodified RouteLink file:",
             filename,
             "to",
-            os.path.join(root, "test", "input", "geo", "Channels"),
+            pathlib.Path(root, "test", "input", "geo", "Channels").resolve(),
         )
 
-        dir_path = os.path.join(root, "test", "input", "geo", "Channels", dirname)
-        if not os.path.isdir(dir_path):
-            os.mkdir(dir_path)
+        dir_path = pathlib.Path(
+            root, "test", "input", "geo", "Channels", dirname
+        ).resolve()
+        if not pathlib.Path.is_dir(dir_path):
+            pathlib.Path.mkdir(dir_path)
 
         RouteLink_domain = RouteLink.loc[data.index.values]
         RouteLink_domain = gpd.GeoDataFrame(
@@ -891,10 +894,10 @@ def main():
         )
 
         RouteLink_domain = RouteLink_domain.drop(columns=["time", "gages"])
-        RouteLink_domain.to_file(os.path.join(dir_path, filename))
+        RouteLink_domain.to_file(pathlib.Path(dir_path, filename).resolve())
 
+        print("Number of segments in original RouteLink:", len(RouteLink_domain))
     print("Number of segments in modified RouteLink:", len(RouteLink_edit))
-    print("Number of segments in original RouteLink:", len(RouteLink_domain))
 
 
 if __name__ == "__main__":

--- a/src/python_framework_v02/troute/nhd_network_augment.py
+++ b/src/python_framework_v02/troute/nhd_network_augment.py
@@ -4,7 +4,6 @@ import geopandas as gpd
 import xarray as xr
 from functools import partial
 from itertools import chain
-import os
 import sys
 import pathlib
 import argparse

--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -44,9 +44,9 @@ def set_supernetwork_parameters(
 
     elif supernetwork == "Pocono_TEST1":
         return {
-            "geo_file_path": os.path.join(
+            "geo_file_path": pathlib.Path(
                 geo_input_folder, "PoconoSampleData1", "PoconoSampleRouteLink1.shp"
-            ),
+            ).resolve(),
             "columns": {
                 "key": "link",
                 "downstream": "to",
@@ -68,9 +68,9 @@ def set_supernetwork_parameters(
             "terminal_code": 0,
             "layer_string": 0,
             "waterbody_parameter_file_type": "Level_Pool",
-            "waterbody_parameter_file_path": os.path.join(
+            "waterbody_parameter_file_path": pathlib.Path(
                 geo_input_folder, "NWM_2.1_Sample_Datasets", "LAKEPARM_CONUS.nc"
-            ),
+            ).resolve(),
             "waterbody_parameter_columns": {
                 "waterbody_area": "LkArea",  # area of reservoir
                 "weir_elevation": "WeirE",
@@ -90,12 +90,12 @@ def set_supernetwork_parameters(
         rv.update(
             {
                 "title_string": "Pocono Test 2 Example",  # overwrites other title...
-                "mask_file_path": os.path.join(
+                "mask_file_path": pathlib.Path(
                     geo_input_folder,
                     "Channels",
                     "masks",
                     "PoconoRouteLink_TEST2_nwm_mc.txt",
-                ),
+                ).resolve(),
                 "mask_driver_string": "csv",
                 "mask_layer_string": "",
                 "mask_key": 0,
@@ -133,12 +133,12 @@ def set_supernetwork_parameters(
         rv.update(
             {
                 "title_string": "NHD 2.0 Conchos Basin of the LowerColorado River",  # overwrites other title...
-                "mask_file_path": os.path.join(
+                "mask_file_path": pathlib.Path(
                     geo_input_folder,
                     "Channels",
                     "masks",
                     "LowerColorado_Conchos_FULL_RES.txt",
-                ),
+                ).resolve(),
                 "mask_driver_string": "csv",
                 "mask_layer_string": "",
                 "mask_key": 0,
@@ -149,9 +149,9 @@ def set_supernetwork_parameters(
 
     elif supernetwork == "Brazos_LowerColorado_ge5":
         return {
-            "geo_file_path": os.path.join(
+            "geo_file_path": pathlib.Path(
                 geo_input_folder, "Channels", "NHD_BrazosLowerColorado_Channels.shp"
-            ),
+            ).resolve(),
             "columns": {
                 "key": "featureID",
                 "downstream": "to",
@@ -178,12 +178,12 @@ def set_supernetwork_parameters(
         rv.update(
             {
                 "title_string": "NHD 2.0 Brazos and LowerColorado Basins",  # overwrites other title...
-                "mask_file_path": os.path.join(
+                "mask_file_path": pathlib.Path(
                     geo_input_folder,
                     "Channels",
                     "masks",
                     "Brazos_LowerColorado_FULL_RES.txt",
-                ),
+                ).resolve(),
                 "mask_driver_string": r"csv",
                 "mask_layer_string": r"",
                 "mask_key": 0,
@@ -199,12 +199,12 @@ def set_supernetwork_parameters(
         rv.update(
             {
                 "title_string": "NHD 2.0 GNIS labeled streams in the Brazos and LowerColorado Basins",  # overwrites other title...
-                "mask_file_path": os.path.join(
+                "mask_file_path": pathlib.Path(
                     geo_input_folder,
                     "Channels",
                     "masks",
                     "Brazos_LowerColorado_Named_Streams.csv",
-                ),
+                ).resolve(),
                 "mask_driver_string": r"csv",
                 "mask_layer_string": r"",
                 "mask_key": 0,
@@ -220,9 +220,9 @@ def set_supernetwork_parameters(
         rv.update(
             {
                 "title_string": "NHD CONUS Order 5 and Greater",  # overwrites other title...
-                "mask_file_path": os.path.join(
+                "mask_file_path": pathlib.Path(
                     geo_input_folder, "Channels", "masks", "CONUS_ge5.txt"
-                ),
+                ).resolve(),
                 "mask_driver_string": "csv",
                 "mask_layer_string": "",
                 "mask_key": 0,
@@ -238,9 +238,9 @@ def set_supernetwork_parameters(
         rv.update(
             {
                 "title_string": "CONUS 'Mainstems' (Channels below gages and AHPS prediction points)",  # overwrites other title...
-                "mask_file_path": os.path.join(
+                "mask_file_path": pathlib.Path(
                     geo_input_folder, r"Channels", r"masks", r"conus_Mainstem_links.txt"
-                ),
+                ).resolve(),
                 "mask_driver_string": r"csv",
                 "mask_layer_string": r"",
                 "mask_key": 0,
@@ -250,9 +250,9 @@ def set_supernetwork_parameters(
         return rv
 
         # return {
-        #     "geo_file_path": os.path.join(
+        #     "geo_file_path": pathlib.Path(
         #         geo_input_folder, r"Channels", r"conus_routeLink_subset.nc"
-        #     ),
+        #     ).resolve(),
         #     "key_col": 0,
         #     "downstream_col": 2,
         #     "length_col": 10,
@@ -280,12 +280,12 @@ def set_supernetwork_parameters(
         rv.update(
             {
                 "title_string": "CONUS NWM v2.0 only GNIS labeled streams",  # overwrites other title...
-                "mask_file_path": os.path.join(
+                "mask_file_path": pathlib.Path(
                     geo_input_folder,
                     "Channels",
                     "masks",
                     "nwm_reaches_conus_v21_wgnis_name.csv",
-                ),
+                ).resolve(),
                 "mask_driver_string": "csv",
                 "mask_layer_string": "",
                 "mask_key": 0,
@@ -301,9 +301,9 @@ def set_supernetwork_parameters(
         rv.update(
             {
                 "title_string": "Cape Fear River Basin, NC",  # overwrites other title...
-                "mask_file_path": os.path.join(
+                "mask_file_path": pathlib.Path(
                     geo_input_folder, "Channels", "masks", "CapeFear_FULL_RES.txt",
-                ),
+                ).resolve(),
                 "mask_driver_string": "csv",
                 "mask_layer_string": "",
                 "mask_key": 0,
@@ -319,9 +319,9 @@ def set_supernetwork_parameters(
         rv.update(
             {
                 "title_string": "Hurricane Florence Domain, near Durham NC",  # overwrites other title...
-                "mask_file_path": os.path.join(
+                "mask_file_path": pathlib.Path(
                     geo_input_folder, "Channels", "masks", "Florence_FULL_RES.txt",
-                ),
+                ).resolve(),
                 "mask_driver_string": "csv",
                 "mask_layer_string": "",
                 "mask_key": 0,
@@ -338,9 +338,9 @@ def set_supernetwork_parameters(
         sep = "."
 
         return {
-            "geo_file_path": os.path.join(
+            "geo_file_path": pathlib.Path(
                 geo_input_folder, "Channels", sep.join([ROUTELINK, ModelVer, ext])
-            ),
+            ).resolve(),
             "data_link": f"https://www.nco.ncep.noaa.gov/pmb/codes/nwprod/{ModelVer}/parm/domain/{ROUTELINK}{sep}{ext}",
             "columns": {
                 "key": "link",
@@ -358,9 +358,9 @@ def set_supernetwork_parameters(
                 "cs": "ChSlp",
             },
             "waterbody_parameter_file_type": "Level_Pool",
-            "waterbody_parameter_file_path": os.path.join(
+            "waterbody_parameter_file_path": pathlib.Path(
                 geo_input_folder, "NWM_2.1_Sample_Datasets", "LAKEPARM_CONUS.nc"
-            ),
+            ).resolve(),
             "waterbody_parameter_columns": {
                 "waterbody_area": "LkArea",
                 "weir_elevation": "WeirE",
@@ -380,7 +380,7 @@ def set_supernetwork_parameters(
         }
 
     elif supernetwork == "custom":
-        custominput = os.path.join(geo_input_folder)
+        custominput = pathlib.Path(geo_input_folder).resolve()
         with open(custominput, "r") as json_file:
             return json.load(json_file)
             # TODO: add error trapping for potentially missing files

--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -1,11 +1,9 @@
 import json
-import os
-
-import glob
 import pandas as pd
 from functools import partial
 import troute.nhd_io as nhd_io
 import troute.nhd_network as nhd_network
+import pathlib
 
 
 def set_supernetwork_parameters(
@@ -490,7 +488,8 @@ def build_qlateral_array(forcing_parameters, connections_keys, nts, qts_subdivis
             "qlat_file_index_col", "feature_id"
         )
         qlat_file_value_col = forcing_parameters.get("qlat_file_value_col", "q_lateral")
-        qlat_files = glob.glob(qlat_input_folder + qlat_file_pattern_filter)
+        
+        qlat_files = qlat_input_folder.glob(qlat_file_pattern_filter)
         qlat_df = nhd_io.get_ql_from_wrf_hydro_mf(
             qlat_files=qlat_files,
             index_col=qlat_file_index_col,

--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -488,7 +488,7 @@ def build_qlateral_array(forcing_parameters, connections_keys, nts, qts_subdivis
             "qlat_file_index_col", "feature_id"
         )
         qlat_file_value_col = forcing_parameters.get("qlat_file_value_col", "q_lateral")
-        
+
         qlat_files = qlat_input_folder.glob(qlat_file_pattern_filter)
         qlat_df = nhd_io.get_ql_from_wrf_hydro_mf(
             qlat_files=qlat_files,

--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -396,14 +396,14 @@ def build_connections(supernetwork_parameters, dt):
     # TODO: Remove the dependence on dt in this function
 
     cols = supernetwork_parameters["columns"]
-    param_df = nhd_io.read(supernetwork_parameters["geo_file_path"])
+    param_df = nhd_io.read(pathlib.Path(supernetwork_parameters["geo_file_path"]))
 
     param_df = param_df[list(cols.values())]
     param_df = param_df.set_index(cols["key"])
 
     if "mask_file_path" in supernetwork_parameters:
         data_mask = nhd_io.read_mask(
-            supernetwork_parameters["mask_file_path"],
+            pathlib.Path(supernetwork_parameters["mask_file_path"]),
             layer_string=supernetwork_parameters["mask_layer_string"],
         )
         param_df = param_df.filter(
@@ -481,6 +481,7 @@ def build_qlateral_array(forcing_parameters, connections_keys, nts, qts_subdivis
     qlat_input_folder = forcing_parameters.get("qlat_input_folder", None)
     qlat_input_file = forcing_parameters.get("qlat_input_file", None)
     if qlat_input_folder:
+        qlat_input_folder = pathlib.Path(qlat_input_folder)
         qlat_file_pattern_filter = forcing_parameters.get(
             "qlat_file_pattern_filter", "*CHRT_OUT*"
         )

--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -103,9 +103,9 @@ def set_supernetwork_parameters(
         return rv
 
         # return {
-        #'geo_file_path' : os.path.join(geo_input_folder
+        #'geo_file_path' : pathlib.Path(geo_input_folder
     # , r'PoconoSampleData2'
-    # , r'PoconoRouteLink_testsamp1_nwm_mc.shp')
+    # , r'PoconoRouteLink_testsamp1_nwm_mc.shp').resolve()
     # , 'key_col' : 18
     # , 'downstream_col' : 23
     # , 'length_col' : 5

--- a/src/python_routing_v02/build_tests.py
+++ b/src/python_routing_v02/build_tests.py
@@ -158,11 +158,10 @@ def build_test_parameters(
 
 
 def parity_check(parity_parameters, run_parameters, nts, dt, results):
-def parity_check(parity_parameters, run_parameters, nts, dt, results):
     
     if "parity_check_input_folder" in parity_parameters:
         
-        validation_files = parity_parameters["parity_check_input_folder"].rglob(
+        validation_files = pathlib.Path(parity_parameters["parity_check_input_folder"]).rglob(
             parity_parameters["parity_check_file_pattern_filter"]
         )
 

--- a/src/python_routing_v02/build_tests.py
+++ b/src/python_routing_v02/build_tests.py
@@ -7,13 +7,11 @@ Test v02 routing on specific test cases
 
 """
 ## Parallel execution
-import os
 import sys
 import time
 import numpy as np
 import argparse
 import pathlib
-import glob
 import pandas as pd
 from functools import partial
 from joblib import delayed, Parallel
@@ -161,14 +159,11 @@ def build_test_parameters(
 
 def parity_check(parity_parameters, run_parameters, nts, dt, results):
     
-    if "parity_check_input_folder" in parity_parameters.keys():
+    if "parity_check_input_folder" in parity_parameters:
         
-        validation_files = glob.glob(
-            parity_parameters["parity_check_input_folder"]
-            + parity_parameters["parity_check_file_pattern_filter"],
-            recursive=True,
-        )
-            
+        validation_files = parity_parameters["parity_check_input_folder"].rglob(
+            parity_parameters["parity_check_file_pattern_filter"])
+
         # read validation data from CHRTOUT files
         validation_data = nhd_io.get_ql_from_wrf_hydro_mf(
             validation_files,
@@ -177,7 +172,7 @@ def parity_check(parity_parameters, run_parameters, nts, dt, results):
             # [compare_node],
         )
     
-    if "parity_check_file" in parity_parameters.keys():
+    if "parity_check_file" in parity_parameters:
         validation_data = pd.read_csv(parity_parameters["parity_check_file"], index_col=0)
         validation_data.index = validation_data.index.astype(int)
         validation_data.columns = validation_data.columns.astype("datetime64[ns]")

--- a/src/python_routing_v02/build_tests.py
+++ b/src/python_routing_v02/build_tests.py
@@ -49,20 +49,20 @@ def build_test_parameters(
         print("running test case for Pocono_TEST1 domain - NO RESERVOIRS")
 
         # File path to WRF Hydro data
-        NWM_test_path = os.path.join(
+        NWM_test_path = pathlib.Path(
             root, "test/input/geo/NWM_2.1_Sample_Datasets/Pocono_TEST1/"
-        )
+        ).resolve()
 
         # Simulation domain RouteLink file
-        routelink_file = os.path.join(
+        routelink_file = pathlib.Path(
             NWM_test_path, "primary_domain", "DOMAIN", "Route_Link.nc",
-        )
+        ).resolve()
 
         # Speficify WRF hydro restart file, name and destination
         time_string = "2017-12-31_06-00_DOMAIN1"
-        wrf_hydro_restart_file = os.path.join(
+        wrf_hydro_restart_file = pathlib.Path(
             NWM_test_path, "example_RESTART", "HYDRO_RST." + time_string
-        )
+        ).resolve()
 
         # specify supernetwork parameters
         supernetwork_parameters = {
@@ -105,11 +105,11 @@ def build_test_parameters(
         restart_parameters["wrf_hydro_channel_restart_depth_flow_field_name"] = "hlink"
 
         # specify restart parameters
-        forcing_parameters["qlat_input_folder"] = os.path.join(
+        forcing_parameters["qlat_input_folder"] = pathlib.Path(
             root,
             "test/input/geo/NWM_2.1_Sample_Datasets/Pocono_TEST1/example_CHRTOUT/",
-        )
-        forcing_parameters["qlat_file_pattern_filter"] = "/*.CHRTOUT_DOMAIN1"
+        ).resolve()
+        forcing_parameters["qlat_file_pattern_filter"] = "*.CHRTOUT_DOMAIN1"
         forcing_parameters["qlat_file_index_col"] = "feature_id"
         forcing_parameters["qlat_file_value_col"] = "q_lateral"
 
@@ -140,11 +140,11 @@ def build_test_parameters(
 
         run_parameters["assume_short_ts"] = True
 
-        parity_parameters["parity_check_input_folder"] = os.path.join(
+        parity_parameters["parity_check_input_folder"] = pathlib.Path(
             root,
             "test/input/geo/NWM_2.1_Sample_Datasets/Pocono_TEST1/example_CHRTOUT/",
-        )
-        parity_parameters["parity_check_file_pattern_filter"] = "/*.CHRTOUT_DOMAIN1"
+        ).resolve()
+        parity_parameters["parity_check_file_pattern_filter"] = "*.CHRTOUT_DOMAIN1"
         parity_parameters["parity_check_file_index_col"] = "feature_id"
         parity_parameters["parity_check_file_value_col"] = "streamflow"
         parity_parameters["parity_check_compare_node"] = 4186169

--- a/src/python_routing_v02/build_tests.py
+++ b/src/python_routing_v02/build_tests.py
@@ -158,11 +158,13 @@ def build_test_parameters(
 
 
 def parity_check(parity_parameters, run_parameters, nts, dt, results):
+def parity_check(parity_parameters, run_parameters, nts, dt, results):
     
     if "parity_check_input_folder" in parity_parameters:
         
         validation_files = parity_parameters["parity_check_input_folder"].rglob(
-            parity_parameters["parity_check_file_pattern_filter"])
+            parity_parameters["parity_check_file_pattern_filter"]
+        )
 
         # read validation data from CHRTOUT files
         validation_data = nhd_io.get_ql_from_wrf_hydro_mf(

--- a/test/input/yaml/CustomInput.yaml
+++ b/test/input/yaml/CustomInput.yaml
@@ -74,7 +74,7 @@ waterbody_parameters:
 #WRF-Hydro output file 
 forcing_parameters:
     qlat_input_folder: "../../test/input/geo/NWM_2.1_Sample_Datasets/Pocono_TEST1/example_CHRTOUT/"
-    qlat_file_pattern_filter: "/*.CHRTOUT_DOMAIN1"
+    qlat_file_pattern_filter: "*.CHRTOUT_DOMAIN1"
     qlat_file_index_col: feature_id
     qlat_file_value_col: q_lateral
 #WRF-Hydro restart files
@@ -97,7 +97,7 @@ restart_parameters:
     wrf_hydro_waterbody_crosswalk_filter_file_field_name: NHDWaterbodyComID
 parity_parameters:
     parity_check_input_folder: "../../test/input/geo/NWM_2.1_Sample_Datasets/Pocono_TEST1/example_CHRTOUT/"
-    parity_check_file_pattern_filter: "/*.CHRTOUT_DOMAIN1"
+    parity_check_file_pattern_filter: "*.CHRTOUT_DOMAIN1"
     parity_check_file_index_col: feature_id
     parity_check_file_value_col: streamflow
     parity_check_compare_node: 4186169


### PR DESCRIPTION
Moving all path manipulation (os.path and glob.glob) to pathlib.  Subsumes all content in #221 

- [x] os.path.join --> pathlib.Path or pathlib.Path.joinpath
- [x] glob.glob --> pathlib.glob


Testcases: 
- [x] `python compute_nhd_routing_SingleSeg_v02.py --test pocono1 -t -v --debuglevel 1`
- [x] `python compute_nhd_routing_SingleSeg_v02.py -f ../../test/input/yaml/CustomInput.yaml`
- [x] `python compute_nhd_routing_SingleSeg_v02.py -t -n Mainstems_CONUS -v --debuglevel 1 --parallel by-subnetwork-jit-clustered --subnet-size 100 --nts 288 --cpu-pool  6`
- [x] ` python compute_nhd_routing_SingleSeg_v02.py -f ../../test/input/yaml/Florence_Benchmark.yaml`