### PR TITLE
Interior terminal nodes

### DIFF
--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -323,11 +323,11 @@ def main_v02(argv):
         start_time = time.time()
 
     # STEP 1: Build basic network connections graph
-    connections, param_df, wbodies, gages = nnu.build_connections(
+    connections, param_df, wbody_conn, gages = nnu.build_connections(
         supernetwork_parameters
     )
     if break_network_at_waterbodies:
-        connections = nhd_network.replace_waterbodies_connections(connections, wbodies)
+        connections = nhd_network.replace_waterbodies_connections(connections, wbody_conn)
 
     if verbose:
         print("supernetwork connections set complete")
@@ -345,7 +345,7 @@ def main_v02(argv):
     if break_network_at_waterbodies:
         # Read waterbody parameters
         waterbodies_df = nhd_io.read_waterbody_df(
-            waterbody_parameters, {"level_pool": wbodies.values()}
+            waterbody_parameters, {"level_pool": wbody_conn.values()}
         )
 
         # Remove duplicate lake_ids and rows
@@ -374,7 +374,7 @@ def main_v02(argv):
             waterbody_type_specified = True
 
             waterbody_types_df = nhd_io.read_reservoir_parameter_file(wb_params_hybrid_and_rfc["reservoir_parameter_file"], \
-                wb_params_level_pool["level_pool_waterbody_id"], wbodies.values(),) 
+                wb_params_level_pool["level_pool_waterbody_id"], wbody_conn.values(),)
 
             # Remove duplicate lake_ids and rows
             waterbody_types_df = (
@@ -530,7 +530,7 @@ def main_v02(argv):
     results = compute_nhd_routing_v02(
         connections,
         rconn,
-        wbodies,
+        wbody_conn,
         reaches_bytw,
         compute_func,
         run_parameters.get("parallel_compute_method", None),
@@ -856,7 +856,7 @@ def main_v03(argv):
     (
         connections,
         param_df,
-        wbodies,
+        wbody_conn,
         waterbodies_df,
         waterbody_types_df,
         break_network_at_waterbodies,
@@ -930,7 +930,7 @@ def main_v03(argv):
         run_results = nwm_route(
             connections,
             rconn,
-            wbodies,
+            wbody_conn,
             reaches_bytw,
             parallel_compute_method,
             compute_kernel,

--- a/src/nwm_routing/src/nwm_routing/preprocess.py
+++ b/src/nwm_routing/src/nwm_routing/preprocess.py
@@ -21,7 +21,7 @@ def nwm_network_preprocess(
 
     # STEP 1: Build basic network connections graph,
     # read network parameters, identify waterbodies and gages, if any.
-    connections, param_df, wbodies, gages = nnu.build_connections(
+    connections, param_df, wbody_conn, gages = nnu.build_connections(
         supernetwork_parameters,
     )
 
@@ -33,12 +33,12 @@ def nwm_network_preprocess(
     )
 
     if (
-        not wbodies
+        not wbody_conn
     ):  # Turn off any further reservoir processing if the network contains no waterbodies
         break_network_at_waterbodies = False
 
     if break_network_at_waterbodies:
-        connections = nhd_network.replace_waterbodies_connections(connections, wbodies)
+        connections = nhd_network.replace_waterbodies_connections(connections, wbody_conn)
 
     if verbose:
         print("supernetwork connections set complete")
@@ -54,7 +54,7 @@ def nwm_network_preprocess(
     if break_network_at_waterbodies:
         # Read waterbody parameters
         waterbodies_df = nhd_io.read_waterbody_df(
-            waterbody_parameters, {"level_pool": wbodies.values()}
+            waterbody_parameters, {"level_pool": wbody_conn.values()}
         )
 
         # Remove duplicate lake_ids and rows
@@ -84,7 +84,7 @@ def nwm_network_preprocess(
             waterbody_type_specified = True
 
             waterbody_types_df = nhd_io.read_reservoir_parameter_file(wb_params_hybrid_and_rfc["reservoir_parameter_file"], \
-                wb_params_level_pool["level_pool_waterbody_id"], wbodies.values(),) 
+                wb_params_level_pool["level_pool_waterbody_id"], wbody_conn.values(),)
 
             # Remove duplicate lake_ids and rows
             waterbody_types_df = (
@@ -106,7 +106,7 @@ def nwm_network_preprocess(
 
     network_break_segments = set()
     if break_network_at_waterbodies:
-        network_break_segments = network_break_segments.union(wbodies.values())
+        network_break_segments = network_break_segments.union(wbody_conn.values())
     if break_network_at_gages:
         network_break_segments = network_break_segments.union(gages.keys())
 
@@ -121,10 +121,10 @@ def nwm_network_preprocess(
     return (
         connections,
         param_df,
-        wbodies,
+        wbody_conn,
         waterbodies_df,
         waterbody_types_df,
-        break_network_at_waterbodies,  # Could this be inferred from the wbodies or waterbodies_df  # Could this be inferred from the wbodies or waterbodies_df? Consider making this name less about the network and more about the reservoir simulation.
+        break_network_at_waterbodies,  # Could this be inferred from the wbody_conn or waterbodies_df  # Could this be inferred from the wbody_conn or waterbodies_df? Consider making this name less about the network and more about the reservoir simulation.
         waterbody_type_specified,  # Seems like this could be inferred from waterbody_types_df...
         independent_networks,
         reaches_bytw,

--- a/src/python_framework_v02/troute/nhd_network.py
+++ b/src/python_framework_v02/troute/nhd_network.py
@@ -42,7 +42,7 @@ def out_degrees(N):
     return in_degrees(reverse_network(N))
 
 
-def extract_connections(rows, target_col, terminal_code=0):
+def extract_connections(rows, target_col, terminal_codes={0}):
     """Extract connection network from dataframe.
 
     Arguments:
@@ -58,7 +58,7 @@ def extract_connections(rows, target_col, terminal_code=0):
         if src not in network:
             network[src] = []
 
-        if dst > 0:
+        if dst not in terminal_codes:
             network[src].append(dst)
     return network
 

--- a/src/python_framework_v02/troute/nhd_network.py
+++ b/src/python_framework_v02/troute/nhd_network.py
@@ -63,7 +63,7 @@ def extract_connections(rows, target_col, terminal_codes={0}):
     return network
 
 
-def extract_waterbodies(rows, target_col, waterbody_null=-9999):
+def extract_waterbody_connections(rows, target_col, waterbody_null=-9999):
     """Extract waterbody mapping from dataframe."""
     return (
         rows.loc[rows[target_col] != waterbody_null, target_col].astype("int").to_dict()

--- a/src/python_framework_v02/troute/nhd_network.py
+++ b/src/python_framework_v02/troute/nhd_network.py
@@ -42,7 +42,7 @@ def out_degrees(N):
     return in_degrees(reverse_network(N))
 
 
-def extract_connections(rows, target_col, terminal_codes={0}):
+def extract_connections(rows, target_col, terminal_codes=None):
     """Extract connection network from dataframe.
 
     Arguments:
@@ -53,6 +53,11 @@ def extract_connections(rows, target_col, terminal_codes={0}):
     Returns:
         (dict)
     """
+    if terminal_codes is not None:
+        terminal_codes = set(terminal_codes)
+    else:
+        terminal_codes = {0}
+
     network = {}
     for src, dst in rows[target_col].items():
         if src not in network:

--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -450,13 +450,17 @@ def build_connections(supernetwork_parameters):
     terminal_codes.add(terminal_code)
     # ... but there may also be off-domain nodes that are not explicitly identified
     # but which are terminal (i.e., off-domain) as a result of a mask or some other
-    # an interior domain truncation that results in a 
-    # otherwise valid node value being pointed to, but which is masked out or 
+    # an interior domain truncation that results in a
+    # otherwise valid node value being pointed to, but which is masked out or
     # being intentionally separated into another domain.
-    terminal_codes = terminal_codes | set(param_df[~param_df["downstream"].isin(param_df.index)]["downstream"].values)
-    connections = nhd_network.extract_connections(param_df, "downstream", terminal_codes)
+    terminal_codes = terminal_codes | set(
+        param_df[~param_df["downstream"].isin(param_df.index)]["downstream"].values
+    )
+    connections = nhd_network.extract_connections(
+        param_df, "downstream", terminal_codes=terminal_codes
+    )
     param_df = param_df.drop("downstream", axis=1)
-    
+
     param_df = param_df.astype("float32")
 
     # datasub = data[['dt', 'bw', 'tw', 'twcc', 'dx', 'n', 'ncc', 'cs', 's0']]

--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -445,7 +445,16 @@ def build_connections(supernetwork_parameters):
         gages = build_gages(param_df[["gages"]])
         param_df = param_df.drop("gages", axis=1)
 
-    connections = nhd_network.extract_connections(param_df, "downstream")
+    # There can be an externally determined terminal code -- that's this first value
+    terminal_codes = set()
+    terminal_codes.add(terminal_code)
+    # ... but there may also be off-domain nodes that are not explicitly identified
+    # but which are terminal (i.e., off-domain) as a result of a mask or some other
+    # an interior domain truncation that results in a 
+    # otherwise valid node value being pointed to, but which is masked out or 
+    # being intentionally separated into another domain.
+    terminal_codes = terminal_codes | set(param_df[~param_df["downstream"].isin(param_df.index)]["downstream"].values)
+    connections = nhd_network.extract_connections(param_df, "downstream", terminal_codes)
     param_df = param_df.drop("downstream", axis=1)
     
     param_df = param_df.astype("float32")

--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -481,7 +481,7 @@ def build_waterbodies(
     supernetwork_parameters
     waterbody_crosswalk_column
     """
-    wbodies = nhd_network.extract_waterbodies(
+    wbody_conn = nhd_network.extract_waterbody_connections(
         segment_reservoir_df,
         waterbody_crosswalk_column,
         supernetwork_parameters["waterbody_null_code"],
@@ -490,7 +490,7 @@ def build_waterbodies(
     # TODO: Add function to read LAKEPARM.nc here
     # TODO: return the lakeparam_df
 
-    return wbodies
+    return wbody_conn
 
 
 def organize_independent_networks(connections, wbodies=None):

--- a/src/python_framework_v02/troute/test_nhd_network.py
+++ b/src/python_framework_v02/troute/test_nhd_network.py
@@ -1,0 +1,200 @@
+reservoir_ids = [401, 402, 403]
+network_clean = [
+    [0, 456, -999, 0],
+    [1, 178, 4, 0],
+    [2, 394, 0, 0],
+    [3, 301, 2, 0],
+    [4, 798, 0, 403],
+    [5, 679, 4, 403],
+    [6, 523, 0, 0],
+    [7, 815, 2, 0],
+    [8, 841, -999, 0],
+    [9, 514, 8, 0],
+    [10, 458, 9, 0],
+    [11, 832, 10, 0],
+    [12, 543, 11, 0],
+    [13, 240, 12, 0],
+    [14, 548, 13, 0],
+    [15, 920, 14, 0],
+    [16, 920, 15, 401],
+    [17, 514, 16, 401],
+    [18, 458, 17, 0],
+    [180, 458, 17, 0],
+    [181, 458, 180, 0],
+    [19, 832, 18, 0],
+    [20, 543, 19, 0],
+    [21, 240, 16, 401],
+    [22, 548, 21, 0],
+    [23, 920, 22, 0],
+    [24, 240, 23, 0],
+    [25, 548, 12, 0],
+    [26, 920, 25, 402],
+    [27, 920, 26, 402],
+    [28, 920, 27, 0],
+    [2800, 920, 2700, 0],
+]
+# Should create independent networks with terminal nodes at 2800, 0, and 8
+
+# 50-21, 60-62, 70-73, 81-84 are sets of circular networks, 
+# which is an error and should be filtered
+network_circulars = [
+    [50, 178, 51, 0],
+    [51, 178, 50, 0],
+    [60, 178, 61, 0],
+    [61, 178, 62, 0],
+    [62, 178, 60, 0],
+    [70, 178, 71, 0],
+    [71, 178, 72, 0],
+    [72, 178, 73, 0],
+    [73, 178, 70, 0],
+    [80, 178, 81, 0],
+    [81, 178, 82, 0],
+    [82, 178, 83, 0],
+    [83, 178, 84, 0],
+    [84, 178, 80, 0],
+    [0, 456, -999, 0],
+    [1, 178, 4, 0],
+    [2, 394, 0, 0],
+    [3, 301, 2, 0],
+    [4, 798, 0, 0],
+    [5, 679, 4, 0],
+    [6, 523, 0, 0],
+    [7, 815, 2, 0],
+    [8, 841, -999, 0],
+    [9, 514, 8, 0],
+    [10, 458, 9, 0],
+    [11, 832, 10, 0],
+    [12, 543, 11, 0],
+    [13, 240, 12, 0],
+    [14, 548, 13, 0],
+    [15, 920, 14, 0],
+    [16, 920, 15, 401],
+    [17, 514, 16, 401],
+    [18, 458, 17, 0],
+    [180, 458, 17, 0],
+    [181, 458, 180, 0],
+    [19, 832, 18, 0],
+    [20, 543, 19, 0],
+    [21, 240, 16, 401],
+    [22, 548, 21, 0],
+    [23, 920, 22, 0],
+    [24, 240, 23, 0],
+    [25, 548, 12, 0],
+    [26, 920, 25, 0],
+    [27, 920, 26, 0],
+    [28, 920, 27, 0],
+    [2800, 920, 2700, 0], 
+]
+
+test_key_col = 0
+test_downstream_col = 2
+test_length_col = 1
+test_terminal_code = -999
+test_waterbody_col = 3
+test_waterbody_null_code = 0
+
+test_columns = {
+    "key": 0,
+    "dx": 1,
+    "downstream": 2,
+    "waterbody": 3,
+}
+
+reverse_test_columns = {0: "key", 1: "dx", 2: "downstream", 3: "waterbody"}
+
+expected_connections = {
+    0: [],
+    1: [4],
+    2: [0],
+    3: [2],
+    4: [0],
+    5: [4],
+    6: [0],
+    7: [2],
+    8: [],
+    9: [8],
+    10: [9],
+    11: [10],
+    12: [11],
+    13: [12],
+    14: [13],
+    15: [14],
+    16: [15],
+    17: [16],
+    18: [17],
+    180: [17],
+    181: [180],
+    19: [18],
+    20: [19],
+    21: [16],
+    22: [21],
+    23: [22],
+    24: [23],
+    25: [12],
+    26: [25],
+    27: [26],
+    28: [27],
+    2800: [],
+}
+
+expected_rconn = {0: [2, 4, 6], 1: [], 4: [1, 5], 2: [3, 7], 3: [], 5: [], 6: [], 7: [], 8: [9], 9: [10], 10: [11], 11: [12], 12: [13, 25], 13: [14], 14: [15], 15: [16], 16: [17, 21], 17: [18, 180], 18: [19], 180: [181], 181: [], 19: [20], 20: [], 21: [22], 22: [23], 23: [24], 24: [], 25: [26], 26: [27], 27: [28], 28: [], 2800: []}
+
+expected_wbody_connections = {4: 403, 5: 403, 16: 401, 17: 401, 21: 401, 26: 402, 27: 402}
+
+# network_with_substituted_reservoirs = []
+# rconn = {"down":["up (is a reservoir)"]}
+# path_func = partial(nhd_network.split_at_waterbodies_and_junctions, ["up (is a reservoir)"], rconn)
+# nhd_network.dfs_decomposition_depth_tuple(rconn, path_func)
+# list(nhd_network.dfs_decomposition_depth_tuple(rconn, path_func))
+# [(0, ['down'])]
+
+import pandas as pd
+import troute.nhd_network_utilities_v02 as nnu
+
+test_param_df = pd.DataFrame(network_clean)
+test_param_df = test_param_df.rename(columns=nnu.reverse_dict(test_columns))
+test_param_df = test_param_df.set_index("key")
+
+import troute.nhd_network_utilities_v02 as nnu
+import troute.nhd_network as nhd_network
+
+def test_reverse_dict():
+
+    result = nnu.reverse_dict(test_columns)
+    assert result == reverse_test_columns
+
+
+def test_build_connections():
+
+    # There can be an externally determined terminal code -- that's this first value
+    terminal_codes = set()
+    terminal_codes.add(test_terminal_code)
+    # ... but there may also be off-domain nodes that are not explicitly identified
+    # but which are terminal (i.e., off-domain) as a result of a mask or some other
+    # an interior domain truncation that results in a
+    # otherwise valid node value being pointed to, but which is masked out or
+    # being intentionally separated into another domain.
+    terminal_codes = terminal_codes | set(
+        test_param_df[~test_param_df["downstream"].isin(test_param_df.index)][
+            "downstream"
+        ].values
+    )
+
+    connections = nhd_network.extract_connections(
+        test_param_df, "downstream", terminal_codes
+    )
+    assert connections == expected_connections
+
+
+def test_reverse_network():
+    connections = expected_connections
+    rconn = nhd_network.reverse_network(connections)
+    assert expected_rconn == rconn
+    rrconn = nhd_network.reverse_network(rconn)
+    assert rrconn == connections
+
+
+def test_extract_waterbodies():
+    wbody_connections = nhd_network.extract_waterbody_connections(test_param_df, "waterbody", test_waterbody_null_code)
+    assert wbody_connections == expected_wbody_connections
+

--- a/src/python_routing_v02/troute/routing/compute.py
+++ b/src/python_routing_v02/troute/routing/compute.py
@@ -30,7 +30,7 @@ _compute_func_map = defaultdict(
 def compute_nhd_routing_v02(
     connections,
     rconn,
-    wbodies,
+    wbody_conn,  # TODO: We never use this argument... delete it!!!
     reaches_bytw,
     compute_func_name,
     parallel_compute_method,


### PR DESCRIPTION
Somewhere, way back, we had some sort of catch for a case where a set of masked segments that were part of a larger network would generate a valid connections set by setting the off-network terminal nodes to negative values. These 'to' or 'downstream' segment ids exist in the larger network, but when masked, are not part of the computation domain. Somewhere along the way, we lost that catch, but since all of our test cases had been boiled down to situations where the terminal codes are all 0, apparently. Or we have been just lucking-out. 

Either way, this introduces a more clear usage of the "terminal_code" and modifies the principal call in the code to this function to use the code and any non-standard internal codes in the call to the function `extract_connections`. 

~~The PR is frozen as a draft until I can add a unit test.~~

A Unit Test is added as part of the PR. 