### PR TITLE
[old - don't merge] Enabling by-subnetwork parallel in `mc_reach.compute_network_structured`

### DIFF
--- a/src/python_routing_v02/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/fast_reach/mc_reach.pyx
@@ -808,7 +808,14 @@ cpdef object compute_network_structured_obj(
                 (MC_Reach(segment_objects, array('l',upstream_ids)), reach_type)
                 )
 
-
+# TO DO place upstream flow vel and depth data into flowveldepth array to allow subnet parallel.
+#     for upstream_tw_id in upstream_results:
+#     tmp = upstream_results[upstream_tw_id]
+#     fill_index = tmp["position_index"]
+#     fill_index_mask[fill_index] = False
+#     for idx, val in enumerate(tmp["results"]):
+#         flowveldepth[fill_index, idx] = val
+    
     #Init buffers
     lateral_flows = np.zeros( max_buff_size, dtype='float32' )
     buf_view = np.zeros( (max_buff_size, 13), dtype='float32')

--- a/src/python_routing_v02/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/fast_reach/mc_reach.pyx
@@ -1019,20 +1019,19 @@ cpdef object compute_network_structured(
                 MC_Reach(segment_objects, array('l',upstream_ids))
                 )
             
-    # TO DO place upstream flow vel and depth data into flowveldepth array to allow subnet parallel.
-#     cdef np.ndarray fill_index_mask = np.ones_like(data_idx, dtype=bool)
-#     cdef Py_ssize_t fill_index
-#     cdef long upstream_tw_id
-#     cdef dict tmp
-#     cdef int idx
-#     cdef float val
+    cdef np.ndarray fill_index_mask = np.ones_like(data_idx, dtype=bool)
+    cdef Py_ssize_t fill_index
+    cdef long upstream_tw_id
+    cdef dict tmp
+    cdef int idx
+    cdef float val
     
-#     for upstream_tw_id in upstream_results:
-#     tmp = upstream_results[upstream_tw_id]
-#     fill_index = tmp["position_index"]
-#     fill_index_mask[fill_index] = False
-#     for idx, val in enumerate(tmp["results"]):
-#         flowveldepth[fill_index, idx] = val
+    for upstream_tw_id in upstream_results:
+    tmp = upstream_results[upstream_tw_id]
+    fill_index = tmp["position_index"]
+    fill_index_mask[fill_index] = False
+    for idx, val in enumerate(tmp["results"]):
+        flowveldepth_nd[fill_index, (idx/3)+1] = val
 
     #Init buffers
     lateral_flows = np.zeros( max_buff_size, dtype='float32' )
@@ -1115,4 +1114,4 @@ cpdef object compute_network_structured(
     #slice off the initial condition timestep and return
     output = np.asarray(flowveldepth[:,1:,:], dtype='float32')
     #return np.asarray(data_idx, dtype=np.intp), np.asarray(flowveldepth.base.reshape(flowveldepth.shape[0], -1), dtype='float32')
-    return np.asarray(data_idx, dtype=np.intp), output.reshape(output.shape[0], -1)
+    return np.asarray(data_idx, dtype=np.intp), output.reshape(output.shape[0], -1)[fill_index_mask]

--- a/src/python_routing_v02/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/fast_reach/mc_reach.pyx
@@ -808,14 +808,6 @@ cpdef object compute_network_structured_obj(
                 (MC_Reach(segment_objects, array('l',upstream_ids)), reach_type)
                 )
 
-# TO DO place upstream flow vel and depth data into flowveldepth array to allow subnet parallel.
-#     for upstream_tw_id in upstream_results:
-#     tmp = upstream_results[upstream_tw_id]
-#     fill_index = tmp["position_index"]
-#     fill_index_mask[fill_index] = False
-#     for idx, val in enumerate(tmp["results"]):
-#         flowveldepth[fill_index, idx] = val
-    
     #Init buffers
     lateral_flows = np.zeros( max_buff_size, dtype='float32' )
     buf_view = np.zeros( (max_buff_size, 13), dtype='float32')
@@ -1026,6 +1018,14 @@ cpdef object compute_network_structured(
                 #tuple of MC_Reach and reach_type
                 MC_Reach(segment_objects, array('l',upstream_ids))
                 )
+            
+    # TO DO place upstream flow vel and depth data into flowveldepth array to allow subnet parallel.
+#     for upstream_tw_id in upstream_results:
+#     tmp = upstream_results[upstream_tw_id]
+#     fill_index = tmp["position_index"]
+#     fill_index_mask[fill_index] = False
+#     for idx, val in enumerate(tmp["results"]):
+#         flowveldepth[fill_index, idx] = val
 
     #Init buffers
     lateral_flows = np.zeros( max_buff_size, dtype='float32' )

--- a/src/python_routing_v02/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/fast_reach/mc_reach.pyx
@@ -1027,11 +1027,14 @@ cpdef object compute_network_structured(
     cdef float val
     
     for upstream_tw_id in upstream_results:
-    tmp = upstream_results[upstream_tw_id]
-    fill_index = tmp["position_index"]
-    fill_index_mask[fill_index] = False
-    for idx, val in enumerate(tmp["results"]):
-        flowveldepth_nd[fill_index, (idx/3)+1] = val
+        tmp = upstream_results[upstream_tw_id]
+        fill_index = tmp["position_index"]
+        fill_index_mask[fill_index] = False
+        for idx, val in enumerate(tmp["results"]):            
+            if idx == 0:
+                flowveldepth_nd[fill_index, idx+1, 0] = val
+            else:
+                flowveldepth_nd[fill_index, np.floor(idx/3).astype('int')+1, np.mod(idx,3)] = val
 
     #Init buffers
     lateral_flows = np.zeros( max_buff_size, dtype='float32' )
@@ -1114,4 +1117,4 @@ cpdef object compute_network_structured(
     #slice off the initial condition timestep and return
     output = np.asarray(flowveldepth[:,1:,:], dtype='float32')
     #return np.asarray(data_idx, dtype=np.intp), np.asarray(flowveldepth.base.reshape(flowveldepth.shape[0], -1), dtype='float32')
-    return np.asarray(data_idx, dtype=np.intp), output.reshape(output.shape[0], -1)[fill_index_mask]
+    return np.asarray(data_idx, dtype=np.intp)[fill_index_mask], output.reshape(output.shape[0], -1)[fill_index_mask]

--- a/src/python_routing_v02/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/fast_reach/mc_reach.pyx
@@ -1031,10 +1031,7 @@ cpdef object compute_network_structured(
         fill_index = tmp["position_index"]
         fill_index_mask[fill_index] = False
         for idx, val in enumerate(tmp["results"]):            
-            if idx == 0:
-                flowveldepth_nd[fill_index, idx+1, 0] = val
-            else:
-                flowveldepth_nd[fill_index, np.floor(idx/3).astype('int')+1, np.mod(idx,3)] = val
+            flowveldepth_nd[fill_index, np.floor(idx//3).astype('int')+1, idx%3] = val
 
     #Init buffers
     lateral_flows = np.zeros( max_buff_size, dtype='float32' )

--- a/src/python_routing_v02/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/fast_reach/mc_reach.pyx
@@ -1020,6 +1020,13 @@ cpdef object compute_network_structured(
                 )
             
     # TO DO place upstream flow vel and depth data into flowveldepth array to allow subnet parallel.
+#     cdef np.ndarray fill_index_mask = np.ones_like(data_idx, dtype=bool)
+#     cdef Py_ssize_t fill_index
+#     cdef long upstream_tw_id
+#     cdef dict tmp
+#     cdef int idx
+#     cdef float val
+    
 #     for upstream_tw_id in upstream_results:
 #     tmp = upstream_results[upstream_tw_id]
 #     fill_index = tmp["position_index"]

--- a/test/input/yaml/Croton_NY_levelpool.yaml
+++ b/test/input/yaml/Croton_NY_levelpool.yaml
@@ -1,8 +1,9 @@
 ---
 #initial input parameters
 run_parameters:
-    parallel_compute_method: by-subnetwork-jit  # OPTIONS: <omit flag for serial execution>, "by-network", "by-subnetwork-jit", "by-subnetwork-jit-clustered"
-    # subnetwork_target_size: 100  # by-subnetwork* requires a value here to identify the target subnetwork size.
+    parallel_compute_method: by-subnetwork-jit-clustered  # OPTIONS: <omit flag for serial execution>, "by-network", "by-subnetwork-jit", "by-subnetwork-jit-clustered"
+    cpu_pool: 4
+    subnetwork_target_size: 20  # by-subnetwork* requires a value here to identify the target subnetwork size.
     verbose: true  # verbose output (leave blank for quiet output.)
     showtiming: true  # set the showtiming (omit flag for no timing information.)
     debuglevel: 1  # set the debuglevel for additional console output.

--- a/test/input/yaml/Croton_NY_levelpool.yaml
+++ b/test/input/yaml/Croton_NY_levelpool.yaml
@@ -1,14 +1,14 @@
 ---
 #initial input parameters
 run_parameters:
-    parallel_compute_method: by-network  # OPTIONS: <omit flag for serial execution>, "by-network", "by-subnetwork-jit", "by-subnetwork-jit-clustered"
+    parallel_compute_method: by-subnetwork-jit  # OPTIONS: <omit flag for serial execution>, "by-network", "by-subnetwork-jit", "by-subnetwork-jit-clustered"
     # subnetwork_target_size: 100  # by-subnetwork* requires a value here to identify the target subnetwork size.
     verbose: true  # verbose output (leave blank for quiet output.)
     showtiming: true  # set the showtiming (omit flag for no timing information.)
     debuglevel: 1  # set the debuglevel for additional console output.
     break_network_at_waterbodies: true # replace waterbodies in the route-link dataset with segments representing the reservoir and calculate to divide the computation (leave blank for no splitting.)
                           # WARNING: `break_network_at_waterbodies: true` will only work if compute_method is set to "V02-structured-obj" and parallel_compute_method is unset (serial execution) or set to "by-network".
-    compute_method: V02-structured-obj  # OPTIONS: "V02-caching", "V02-structured-obj", "V02-structured"
+    compute_method: V02-structured  # OPTIONS: "V02-caching", "V02-structured-obj", "V02-structured"
     assume_short_ts: true  # use the previous timestep value for both current and previous flow.
     qts_subdivisions: 12  # number of timesteps per forcing (qlateral) timestep.
     dt: 300  # default timestep length, seconds


### PR DESCRIPTION
This pull requests enables by-subnetwork parallelization of the `compute_network_structured` routing compute method. The basic idea of these changes is to write the flow, velocity, and depth to the `flowveldepth` array for the upstream neighboring segments of a particular sub-network. 