### PR TITLE
Use comma [i,j] index instead of [i][j]

### DIFF
--- a/src/python_routing_v02/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/fast_reach/mc_reach.pyx
@@ -228,7 +228,7 @@ cpdef object compute_network(
         fill_index = tmp["position_index"]
         fill_index_mask[fill_index] = False
         for idx, val in enumerate(tmp["results"]):
-            flowveldepth[fill_index][idx] = val
+            flowveldepth[fill_index, idx] = val
 
     cdef:
         Py_ssize_t[:] srows  # Source rows indexes


### PR DESCRIPTION
change `flowveldepth[fill_index][idx] = val` to  `flowveldepth[fill_index, idx] = val`

#249 

Just made the tiny changed listed in the above comment. 