### PR TITLE
Fix waterbody splitting

### DIFF
--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -729,6 +729,12 @@ def compute_nhd_routing_v02(
                 qlat_sub = qlats.loc[param_df_sub.index]
                 q0_sub = q0.loc[param_df_sub.index]
 
+                param_df_sub = param_df_sub.reindex(
+                    param_df_sub.index.tolist() + lake_segs
+                ).sort_index()
+                qlat_sub = qlat_sub.reindex(param_df_sub.index)
+                q0_sub = q0_sub.reindex(param_df_sub.index)
+
                 jobs.append(
                     delayed(compute_func)(
                         nts,
@@ -804,6 +810,12 @@ def compute_nhd_routing_v02(
             # q0_sub = q0.loc[common_segs].sort_index()
             qlat_sub = qlats.loc[param_df_sub.index]
             q0_sub = q0.loc[param_df_sub.index]
+
+            param_df_sub = param_df_sub.reindex(
+                param_df_sub.index.tolist() + lake_segs
+            ).sort_index()
+            qlat_sub = qlat_sub.reindex(param_df_sub.index)
+            q0_sub = q0_sub.reindex(param_df_sub.index)
 
             reach_type_list = [
                 1 if (set(reaches) & wbodies_segs) else 0 for reaches in reach_list

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -1068,7 +1068,9 @@ def main():
 
     independent_networks, reaches_bytw, rconn = nnu.organize_independent_networks(
         connections,
-        wbodies if break_network_at_waterbodies else False,
+        list(waterbodies_df_reduced.index.values)
+        if break_network_at_waterbodies
+        else None,
     )
 
     if verbose:


### PR DESCRIPTION
Bug fix to recent waterbody PR. wbodies was being passed to the network splitting function, which resulted in improper partitioning -- waterbodies need to be isolated to their own networks, which now happens properly with this fix.

All simple tests pass:
- [x] python compute_nhd_routing_SingleSeg_v02.py -f ../../test/input/yaml/CustomInput.yaml
- [x] python compute_nhd_routing_SingleSeg_v02.py -t -n Mainstems_CONUS -v --debuglevel 1 --parallel by-subnetwork-jit-clustered --subnet-size 100 --nts 288 --cpu-pool 6
- [x] python compute_nhd_routing_SingleSeg_v02.py -t -n Mainstems_CONUS -v --debuglevel 1 --parallel by-network --nts 288 --cpu-pool 6
- [x] python compute_nhd_routing_SingleSeg_v02.py --test pocono1 -t -v --debuglevel 1
- [x] python compute_nhd_routing_SingleSeg_v02.py -f ../../test/input/yaml/Florence_Benchmark.yaml


We were handing over the wrong set: 
wbodies is the dict of segments that are waterbodies, for instance: 
```
{4186223: 4184997,
 4186287: 4185089,
 4186297: 4185089,
 4186305: 4185089,
 4186307: 4185089,
 4186309: 4185089,
 4186331: 4185105,
 4186333: 4185105,
 4186345: 4185105,
 4186347: 4185105,
 4186355: 4185105,
 4186357: 4185105,
 4186359: 4185105,
 4186361: 4185105,
 4186363: 4185105,
 4186371: 4185105,
 4186379: 4185105}
```
Those were never found by the splitting algorithm because they had been removed from the network.

vs.

the index of the new waterbodies dataframe provides the list of waterbody ids, e.g.,
```
[4184997, 4185089, 4185105]
```
