### PR TITLE
Fix compile errors.

### DIFF
--- a/src/fortran_routing/Reservoir_Binding/Reservoirs/makefile
+++ b/src/fortran_routing/Reservoir_Binding/Reservoirs/makefile
@@ -1,9 +1,8 @@
-NETCDFINC       :=       $(NETCDF_INC)
-NETCDFLIB       =       -L$(NETCDF_LIB) -lnetcdff -lnetcdf
-COMPILER90 = gfortran
+NETCDFINC := $(shell nc-config --fflags)
+NETCDFLIB := $(shell nc-config --flibs)
+COMPILER90 = $(F90)
 F90FLAGS = -w -c -ffree-form -ffree-line-length-none -fconvert=big-endian -frecord-marker=4
-F90FLAGS := -g $(F90FLAGS) -I$(NETCDFINC) -static-libgfortran -static-libgcc -nodefaultlibs -lgfortran -lgcc -fPIC
-AR = ar
+F90FLAGS := -g $(F90FLAGS) $(NETCDFINC) $(NETCDFLIB) -static-libgfortran -static-libgcc -nodefaultlibs -lgfortran -lgcc -fPIC
 ARFLAGS = rc
 
 VPATH = ./Level_Pool ./Persistence_Level_Pool_Hybrid ./RFC_Forecasts

--- a/src/fortran_routing/mc_pylink_v00/MC_singleSeg_singleTS/makefile
+++ b/src/fortran_routing/mc_pylink_v00/MC_singleSeg_singleTS/makefile
@@ -1,5 +1,5 @@
 # compiler
-FC := gfortran
+FC := $(F90)
 
 # compile flags
 #FCFLAGS = -c -fdefault-real-8 -fno-align-commons -fbounds-check --free-form

--- a/src/python_routing_v02/compiler.sh
+++ b/src/python_routing_v02/compiler.sh
@@ -11,6 +11,12 @@ build_reservoir_kernel=true
 build_framework=true
 build_routing=true
 
+if [ -z "$F90" ]
+then
+    export F90="gfortran"
+    echo "using F90='gfortran'"
+fi
+
 #if you have custom static library paths, uncomment below and export them
 #export LIBRARY_PATH=<paths>:$LIBRARY_PATH
 #if you have custom dynamic library paths, uncomment below and export them


### PR DESCRIPTION
This resolves the issues with missing symbols on my machine as well as
the troubles with the netcdf library.

The root of the issue was the hardcoding of gfortran in the makefiles. The netcdf library issues were resolved by querying netcdf library for the include paths and linking options.

tag: @hellkite500 @jameshalgren 