### PR TITLE
simplify handling of output flags

### DIFF
--- a/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
+++ b/src/python_routing_v02/compute_nhd_routing_SingleSeg_v02.py
@@ -1273,13 +1273,12 @@ def main():
     if verbose:
         print(f"Handling output ...")
 
-    if output_parameters:
-        csv_output = output_parameters.get("csv_output", None)
-        if csv_output:
-            csv_output_folder = output_parameters["csv_output"].get(
-                "csv_output_folder", None
-            )
-            csv_output_segments = csv_output.get("csv_output_segments", None)
+    csv_output = output_parameters.get("csv_output", None)
+    if csv_output:
+        csv_output_folder = output_parameters["csv_output"].get(
+            "csv_output_folder", None
+        )
+        csv_output_segments = csv_output.get("csv_output_segments", None)
 
     if (debuglevel <= -1) or csv_output:
 


### PR DESCRIPTION
This super brief pull request updates the csv handling slightly to allow more easily for and empty output field in the control yaml file, thus: 

``` yaml
output_parameters:{} 
```
or 
``` yaml
#output_parameters:
```

Passes the following tests without changes to prior behavior: 
```
#!/bin/bash -x
python compute_nhd_routing_SingleSeg_v02.py -f ../../test/input/yaml/CustomInput.yaml
python compute_nhd_routing_SingleSeg_v02.py -f ../../test/input/yaml/Croton_NY_levelpool.yaml
python compute_nhd_routing_SingleSeg_v02.py -f ../../test/input/yaml/Croton_NY_with_wb_dev.yaml
python compute_nhd_routing_SingleSeg_v02.py --test pocono1 -t -v --debuglevel 1
python compute_nhd_routing_SingleSeg_v02.py -t -n Mainstems_CONUS -v --debuglevel 1 --parallel by-network --nts 288 --cpu-pool 6
python compute_nhd_routing_SingleSeg_v02.py -t -n Mainstems_CONUS -v --debuglevel 1 --parallel by-subnetwork-jit-clustered --subnet-size 100 --nts 288 --cpu-pool 6
python compute_nhd_routing_SingleSeg_v02.py -f ../../test/input/yaml/Florence_Benchmark.yaml
python compute_nhd_routing_SingleSeg_v02.py -f ../../test/input/yaml/Florence_Benchmark_diff.yaml
```
