### PR TITLE
Write t-route states to WRF-Hydro restart files

### DIFF
--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -219,7 +219,9 @@ def drop_all_coords(ds):
     return ds.reset_coords(drop=True)
 
 
-def write_q_to_wrf_hydro(flowveldepth, chrtout_files, qts_subdivisions):
+def write_q_to_wrf_hydro(
+    flowveldepth, chrtout_files, qts_subdivisions, new_extension="TRTE"
+):
     """
     Write t-route simulated flows to WRF-Hydro CHRTOUT files.
 
@@ -262,7 +264,9 @@ def write_q_to_wrf_hydro(flowveldepth, chrtout_files, qts_subdivisions):
         dataset_list.append(vals)
 
     # save a new set of chrtout files to disk that contail t-route simulated flow
-    chrtout_files_new = [s.parent / (s.name + ".TRTE") for s in chrtout_files]
+    chrtout_files_new = [
+        s.parent / (s.name + "." + new_extension) for s in chrtout_files
+    ]
 
     # mfdataset solution - can theoretically be parallelised via dask.distributed
     xr.save_mfdataset(dataset_list, paths=chrtout_files_new)
@@ -532,6 +536,7 @@ def write_channel_restart_to_wrf_hydro(
     nts_troute,
     crosswalk_file,
     channel_ID_column,
+    new_extension,
     restart_file_dimension_var="links",
     troute_us_flow_var_name="qlink1_troute",
     troute_ds_flow_var_name="qlink2_troute",
@@ -620,7 +625,7 @@ def write_channel_restart_to_wrf_hydro(
                 ds[troute_depth_var_name] = htrt_DataArray
 
                 # write edited to disk with new filename
-                ds.to_netcdf(f.parent / (f.name + ".TROUTE"))
+                ds.to_netcdf(f.parent / (f.name + "." + new_extension))
 
 
 def get_reservoir_restart_from_wrf_hydro(

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -1293,13 +1293,18 @@ def main():
         wrf_hydro_restart_dir = output_parameters.get(
             "wrf_hydro_channel_restart_directory", None
         )
+        wrf_hydro_channel_restart_new_extension = output_parameters.get(
+            "wrf_hydro_channel_restart_new_extension", "TRTE"
+        )
         if wrf_hydro_restart_dir:
 
             # list of WRF Hydro restart files
             wrf_hydro_restart_files = list(
                 Path(wrf_hydro_restart_dir).glob(
                     output_parameters["wrf_hydro_channel_restart_pattern_filter"]
-                    + "[!.TROUTE]"
+                    + "[!"
+                    + wrf_hydro_channel_restart_new_extension
+                    + "]"
                 )
             )
 
@@ -1314,6 +1319,7 @@ def main():
                     restart_parameters.get(
                         "wrf_hydro_channel_ID_crosswalk_file_field_name"
                     ),
+                    wrf_hydro_channel_restart_new_extension,
                 )
             else:
                 # print error and/or raise exception
@@ -1322,8 +1328,9 @@ def main():
                 )
                 raise AssertionError
 
-        chrtout_folder = Path(
-            output_parameters.get("wrf_hydro_channel_output_folder", None)
+        chrtout_folder = output_parameters.get("wrf_hydro_channel_output_folder", None)
+        wrf_hydro_channel_output_new_extension = output_parameters.get(
+            "wrf_hydro_channel_output_new_extension", "TRTE"
         )
         if chrtout_folder:
             chrtout_files = list(

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -14,13 +14,12 @@ A demonstration version of this code is stored in this Colaboratory notebook:
 
 """
 ## Parallel execution
-import os
 import sys
 import time
 from datetime import datetime
 import numpy as np
 import argparse
-import pathlib
+from pathlib import Path
 import glob
 import pandas as pd
 from collections import defaultdict
@@ -284,9 +283,9 @@ def _handle_args():
 
 ENV_IS_CL = False
 if ENV_IS_CL:
-    root = pathlib.Path("/", "content", "t-route")
+    root = Path("/", "content", "t-route")
 elif not ENV_IS_CL:
-    root = pathlib.Path("../..").resolve()
+    root = Path("../..").resolve()
     # sys.path.append(r"../python_framework_v02")
 
     # TODO: automate compile for the package scripts
@@ -299,6 +298,7 @@ import diffusive
 import troute.nhd_network as nhd_network
 import troute.nhd_io as nhd_io
 import build_tests  # TODO: Determine whether and how to incorporate this into setup.py
+
 
 def writetoFile(file, writeString):
     file.write(writeString)
@@ -426,7 +426,8 @@ def compute_nhd_routing_v02(
 
                     segs.extend(offnetwork_upstreams)
                     param_df_sub = param_df.loc[
-                        segs, ["dt", "bw", "tw", "twcc", "dx", "n", "ncc", "cs", "s0", "alt"],
+                        segs,
+                        ["dt", "bw", "tw", "twcc", "dx", "n", "ncc", "cs", "s0", "alt"],
                     ].sort_index()
                     if order < max(subnetworks_only_ordered_jit.keys()):
                         for us_subn_tw in offnetwork_upstreams:
@@ -572,7 +573,8 @@ def compute_nhd_routing_v02(
 
                     segs.extend(offnetwork_upstreams)
                     param_df_sub = param_df.loc[
-                        segs, ["dt", "bw", "tw", "twcc", "dx", "n", "ncc", "cs", "s0", "alt"],
+                        segs,
+                        ["dt", "bw", "tw", "twcc", "dx", "n", "ncc", "cs", "s0", "alt"],
                     ].sort_index()
                     if order < max(subnetworks_only_ordered_jit.keys()):
                         for us_subn_tw in offnetwork_upstreams:
@@ -912,7 +914,7 @@ def _input_handler():
         output_parameters["csv_output"] = {}
         output_parameters["csv_output"]["csv_output_folder"] = args.csv_output_folder
 
-        test_folder = pathlib.Path(root, "test")
+        test_folder = Path(root, "test")
         geo_input_folder = test_folder.joinpath("input", "geo")
 
         test_case = args.test_case
@@ -1286,49 +1288,52 @@ def main():
                 ],
                 copy=False,
             )
-            
-        if output_parameters.get("write_wrf_hydro_channel_restart", None):
-            # directory containing WRF Hydro restart files
-            restart_dir = output_parameters.get("wrf_hydro_channel_restart_directory",None)
- 
+
+        # directory containing WRF Hydro restart files
+        wrf_hydro_restart_dir = output_parameters.get(
+            "wrf_hydro_channel_restart_directory", None
+        )
+        if wrf_hydro_restart_dir:
+
             # list of WRF Hydro restart files
-            restart_files = glob.glob(
-                os.path.join(
-                    restart_dir, 
-                    output_parameters["wrf_hydro_channel_restart_pattern_filter"] + "[!.TROUTE]"
+            wrf_hydro_restart_files = list(
+                Path(wrf_hydro_restart_dir).glob(
+                    output_parameters["wrf_hydro_channel_restart_pattern_filter"]
+                    + "[!.TROUTE]"
                 )
-            )  
-            
-            try:
-                if not pathlib.Path(restart_dir).exists() or len(restart_files) == 0:
-                    raise AssertionError
-            except AssertionError:
-                print('WRF Hydro restart files not found - Aborting restart write sequence')
-            else:
-                
+            )
+
+            if len(wrf_hydro_restart_files) > 0:
                 nhd_io.write_channel_restart_to_wrf_hydro(
                     flowveldepth,
-                    restart_files,
+                    wrf_hydro_restart_files,
                     restart_parameters.get("wrf_hydro_channel_restart_file"),
                     run_parameters.get("dt"),
                     run_parameters.get("nts"),
                     restart_parameters.get("wrf_hydro_channel_ID_crosswalk_file"),
-                    restart_parameters.get("wrf_hydro_channel_ID_crosswalk_file_field_name"),
+                    restart_parameters.get(
+                        "wrf_hydro_channel_ID_crosswalk_file_field_name"
+                    ),
                 )
-                
-                
-        if output_parameters.get("write_chrtout", None):
-            if forcing_parameters.get("qlat_input_folder", None):
+            else:
+                # print error and/or raise exception
+                print(
+                    "WRF Hydro restart files not found - Aborting restart write sequence"
+                )
+                raise AssertionError
 
-                qlat_input_folder = pathlib.Path(forcing_parameters.get("qlat_input_folder"))
-                chrtout_files = glob.glob(
-                        os.path.join(
-                            qlat_input_folder,
-                            forcing_parameters["qlat_file_pattern_filter"]
-                        )
-                    )
-
-                nhd_io.write_q_to_wrf_hydro(flowveldepth, chrtout_files, run_parameters["qts_subdivisions"])
+        chrtout_folder = Path(
+            output_parameters.get("wrf_hydro_channel_output_folder", None)
+        )
+        if chrtout_folder:
+            chrtout_files = list(
+                Path(chrtout_folder).glob(
+                    output_parameters["wrf_hydro_channel_output_file_pattern_filter"]
+                )
+            )
+            nhd_io.write_q_to_wrf_hydro(
+                flowveldepth, chrtout_files, run_parameters["qts_subdivisions"]
+            )
 
         if csv_output_folder:
             # create filenames
@@ -1345,7 +1350,7 @@ def main():
                 filename_fvd = "flowveldepth_" + run_time_stamp + ".csv"
                 filename_courant = "courant_" + run_time_stamp + ".csv"
 
-            output_path = pathlib.Path(csv_output_folder).resolve()
+            output_path = Path(csv_output_folder).resolve()
 
             flowveldepth = flowveldepth.sort_index()
             flowveldepth.to_csv(output_path.joinpath(filename_fvd))

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -1306,80 +1306,16 @@ def main():
                 print('WRF Hydro restart files not found - Aborting restart write sequence')
             else:
                 
-                # --vvvvvvvvvv EVERYTHING HERE TO GO TO FUNCTION IN nhd_io.py vvvvvvvvvvv
-                #---------------------------------------------------------------------------------------------
+                nhd_io.write_channel_restart_to_wrf_hydro(
+                    flowveldepth,
+                    restart_files,
+                    restart_parameters.get("wrf_hydro_channel_restart_file"),
+                    run_parameters.get("dt"),
+                    run_parameters.get("nts"),
+                    restart_parameters.get("wrf_hydro_channel_ID_crosswalk_file"),
+                    restart_parameters.get("wrf_hydro_channel_ID_crosswalk_file_field_name"),
+                )
                 
-                '''
-                Inputs
-                ------
-                restart_files
-                restart_parameters
-                run_parameters
-                '''
-                
-                import xarray as xr
-                import dask.array as da
-                
-                # create t-route simulation timestamp array
-                with xr.open_dataset(restart_parameters.get("wrf_hydro_channel_restart_file")) as ds:
-                    t0 = ds.Restart_Time.replace('_', ' ')
-                t0 = np.array(t0,dtype = np.datetime64)
-                troute_dt = np.timedelta64(run_parameters.get("dt"), 's')
-                troute_timestamps = t0 + np.arange(run_parameters.get("nts")) * troute_dt
-                
-                # extract ordered feature_ids from crosswalk file
-                crosswalk_file = restart_parameters.get("wrf_hydro_channel_ID_crosswalk_file")
-                channel_ID_column = restart_parameters.get("wrf_hydro_channel_ID_crosswalk_file_field_name")
-                
-                with xr.open_dataset(crosswalk_file) as xds:
-                    xdf = xds[channel_ID_column].to_dataframe()
-                xdf = xdf.reset_index()
-                xdf = xdf[[channel_ID_column]]
-                
-                # reindex flowvedl depth array
-                flowveldepth_reindex = flowveldepth.reindex(xdf.link)
-                
-                # get restart timestamps - revise do this one at a time
-                timestamps = []
-                for f in restart_files:
-                    with xr.open_dataset(f) as ds:
-                        
-                        # get timestamp from restart file
-                        t = np.array(
-                            ds.Restart_Time.replace('_', ' '), 
-                            dtype = np.datetime64)
-                        
-                        # find index troute_timestamp value that matches restart file timestamp
-                        a = np.where(troute_timestamps == t)[0].tolist()
-                        
-                        # if the restart timestamp exists in the t-route simulatuion
-                        if len(a) > 0:
- 
-                            # pull flow data from flowveldepth array, package into DataArray
-                            qtrt = flowveldepth_reindex.iloc[:,::3].iloc[:,a].to_numpy().astype("float32")
-                            qtrt = qtrt.reshape((len(flowveldepth_reindex,)))
-                            qtrt_DataArray = xr.DataArray(
-                                data = qtrt,
-                                dims = ["links"],
-                            )
-                            
-                            # pull depth data from flowveldepth array, package into DataArray
-                            htrt = flowveldepth_reindex.iloc[:,2::3].iloc[:,a].to_numpy().astype("float32")
-                            htrt = htrt.reshape((len(flowveldepth_reindex,)))
-                            htrt_DataArray = xr.DataArray(
-                                data = htrt,
-                                dims = ["links"],
-                            )
-                            
-                            # insert troute data into restart dataset
-                            ds['qlink1_troute'] = qtrt_DataArray
-                            ds['qlink2_troute'] = qtrt_DataArray
-                            ds['hlink_troute'] = htrt_DataArray
-                            # write to disk
-                            ds.to_netcdf(f + ".TROUTE")
-                            
-                #---------------------------------------------------------------------------------------------
-                # --^^^^^^^^^ EVERYTHING HERE TO GO TO FUNCTION IN nhd_io.py ^^^^^^^^^^
                 
         if output_parameters.get("write_chrtout", None):
             if forcing_parameters.get("qlat_input_folder", None):

--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -1293,10 +1293,11 @@ def main():
         wrf_hydro_restart_dir = output_parameters.get(
             "wrf_hydro_channel_restart_directory", None
         )
-        wrf_hydro_channel_restart_new_extension = output_parameters.get(
-            "wrf_hydro_channel_restart_new_extension", "TRTE"
-        )
         if wrf_hydro_restart_dir:
+
+            wrf_hydro_channel_restart_new_extension = output_parameters.get(
+                "wrf_hydro_channel_restart_new_extension", "TRTE"
+            )
 
             # list of WRF Hydro restart files
             wrf_hydro_restart_files = list(
@@ -1329,10 +1330,10 @@ def main():
                 raise AssertionError
 
         chrtout_folder = output_parameters.get("wrf_hydro_channel_output_folder", None)
-        wrf_hydro_channel_output_new_extension = output_parameters.get(
-            "wrf_hydro_channel_output_new_extension", "TRTE"
-        )
         if chrtout_folder:
+            wrf_hydro_channel_output_new_extension = output_parameters.get(
+                "wrf_hydro_channel_output_new_extension", "TRTE"
+            )
             chrtout_files = list(
                 Path(chrtout_folder).glob(
                     output_parameters["wrf_hydro_channel_output_file_pattern_filter"]

--- a/test/input/yaml/CustomInput.yaml
+++ b/test/input/yaml/CustomInput.yaml
@@ -25,9 +25,11 @@ output_parameters:
     # Write t-route data to WRF-Hydro restart files
     wrf_hydro_channel_output_folder: "../../test/input/geo/NWM_2.1_Sample_Datasets/Pocono_TEST1/example_CHRTOUT/"
     wrf_hydro_channel_output_file_pattern_filter: "*.CHRTOUT_DOMAIN1"
+    wrf_hydro_channel_output_new_extension: "TROUTE"
     # Write t-route data to WRF-Hydro CHRTOUT files
     wrf_hydro_channel_restart_directory: "../../test/input/geo/NWM_2.1_Sample_Datasets/Pocono_TEST1/example_RESTART/"
     wrf_hydro_channel_restart_pattern_filter: "HYDRO_RST.*"
+    wrf_hydro_channel_restart_new_extension: "TROUTE"
 #data column assignment inside supernetwork_parameters
 supernetwork_parameters:
     title_string: "Pocono1"

--- a/test/input/yaml/CustomInput.yaml
+++ b/test/input/yaml/CustomInput.yaml
@@ -23,6 +23,10 @@ output_parameters:
     #out location for nc file
     nc_output_folder: "../../test/output/text"
     write_chrtout: True
+    # Write t-route data to WRF-Hydro restart files?
+    write_wrf_hydro_channel_restart: True
+    # Directory containing WRF-Hydro restart files
+    wrf_hydro_channel_restart_directory: "../../test/input/geo/NWM_2.1_Sample_Datasets/Pocono_TEST1/example_RESTART"
 #data column assignment inside supernetwork_parameters
 supernetwork_parameters:
     title_string: "Pocono1"

--- a/test/input/yaml/CustomInput.yaml
+++ b/test/input/yaml/CustomInput.yaml
@@ -27,6 +27,7 @@ output_parameters:
     write_wrf_hydro_channel_restart: True
     # Directory containing WRF-Hydro restart files
     wrf_hydro_channel_restart_directory: "../../test/input/geo/NWM_2.1_Sample_Datasets/Pocono_TEST1/example_RESTART/"
+    wrf_hydro_channel_restart_pattern_filter: "HYDRO_RST.*"
 #data column assignment inside supernetwork_parameters
 supernetwork_parameters:
     title_string: "Pocono1"

--- a/test/input/yaml/CustomInput.yaml
+++ b/test/input/yaml/CustomInput.yaml
@@ -26,7 +26,7 @@ output_parameters:
     # Write t-route data to WRF-Hydro restart files?
     write_wrf_hydro_channel_restart: True
     # Directory containing WRF-Hydro restart files
-    wrf_hydro_channel_restart_directory: "../../test/input/geo/NWM_2.1_Sample_Datasets/Pocono_TEST1/example_RESTART"
+    wrf_hydro_channel_restart_directory: "../../test/input/geo/NWM_2.1_Sample_Datasets/Pocono_TEST1/example_RESTART/"
 #data column assignment inside supernetwork_parameters
 supernetwork_parameters:
     title_string: "Pocono1"

--- a/test/input/yaml/CustomInput.yaml
+++ b/test/input/yaml/CustomInput.yaml
@@ -22,10 +22,10 @@ output_parameters:
         csv_output_segments: [4185713, 2743396, 4153198, 4186293, 4186169]
     #out location for nc file
     nc_output_folder: "../../test/output/text"
-    write_chrtout: True
-    # Write t-route data to WRF-Hydro restart files?
-    write_wrf_hydro_channel_restart: True
-    # Directory containing WRF-Hydro restart files
+    # Write t-route data to WRF-Hydro restart files
+    wrf_hydro_channel_output_folder: "../../test/input/geo/NWM_2.1_Sample_Datasets/Pocono_TEST1/example_CHRTOUT/"
+    wrf_hydro_channel_output_file_pattern_filter: "*.CHRTOUT_DOMAIN1"
+    # Write t-route data to WRF-Hydro CHRTOUT files
     wrf_hydro_channel_restart_directory: "../../test/input/geo/NWM_2.1_Sample_Datasets/Pocono_TEST1/example_RESTART/"
     wrf_hydro_channel_restart_pattern_filter: "HYDRO_RST.*"
 #data column assignment inside supernetwork_parameters


### PR DESCRIPTION
New capability to write t-route simulated flow and depth data to WRF-Hydro restart files. The routine opens each WRF-Hydro restart file 

1. Construct a datetime array for the t-route simulation. This is needed to query t-route results against timestamps specified in WRF-Hydro Restart Files. 
2. Re-index the `flowveldepth` dataframe to match segment ID ordering in the Restart FIle
3. Open each WRF-Hydro restart file in a user-specified restart file directory with user specified file pattern filter
    1. Extract restart timestamp by converting Restart_Time attribute to datetime64 datatype
    2. Find the index of t-route datetime array that matches timestamp in Restart File. 
    3. IF a matching timestamp is found, THEN  create Data Arrays of t-route flow and depth data for the matching timestamp, add new variables to Restart File dataset, write edited data set to disk
