### PR TITLE
[WIP] Courant timestep bugfix

### DIFF
--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -597,8 +597,8 @@ def main_v02(argv):
             ).to_flat_index()
             courant = pd.concat(
                 [
-                    pd.DataFrame(c, index=i, columns=courant_columns)
-                    for i, d, c in results
+                    pd.DataFrame(r[2], index=r[0], columns=courant_columns)
+                    for r in results
                 ],
                 copy=False,
             )

--- a/src/nwm_routing/src/nwm_routing/output.py
+++ b/src/nwm_routing/src/nwm_routing/output.py
@@ -81,8 +81,8 @@ def nwm_output_generator(
             ).to_flat_index()
             courant = pd.concat(
                 [
-                    pd.DataFrame(c, index=i, columns=courant_columns)
-                    for i, d, c in results
+                    pd.DataFrame(r[2], index=r[0], columns=courant_columns)
+                    for r in results
                 ],
                 copy=False,
             )

--- a/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
@@ -221,7 +221,7 @@ cpdef object compute_network(
     # courant is a 2D float array that holds courant results
     # columns: courant number (cn), kinematic celerity (ck), x parameter(X) for each timestep
     # rows: indexed by data_idx
-    cdef float[:,::1] courant = np.zeros((data_idx.shape[0], nsteps * 3), dtype='float32')
+    cdef float[:,::1] courant = np.zeros((data_idx.shape[0], (nsteps + 1) * 3), dtype='float32')
 
     flowveldepth[:,0] = initial_conditions[:,1]  # Populate initial flows
     flowveldepth[:,2] = initial_conditions[:,2]  # Populate initial depths
@@ -481,7 +481,7 @@ cpdef object compute_network(
     # The upstream keys have empty results because they are not part of any reaches
     # so we need to delete the null values that return
     if return_courant:
-        return np.asarray(data_idx, dtype=np.intp)[fill_index_mask], np.asarray(flowveldepth[:,qvd_ts_w:], dtype='float32')[fill_index_mask], np.asarray(courant, dtype='float32')[fill_index_mask]
+        return np.asarray(data_idx, dtype=np.intp)[fill_index_mask], np.asarray(flowveldepth[:,qvd_ts_w:], dtype='float32')[fill_index_mask], np.asarray(courant[:,qvd_ts_w:], dtype='float32')[fill_index_mask]
     else:
         return np.asarray(data_idx, dtype=np.intp)[fill_index_mask], np.asarray(flowveldepth[:,qvd_ts_w:], dtype='float32')[fill_index_mask]
 


### PR DESCRIPTION
Bugfix to return capability for returning courant number for simulations using the V02-caching compute kernel. Per comments in issue #362 the problem was that an additional index position was added to accomodate initial conditions in the main array but not in the courant array. This PR now makes the behavior for the courant array match the flowveldepth array. We could probably avoid this somehow, but this seems to work for now. 

This does not yet fix the broken test `python -m nwm_routing -V2  -f ../../test/input/yaml/Florence_Benchmark.yaml` because the yaml file refers to the `V02-structured` compute method, which does not yet handle the courant output properly.

- [ ] Annotate issue to note need to add extra methods