### PR TITLE
[UPDATED (again)] Enabling by-subnetwork parallel in `mc_reach.compute_network_structured`

### DIFF
--- a/src/fortran_routing/Reservoir_Binding/Reservoirs/makefile
+++ b/src/fortran_routing/Reservoir_Binding/Reservoirs/makefile
@@ -1,4 +1,4 @@
-NETCDFINC := $(shell nc-config --fflags)
+NETCDFINC := -I$(NETCDFINC) $(shell nc-config --fflags)
 NETCDFLIB := $(shell nc-config --flibs)
 COMPILER90 = $(F90)
 F90FLAGS = -w -c -ffree-form -ffree-line-length-none -fconvert=big-endian -frecord-marker=4

--- a/src/python_routing_v02/compiler.sh
+++ b/src/python_routing_v02/compiler.sh
@@ -21,6 +21,7 @@ fi
 #export LIBRARY_PATH=<paths>:$LIBRARY_PATH
 #if you have custom dynamic library paths, uncomment below and export them
 #export LD_LIBRARY_PATHS=<paths>:$LD_LIBRARY_PATHS
+export NETCDFINC=/usr/include/openmpi-x86_64/
 
 
 if  [[ "$build_mc_kernel" == true ]]; then

--- a/src/python_routing_v02/troute/routing/compute.py
+++ b/src/python_routing_v02/troute/routing/compute.py
@@ -77,7 +77,14 @@ def compute_nhd_routing_v02(
             for subn_tw, subnet in ordered_subn_dict.items():
                 conn_subn = {k: connections[k] for k in subnet if k in connections}
                 rconn_subn = {k: rconn[k] for k in subnet if k in rconn}
-                path_func = partial(nhd_network.split_at_junction, rconn_subn)
+                if waterbodies_df.empty:
+                    path_func = partial(nhd_network.split_at_junction, rconn_subn)
+                else:
+                    path_func = partial(
+                        nhd_network.split_at_waterbodies_and_junctions,
+                        list(waterbodies_df.index.values),
+                        rconn_subn
+                        )
                 reaches_ordered_bysubntw[order][
                     subn_tw
                 ] = nhd_network.dfs_decomposition(rconn_subn, path_func)
@@ -150,13 +157,44 @@ def compute_nhd_routing_v02(
                                 offnetwork_upstreams.add(us)
 
                     segs.extend(offnetwork_upstreams)
+                    
+                    common_segs = list(param_df.index.intersection(segs))
+                    wbodies_segs = set(segs).symmetric_difference(common_segs)
+                    if not waterbodies_df.empty:
+                        lake_segs = list(waterbodies_df.index.intersection(segs))
+                        waterbodies_df_sub = waterbodies_df.loc[
+                            lake_segs,
+                            [
+                                "LkArea",
+                                "LkMxE",
+                                "OrificeA",
+                                "OrificeC",
+                                "OrificeE",
+                                "WeirC",
+                                "WeirE",
+                                "WeirL",
+                                "ifd",
+                                "qd0",
+                                "h0",
+                            ],
+                        ]
+
+                    else:
+                        lake_segs = []
+                        waterbodies_df_sub = pd.DataFrame()
+                    
                     param_df_sub = param_df.loc[
-                        segs,
+                        common_segs,
                         ["dt", "bw", "tw", "twcc", "dx", "n", "ncc", "cs", "s0", "alt"],
                     ].sort_index()
+                    
+                    param_df_sub_super = param_df_sub.reindex(
+                        param_df_sub.index.tolist() + lake_segs
+                    ).sort_index()
+                    
                     if order < max(subnetworks_only_ordered_jit.keys()):
                         for us_subn_tw in offnetwork_upstreams:
-                            subn_tw_sortposition = param_df_sub.index.get_loc(
+                            subn_tw_sortposition = param_df_sub_super.index.get_loc(
                                 us_subn_tw
                             )
                             flowveldepth_interorder[us_subn_tw][
@@ -178,20 +216,29 @@ def compute_nhd_routing_v02(
                     else:
                         usgs_df_sub = pd.DataFrame()
                         nudging_positions_list = []
+                        
+                    subn_reach_list_with_type = []
+                    for reaches in subn_reach_list:
+                        if set(reaches) & wbodies_segs:
+                            reach_type = 1  # type 1 for waterbody/lake
+                        else:
+                            reach_type = 0  # type 0 for reach
+
+                        reach_and_type_tuple = (reaches, reach_type)
+
+                        subn_reach_list_with_type.append(reach_and_type_tuple)
+
 
                     last_obs_sub = pd.DataFrame()
 
                     qlat_sub = qlats.loc[param_df_sub.index]
                     q0_sub = q0.loc[param_df_sub.index]
 
-                    # TODO: Wire in the proper reservoir distinction
-                    # At present, in by-subnetwork-jit/jit-clustered, these next two lines
-                    # only produce a dummy list, but...
-                    # Eventually, the wiring for reservoir simulation needs to be added.
-                    subn_reach_type_list = [0 for reaches in subn_reach_list]
-                    subn_reach_list_with_type = list(
-                        zip(subn_reach_list, subn_reach_type_list)
-                    )
+                    param_df_sub = param_df_sub.reindex(
+                        param_df_sub.index.tolist() + lake_segs
+                    ).sort_index()
+                    qlat_sub = qlat_sub.reindex(param_df_sub.index)
+                    q0_sub = q0_sub.reindex(param_df_sub.index)
 
                     # results_subn[order].append(
                     #     compute_func(
@@ -206,10 +253,8 @@ def compute_nhd_routing_v02(
                             param_df_sub.values,
                             q0_sub.values.astype("float32"),
                             qlat_sub.values.astype("float32"),
-                            [],  # lake_segs
-                            np.empty(
-                                shape=(0, 0), dtype="float64"
-                            ),  # waterbodies_df_sub.values
+                            lake_segs, 
+                            waterbodies_df_sub.values,
                             usgs_df_sub.values.astype("float32"),
                             # flowveldepth_interorder,  # obtain keys and values from this dataset
                             np.array(nudging_positions_list, dtype="int32"),
@@ -271,7 +316,14 @@ def compute_nhd_routing_v02(
             for subn_tw, subnet in ordered_subn_dict.items():
                 conn_subn = {k: connections[k] for k in subnet if k in connections}
                 rconn_subn = {k: rconn[k] for k in subnet if k in rconn}
-                path_func = partial(nhd_network.split_at_junction, rconn_subn)
+                if waterbodies_df.empty:
+                    path_func = partial(nhd_network.split_at_junction, rconn_subn)
+                else:
+                    path_func = partial(
+                        nhd_network.split_at_waterbodies_and_junctions,
+                        list(waterbodies_df.index.values),
+                        rconn_subn
+                        )
                 reaches_ordered_bysubntw[order][
                     subn_tw
                 ] = nhd_network.dfs_decomposition(rconn_subn, path_func)
@@ -301,13 +353,44 @@ def compute_nhd_routing_v02(
                                 offnetwork_upstreams.add(us)
 
                     segs.extend(offnetwork_upstreams)
+                    
+                    common_segs = list(param_df.index.intersection(segs))
+                    wbodies_segs = set(segs).symmetric_difference(common_segs)
+                    if not waterbodies_df.empty:
+                        lake_segs = list(waterbodies_df.index.intersection(segs))
+                        waterbodies_df_sub = waterbodies_df.loc[
+                            lake_segs,
+                            [
+                                "LkArea",
+                                "LkMxE",
+                                "OrificeA",
+                                "OrificeC",
+                                "OrificeE",
+                                "WeirC",
+                                "WeirE",
+                                "WeirL",
+                                "ifd",
+                                "qd0",
+                                "h0",
+                            ],
+                        ]
+
+                    else:
+                        lake_segs = []
+                        waterbodies_df_sub = pd.DataFrame()
+                    
                     param_df_sub = param_df.loc[
-                        segs,
+                        common_segs,
                         ["dt", "bw", "tw", "twcc", "dx", "n", "ncc", "cs", "s0", "alt"],
                     ].sort_index()
+                    
+                    param_df_sub_super = param_df_sub.reindex(
+                        param_df_sub.index.tolist() + lake_segs
+                    ).sort_index()
+                    
                     if order < max(subnetworks_only_ordered_jit.keys()):
                         for us_subn_tw in offnetwork_upstreams:
-                            subn_tw_sortposition = param_df_sub.index.get_loc(
+                            subn_tw_sortposition = param_df_sub_super.index.get_loc(
                                 us_subn_tw
                             )
                             flowveldepth_interorder[us_subn_tw][
@@ -326,19 +409,28 @@ def compute_nhd_routing_v02(
                     else:
                         usgs_df_sub = pd.DataFrame()
                         nudging_positions_list = []
+                        
+                    subn_reach_list_with_type = []
+                    for reaches in subn_reach_list:
+                        if set(reaches) & wbodies_segs:
+                            reach_type = 1  # type 1 for waterbody/lake
+                        else:
+                            reach_type = 0  # type 0 for reach
+
+                        reach_and_type_tuple = (reaches, reach_type)
+
+                        subn_reach_list_with_type.append(reach_and_type_tuple)
 
                     last_obs_sub = pd.DataFrame()
 
                     qlat_sub = qlats.loc[param_df_sub.index]
                     q0_sub = q0.loc[param_df_sub.index]
 
-                    # At present, in by-subnetwork-jit/jit-clustered, these next two lines
-                    # only produce a dummy list, but...
-                    # Eventually, the wiring for reservoir simulation needs to be added.
-                    subn_reach_type_list = [0 for reaches in subn_reach_list]
-                    subn_reach_list_with_type = list(
-                        zip(subn_reach_list, subn_reach_type_list)
-                    )
+                    param_df_sub = param_df_sub.reindex(
+                        param_df_sub.index.tolist() + lake_segs
+                    ).sort_index()
+                    qlat_sub = qlat_sub.reindex(param_df_sub.index)
+                    q0_sub = q0_sub.reindex(param_df_sub.index)
 
                     jobs.append(
                         delayed(compute_func)(
@@ -351,13 +443,12 @@ def compute_nhd_routing_v02(
                             param_df_sub.values,
                             q0_sub.values.astype("float32"),
                             qlat_sub.values.astype("float32"),
-                            [],  # lake_segs
-                            np.empty(
-                                shape=(0, 0), dtype="float64"
-                            ),  # waterbodies_df_sub.values
+                            lake_segs,
+                            waterbodies_df_sub.values,
                             usgs_df_sub.values.astype("float32"),
                             # flowveldepth_interorder,  # obtain keys and values from this dataset
                             np.array(nudging_positions_list, dtype="int32"),
+                            last_obs_sub.values.astype("float32"),
                             {
                                 us: fvd
                                 for us, fvd in flowveldepth_interorder.items()

--- a/src/python_routing_v02/troute/routing/compute.py
+++ b/src/python_routing_v02/troute/routing/compute.py
@@ -160,6 +160,10 @@ def compute_nhd_routing_v02(
                     
                     common_segs = list(param_df.index.intersection(segs))
                     wbodies_segs = set(segs).symmetric_difference(common_segs)
+                    
+                    #Declare empty dataframe
+                    waterbody_types_df_sub = pd.DataFrame()
+                
                     if not waterbodies_df.empty:
                         lake_segs = list(waterbodies_df.index.intersection(segs))
                         waterbodies_df_sub = waterbodies_df.loc[
@@ -178,6 +182,15 @@ def compute_nhd_routing_v02(
                                 "h0",
                             ],
                         ]
+                        
+                        #If reservoir types other than Level Pool are active
+                        if not waterbody_types_df.empty:
+                            waterbody_types_df_sub = waterbody_types_df.loc[
+                                lake_segs,
+                                [
+                                    "reservoir_type",
+                                ],
+                            ]
 
                     else:
                         lake_segs = []
@@ -233,6 +246,21 @@ def compute_nhd_routing_v02(
 
                     qlat_sub = qlats.loc[param_df_sub.index]
                     q0_sub = q0.loc[param_df_sub.index]
+                    
+                    #Determine model_start_time from qlat_start_time
+                    qlat_start_time = list(qlat_sub)[0]
+
+                    qlat_time_step_seconds = qts_subdivisions * dt
+
+                    if not isinstance(qlat_start_time,datetime):
+                        qlat_start_time_datetime_object = datetime.strptime(qlat_start_time, '%Y-%m-%d %H:%M:%S')
+                    else:
+                        qlat_start_time_datetime_object =  qlat_start_time
+
+                    model_start_time_datetime_object = qlat_start_time_datetime_object \
+                    - timedelta(seconds=qlat_time_step_seconds)
+
+                    model_start_time = model_start_time_datetime_object.strftime('%Y-%m-%d_%H:%M:%S')
 
                     param_df_sub = param_df_sub.reindex(
                         param_df_sub.index.tolist() + lake_segs
@@ -255,6 +283,10 @@ def compute_nhd_routing_v02(
                             qlat_sub.values.astype("float32"),
                             lake_segs, 
                             waterbodies_df_sub.values,
+                            waterbody_parameters,
+                            waterbody_types_df_sub.values.astype("int32"),
+                            waterbody_type_specified,
+                            model_start_time,
                             usgs_df_sub.values.astype("float32"),
                             # flowveldepth_interorder,  # obtain keys and values from this dataset
                             np.array(nudging_positions_list, dtype="int32"),
@@ -356,6 +388,10 @@ def compute_nhd_routing_v02(
                     
                     common_segs = list(param_df.index.intersection(segs))
                     wbodies_segs = set(segs).symmetric_difference(common_segs)
+                    
+                    #Declare empty dataframe
+                    waterbody_types_df_sub = pd.DataFrame()
+                
                     if not waterbodies_df.empty:
                         lake_segs = list(waterbodies_df.index.intersection(segs))
                         waterbodies_df_sub = waterbodies_df.loc[
@@ -374,6 +410,15 @@ def compute_nhd_routing_v02(
                                 "h0",
                             ],
                         ]
+                        
+                        #If reservoir types other than Level Pool are active
+                        if not waterbody_types_df.empty:
+                            waterbody_types_df_sub = waterbody_types_df.loc[
+                                lake_segs,
+                                [
+                                    "reservoir_type",
+                                ],
+                            ]
 
                     else:
                         lake_segs = []
@@ -425,6 +470,21 @@ def compute_nhd_routing_v02(
 
                     qlat_sub = qlats.loc[param_df_sub.index]
                     q0_sub = q0.loc[param_df_sub.index]
+                    
+                    #Determine model_start_time from qlat_start_time
+                    qlat_start_time = list(qlat_sub)[0]
+
+                    qlat_time_step_seconds = qts_subdivisions * dt
+
+                    if not isinstance(qlat_start_time,datetime):
+                        qlat_start_time_datetime_object = datetime.strptime(qlat_start_time, '%Y-%m-%d %H:%M:%S')
+                    else:
+                        qlat_start_time_datetime_object =  qlat_start_time
+
+                    model_start_time_datetime_object = qlat_start_time_datetime_object \
+                    - timedelta(seconds=qlat_time_step_seconds)
+
+                    model_start_time = model_start_time_datetime_object.strftime('%Y-%m-%d_%H:%M:%S')
 
                     param_df_sub = param_df_sub.reindex(
                         param_df_sub.index.tolist() + lake_segs
@@ -445,6 +505,10 @@ def compute_nhd_routing_v02(
                             qlat_sub.values.astype("float32"),
                             lake_segs,
                             waterbodies_df_sub.values,
+                            waterbody_parameters,
+                            waterbody_types_df_sub.values.astype("int32"),
+                            waterbody_type_specified,
+                            model_start_time,
                             usgs_df_sub.values.astype("float32"),
                             # flowveldepth_interorder,  # obtain keys and values from this dataset
                             np.array(nudging_positions_list, dtype="int32"),

--- a/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
@@ -1154,6 +1154,20 @@ cpdef object compute_network_structured(
                 #tuple of MC_Reach and reach_type
                 MC_Reach(segment_objects, array('l',upstream_ids))
                 )
+            
+    cdef np.ndarray fill_index_mask = np.ones_like(data_idx, dtype=bool)
+    cdef Py_ssize_t fill_index
+    cdef long upstream_tw_id
+    cdef dict tmp
+    cdef int idx
+    cdef float val
+
+    for upstream_tw_id in upstream_results:
+        tmp = upstream_results[upstream_tw_id]
+        fill_index = tmp["position_index"]
+        fill_index_mask[fill_index] = False
+        for idx, val in enumerate(tmp["results"]):
+            flowveldepth_nd[fill_index, np.floor(idx//3).astype('int')+1, idx%3] = val
 
     #Init buffers
     lateral_flows = np.zeros( max_buff_size, dtype='float32' )
@@ -1246,4 +1260,4 @@ cpdef object compute_network_structured(
     #slice off the initial condition timestep and return
     output = np.asarray(flowveldepth[:,1:,:], dtype='float32')
     #return np.asarray(data_idx, dtype=np.intp), np.asarray(flowveldepth.base.reshape(flowveldepth.shape[0], -1), dtype='float32')
-    return np.asarray(data_idx, dtype=np.intp), output.reshape(output.shape[0], -1)
+    return np.asarray(data_idx, dtype=np.intp)[fill_index_mask], output.reshape(output.shape[0], -1)[fill_index_mask]

--- a/test/input/yaml/Croton_NY_levelpool.yaml
+++ b/test/input/yaml/Croton_NY_levelpool.yaml
@@ -1,14 +1,14 @@
 ---
 #initial input parameters
 run_parameters:
-    #parallel_compute_method: by-network  # OPTIONS: <omit flag for serial execution>, "by-network", "by-subnetwork-jit", "by-subnetwork-jit-clustered"
-    # subnetwork_target_size: 100  # by-subnetwork* requires a value here to identify the target subnetwork size.
+    parallel_compute_method: by-subnetwork-jit  # OPTIONS: <omit flag for serial execution>, "by-network", "by-subnetwork-jit", "by-subnetwork-jit-clustered"
+    subnetwork_target_size: 20  # by-subnetwork* requires a value here to identify the target subnetwork size.
     verbose: true  # verbose output (leave blank for quiet output.)
     showtiming: true  # set the showtiming (omit flag for no timing information.)
     debuglevel: 1  # set the debuglevel for additional console output.
     break_network_at_waterbodies: true # replace waterbodies in the route-link dataset with segments representing the reservoir and calculate to divide the computation (leave blank for no splitting.)
                           # WARNING: `break_network_at_waterbodies: true` will only work if compute_kernel is set to "V02-structured-obj" and parallel_compute_method is unset (serial execution) or set to "by-network".
-    compute_kernel: V02-structured-obj  # OPTIONS: "V02-caching", "V02-structured-obj", "V02-structured"
+    compute_kernel: V02-structured  # OPTIONS: "V02-caching", "V02-structured-obj", "V02-structured"
     assume_short_ts: true  # use the previous timestep value for both current and previous flow.
     qts_subdivisions: 12  # number of timesteps per forcing (qlateral) timestep.
     dt: 300  # default timestep length, seconds


### PR DESCRIPTION
This pull requests enables by-subnetwork parallelization of the compute_network_structured routing compute method. The basic idea of these changes is to write the flow, velocity, and depth to the flowveldepth array for the upstream neighboring segments of a particular sub-network.
