### PR TITLE
DA compatibility with structured compute method 

### DIFF
--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -495,7 +495,7 @@ def main_v02(argv):
         if verbose:
             print("creating usgs time_slice data array ...")
 
-        usgs_df = nnu.build_data_assimilation(data_assimilation_parameters)
+        usgs_df, _ = nnu.build_data_assimilation(data_assimilation_parameters)
 
         if verbose:
             print("usgs array complete")

--- a/src/python_routing_v02/troute/routing/compute.py
+++ b/src/python_routing_v02/troute/routing/compute.py
@@ -768,7 +768,10 @@ def compute_nhd_routing_v02(
 
             qlat_time_step_seconds = qts_subdivisions * dt
 
-            qlat_start_time_datetime_object = datetime.strptime(qlat_start_time, '%Y-%m-%d %H:%M:%S')
+            if not isinstance(qlat_start_time,datetime):
+                qlat_start_time_datetime_object = datetime.strptime(qlat_start_time, '%Y-%m-%d %H:%M:%S')
+            else:
+                qlat_start_time_datetime_object =  qlat_start_time
 
             model_start_time_datetime_object = qlat_start_time_datetime_object \
             - timedelta(seconds=qlat_time_step_seconds)

--- a/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
@@ -1172,7 +1172,7 @@ cpdef object compute_network_structured(
     cdef int idx
     cdef float val
 
-    for upstream_tw_id in upstream_results: 
+    for upstream_tw_id in upstream_results:
         tmp = upstream_results[upstream_tw_id]
         fill_index = tmp["position_index"]
         fill_index_mask[fill_index] = False

--- a/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
@@ -1055,8 +1055,7 @@ cpdef object compute_network_structured(
     # list of reach objects to operate on
     cdef list reach_objects = []
     cdef list segment_objects
-    #pre compute the qlat resample fraction
-    cdef double qlat_resample = (nsteps)/qlat_values.shape[1]
+    cdef int qvd_ts_w = 3  # There are 3 values per timestep (corresponding to 3 columns per timestep)
 
     cdef long sid
     cdef _MC_Segment segment
@@ -1178,7 +1177,7 @@ cpdef object compute_network_structured(
         fill_index = tmp["position_index"]
         fill_index_mask[fill_index] = False
         for idx, val in enumerate(tmp["results"]):
-            flowveldepth_nd[fill_index, (idx//3) + 1, idx%3] = val
+            flowveldepth_nd[fill_index, (idx//qvd_ts_w) + 1, idx%qvd_ts_w] = val
             flowveldepth_nd[fill_index, 0, 0] = init_array[fill_index, 0] # initial flow condition
             flowveldepth_nd[fill_index, 0, 2] = init_array[fill_index, 2] # initial depth condition
 

--- a/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
@@ -1173,12 +1173,14 @@ cpdef object compute_network_structured(
     cdef int idx
     cdef float val
 
-    for upstream_tw_id in upstream_results:
+    for upstream_tw_id in upstream_results:  
         tmp = upstream_results[upstream_tw_id]
         fill_index = tmp["position_index"]
         fill_index_mask[fill_index] = False
         for idx, val in enumerate(tmp["results"]):
-            flowveldepth_nd[fill_index, np.floor(idx//3).astype('int')+1, idx%3] = val
+            flowveldepth_nd[fill_index, (idx//3) + 1, idx%3] = val
+            flowveldepth_nd[fill_index, 0, 0] = init_array[fill_index, 0] # initial flow condition
+            flowveldepth_nd[fill_index, 0, 2] = init_array[fill_index, 2] # initial depth condition
 
     #Init buffers
     lateral_flows = np.zeros( max_buff_size, dtype='float32' )

--- a/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
@@ -1172,7 +1172,7 @@ cpdef object compute_network_structured(
     cdef int idx
     cdef float val
 
-    for upstream_tw_id in upstream_results:  
+    for upstream_tw_id in upstream_results: 
         tmp = upstream_results[upstream_tw_id]
         fill_index = tmp["position_index"]
         fill_index_mask[fill_index] = False

--- a/test/input/yaml/Florence_Benchmark_da.yaml
+++ b/test/input/yaml/Florence_Benchmark_da.yaml
@@ -1,21 +1,17 @@
 ---
 #initial input parameters
 run_parameters:
-    parallel_compute_method: by-subnetwork-jit-clustered  # OPTIONS: <omit flag for serial execution>, "by-network", "by-subnetwork-jit", "by-subnetwork-jit-clustered"
+    parallel_compute_method: by-network # OPTIONS: <omit flag for serial execution>, "by-network", "by-subnetwork-jit", "by-subnetwork-jit-clustered"
     subnetwork_target_size: 100  # by-subnetwork* requires a value here to identify the target subnetwork size.
     cpu_pool: 8
-    #verbose: true  # verbose output (leave blank for quiet output.)
-    #showtiming: true  # set the showtiming (omit flag for no timing information.)
-    #debuglevel: 1  # set the debuglevel for additional console output.
-    # break_network_at_waterbodies: true # replace waterbodies in the route-link dataset with segments representing the reservoir and calculate to divide the computation (leave blank for no splitting.)
-                          # WARNING: `break_network_at_waterbodies: true` will only work if compute_method is set to "V02-structured-obj" and parallel_compute_method is unset (serial execution) or set to "by-network".
+    verbose: true  # verbose output (leave blank for quiet output.)
+    showtiming: true  # set the showtiming (omit flag for no timing information.)
     break_network_at_gages: true  # Ensures gages are in a reach by themselves.
-    # compute_method: V02-structured-obj  # OPTIONS: "V02-caching", "V02-structured-obj", "V02-structured"
+    compute_method: V02-caching  # OPTIONS: "V02-caching", "V02-structured-obj", "V02-structured"
     assume_short_ts: true  # use the previous timestep value for both current and previous flow.
     qts_subdivisions: 12  # number of timesteps per forcing (qlateral) timestep.
     dt: 300  # default timestep length, seconds
     nts: 85  # number of timesteps to simulate. If used with ql_file or ql_folder, nts must be less than the number of ql inputs x qts_subdivisions.
-    # nts: 288  # number of timesteps to simulate. If used with ql_file or ql_folder, nts must be less than the number of ql inputs x qts_subdivisions.
     return_courant: false  # WARNING: true will only work with compute_method "V02-caching", therefore not currently compatible with simulation for waterbodies.
 #output file parameters
 output_parameters: {}
@@ -24,8 +20,6 @@ supernetwork_parameters:
     title_string: "Florence_FullRes"
     geo_file_path: "../../test/input/florence_fullres/florenceNudgingChannelOnly/DOMAIN/Route_Link.nc"
     mask_file_path: "../../test/input/florence_fullres/florenceNudgingChannelOnly/florence_fullres_mask_tw10975909_gage8777381.txt"
-    # mask_file_path: "../../test/input/florence_fullres/florenceNudgingChannelOnly/florence_fullres_mask_tw8777381_gage8777381.txt"
-    # mask_file_path: "../../test/input/florence_fullres/florenceNudgingChannelOnly/florence_fullres_mask_tw8777535_gage8777381.txt"
     mask_layer_string: ""
     mask_driver_string: "csv"
     mask_key: 0
@@ -49,7 +43,6 @@ supernetwork_parameters:
     terminal_code: 0
     driver_string: NetCDF
     layer_string: 0
-
 #waterbody parameters and assignments from lake parm file
 waterbody_parameters:
     level_pool:
@@ -76,7 +69,6 @@ forcing_parameters:
 restart_parameters:
     #WRF-Hydro channels restart file
     wrf_hydro_channel_restart_file: "../../test/input/florence_fullres/florenceNudgingChannelOnly/HYDRO_RST/HYDRO_RST.2018-09-18_00:00_DOMAIN1"
-    # wrf_hydro_channel_restart_file: "../../test/input/florence_fullres/florenceNudgingChannelOnly/RESTART_open-loop/HYDRO_RST.2018-09-10_00:00_DOMAIN1"
     #WRF-Hydro channels ID crosswalk file
     # florence_testcase/florence_933020089/DOMAIN
     wrf_hydro_channel_ID_crosswalk_file: "../../test/input/florence_fullres/florenceNudgingChannelOnly/DOMAIN/Route_Link.nc"
@@ -111,8 +103,6 @@ parity_parameters:
     # parity_check_file: "florence_streamflow_test.csv.hourly"
     parity_check_file_index_col: feature_id
     parity_check_file_value_col: streamflow
-    # parity_check_compare_node: 933020089 # contains only Nan in WRF simulations including waterbodies
-    # parity_check_compare_node: 8835386
     parity_check_compare_node: 10975909
     # parity_check_compare_node: 8778771  # Headwater
     # parity_check_compare_node: 8778459  # Midwater

--- a/test/input/yaml/Florence_Benchmark_da.yaml
+++ b/test/input/yaml/Florence_Benchmark_da.yaml
@@ -13,8 +13,13 @@ run_parameters:
     dt: 300  # default timestep length, seconds
     nts: 85  # number of timesteps to simulate. If used with ql_file or ql_folder, nts must be less than the number of ql inputs x qts_subdivisions.
     return_courant: false  # WARNING: true will only work with compute_method "V02-caching", therefore not currently compatible with simulation for waterbodies.
-#output file parameters
-output_parameters: {}
+output_parameters:
+    #output location for csv file 
+    csv_output:
+        csv_output_folder: {}
+        csv_output_segments: {}
+    #out location for nc file
+    nc_output_folder: {}
 #data column assignment inside supernetwork_parameters
 supernetwork_parameters:
     title_string: "Florence_FullRes"


### PR DESCRIPTION
This pull requests suggest three contributions to the codebase:
# Data assimilation (no decay) compatibility with structured compute method
The basic workflow of replacing flow simulations with gage observations is borrowed from the `mc_reach.compute_network` method and implemented in `mc_reach.compute_network_structured`. This is an important contribution because data assimilation is otherwise not possible in `mc_reach.compute_network_structured`. Moreover, `mc_reach.compute_network_structured` is the only compute scheme capable of handling reservoirs. This update gives us the capability to include both reservoirs and DA into a routing simulation. 

At this time, DA decay is not yet included and will be considered in a forthcoming PR.  

# Bug fix - qlateral subdivision in structured compute
The scheme used to sub-sample WRF-Hydro qlateral data in `mc_reach.compute_network_structured` was incorrect. This has been corrected. 
# Bug fix - initial conditions handling in structured compute with by-subnetwork parallel
Initial conditions for off-network upstream segments in `mc_reach.compute_network_structured` under by-subnetwork parallel were being left out of simulations. This bug fixes positions these initial conditions in the correct spot of the `flowveldepth` array.