### PR TITLE
Da update for caching structured obj

### DIFF
--- a/src/fortran_routing/mc_pylink_v00/MC_singleSeg_singleTS/makefile
+++ b/src/fortran_routing/mc_pylink_v00/MC_singleSeg_singleTS/makefile
@@ -3,7 +3,7 @@ FC := $(F90)
 
 # compile flags
 #FCFLAGS = -c -fdefault-real-8 -fno-align-commons -fbounds-check --free-form
-FCFLAGS = -g -c -O3 -fPIC
+FCFLAGS = -g -c -O2 -fPIC
 # link flags
 FLFLAGS = -static-gfortran -static-libgcc -no-defaultlibs -lgfortran -lgcc
 VPATH = ../Reservoir_singleTS

--- a/src/fortran_routing/mc_pylink_v00/MC_singleSeg_singleTS/makefile
+++ b/src/fortran_routing/mc_pylink_v00/MC_singleSeg_singleTS/makefile
@@ -3,7 +3,7 @@ FC := $(F90)
 
 # compile flags
 #FCFLAGS = -c -fdefault-real-8 -fno-align-commons -fbounds-check --free-form
-FCFLAGS = -g -c -O2 -fPIC
+FCFLAGS = -g -c -O3 -fPIC
 # link flags
 FLFLAGS = -static-gfortran -static-libgcc -no-defaultlibs -lgfortran -lgcc
 VPATH = ../Reservoir_singleTS

--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -487,7 +487,7 @@ def main_v02(argv):
         "data_assimilation_csv", None
     )
     data_assimilation_folder = data_assimilation_parameters.get(
-        "data_assimilation_folder", None
+        "data_assimilation_timeslices_folder", None
     )
     last_obs_file = data_assimilation_parameters.get(
         "wrf_hydro_last_obs_file", None

--- a/src/python_routing_v02/troute/routing/compute.py
+++ b/src/python_routing_v02/troute/routing/compute.py
@@ -1041,6 +1041,7 @@ def compute_nhd_routing_v02(
                     assume_short_ts,
                     return_courant,
                     diffusive_parameters,
+                    6,
                 )
             )
 

--- a/src/python_routing_v02/troute/routing/compute.py
+++ b/src/python_routing_v02/troute/routing/compute.py
@@ -313,9 +313,6 @@ def compute_nhd_routing_v02(
                     subn_reach_list = clustered_subns["subn_reach_list"]
                     upstreams = clustered_subns["upstreams"]
 
-                    usgs_df_sub, lastobs_df_sub, da_positions_list_byseg = _prep_da_dataframes(usgs_df, lastobs_df, param_df_sub.index)
-                    da_positions_list_byreach, da_positions_list_bygage = _prep_da_positions_byreach(subn_reach_list, lastobs_df_sub.index)
-
                     subn_reach_list_with_type = _build_reach_type_list(subn_reach_list, wbodies_segs)
 
                     qlat_sub = qlats.loc[param_df_sub.index]
@@ -336,6 +333,10 @@ def compute_nhd_routing_v02(
                     param_df_sub = param_df_sub.reindex(
                         param_df_sub.index.tolist() + lake_segs
                     ).sort_index()
+
+                    usgs_df_sub, lastobs_df_sub, da_positions_list_byseg = _prep_da_dataframes(usgs_df, lastobs_df, param_df_sub.index)
+                    da_positions_list_byreach, da_positions_list_bygage = _prep_da_positions_byreach(subn_reach_list, lastobs_df_sub.index)
+
                     qlat_sub = qlat_sub.reindex(param_df_sub.index)
                     q0_sub = q0_sub.reindex(param_df_sub.index)
 
@@ -525,9 +526,6 @@ def compute_nhd_routing_v02(
                                 "position_index"
                             ] = subn_tw_sortposition
 
-                    usgs_df_sub, lastobs_df_sub, da_positions_list_byseg = _prep_da_dataframes(usgs_df, lastobs_df, param_df_sub.index)
-                    da_positions_list_byreach, da_positions_list_bygage = _prep_da_positions_byreach(subn_reach_list, lastobs_df_sub.index)
-
                     subn_reach_list_with_type = _build_reach_type_list(subn_reach_list, wbodies_segs)
 
                     qlat_sub = qlats.loc[param_df_sub.index]
@@ -548,6 +546,10 @@ def compute_nhd_routing_v02(
                     param_df_sub = param_df_sub.reindex(
                         param_df_sub.index.tolist() + lake_segs
                     ).sort_index()
+
+                    usgs_df_sub, lastobs_df_sub, da_positions_list_byseg = _prep_da_dataframes(usgs_df, lastobs_df, param_df_sub.index)
+                    da_positions_list_byreach, da_positions_list_bygage = _prep_da_positions_byreach(subn_reach_list, lastobs_df_sub.index)
+
                     qlat_sub = qlat_sub.reindex(param_df_sub.index)
                     q0_sub = q0_sub.reindex(param_df_sub.index)
 
@@ -722,9 +724,6 @@ def compute_nhd_routing_v02(
                                 "position_index"
                             ] = subn_tw_sortposition
 
-                    usgs_df_sub, lastobs_df_sub, da_positions_list_byseg = _prep_da_dataframes(usgs_df, lastobs_df, param_df_sub.index)
-                    da_positions_list_byreach, da_positions_list_bygage = _prep_da_positions_byreach(subn_reach_list, lastobs_df_sub.index)
-
                     subn_reach_list_with_type = _build_reach_type_list(subn_reach_list, wbodies_segs)
 
                     qlat_sub = qlats.loc[param_df_sub.index]
@@ -745,6 +744,10 @@ def compute_nhd_routing_v02(
                     param_df_sub = param_df_sub.reindex(
                         param_df_sub.index.tolist() + lake_segs
                     ).sort_index()
+
+                    usgs_df_sub, lastobs_df_sub, da_positions_list_byseg = _prep_da_dataframes(usgs_df, lastobs_df, param_df_sub.index)
+                    da_positions_list_byreach, da_positions_list_bygage = _prep_da_positions_byreach(subn_reach_list, lastobs_df_sub.index)
+
                     qlat_sub = qlat_sub.reindex(param_df_sub.index)
                     q0_sub = q0_sub.reindex(param_df_sub.index)
 
@@ -867,9 +870,6 @@ def compute_nhd_routing_v02(
                     ["dt", "bw", "tw", "twcc", "dx", "n", "ncc", "cs", "s0", "alt"],
                 ].sort_index()
 
-                usgs_df_sub, lastobs_df_sub, da_positions_list_byseg = _prep_da_dataframes(usgs_df, lastobs_df, param_df_sub.index)
-                da_positions_list_byreach, da_positions_list_bygage = _prep_da_positions_byreach(reach_list, lastobs_df_sub.index)
-
                 reaches_list_with_type = _build_reach_type_list(reach_list, wbodies_segs)
 
                 # qlat_sub = qlats.loc[common_segs].sort_index()
@@ -892,6 +892,10 @@ def compute_nhd_routing_v02(
                 param_df_sub = param_df_sub.reindex(
                     param_df_sub.index.tolist() + lake_segs
                 ).sort_index()
+
+                usgs_df_sub, lastobs_df_sub, da_positions_list_byseg = _prep_da_dataframes(usgs_df, lastobs_df, param_df_sub.index)
+                da_positions_list_byreach, da_positions_list_bygage = _prep_da_positions_byreach(reach_list, lastobs_df_sub.index)
+
                 qlat_sub = qlat_sub.reindex(param_df_sub.index)
                 q0_sub = q0_sub.reindex(param_df_sub.index)
 
@@ -984,8 +988,7 @@ def compute_nhd_routing_v02(
                 ["dt", "bw", "tw", "twcc", "dx", "n", "ncc", "cs", "s0", "alt"],
             ].sort_index()
 
-            usgs_df_sub, lastobs_df_sub, da_positions_list_byseg = _prep_da_dataframes(usgs_df, lastobs_df, param_df_sub.index)
-            da_positions_list_byreach, da_positions_list_bygage = _prep_da_positions_byreach(reach_list, lastobs_df_sub.index)
+            reaches_list_with_type = _build_reach_type_list(reach_list, wbodies_segs)
 
             # qlat_sub = qlats.loc[common_segs].sort_index()
             # q0_sub = q0.loc[common_segs].sort_index()
@@ -1007,10 +1010,12 @@ def compute_nhd_routing_v02(
             param_df_sub = param_df_sub.reindex(
                 param_df_sub.index.tolist() + lake_segs
             ).sort_index()
+
+            usgs_df_sub, lastobs_df_sub, da_positions_list_byseg = _prep_da_dataframes(usgs_df, lastobs_df, param_df_sub.index)
+            da_positions_list_byreach, da_positions_list_bygage = _prep_da_positions_byreach(reach_list, lastobs_df_sub.index)
+
             qlat_sub = qlat_sub.reindex(param_df_sub.index)
             q0_sub = q0_sub.reindex(param_df_sub.index)
-
-            reaches_list_with_type = _build_reach_type_list(reach_list, wbodies_segs)
 
             results.append(
                 compute_func(

--- a/src/python_routing_v02/troute/routing/compute.py
+++ b/src/python_routing_v02/troute/routing/compute.py
@@ -87,14 +87,14 @@ def _prep_da_dataframes(
         # Create a completely empty list of gages -- the .shape[1] attribute
         # will be == 0, and that will trigger a reference to the lastobs.
         # in the compute kernel below.
-        usgs_df_sub = pd.DataFrame(index=[lastobs_df_sub.index],columns=[])
+        usgs_df_sub = pd.DataFrame(index=lastobs_df_sub.index,columns=[])
         usgs_segs = lastobs_segs
         da_positions_list_byseg = param_df_sub_idx.get_indexer(lastobs_segs)
     elif not usgs_df.empty and lastobs_df.empty:
         usgs_segs = list(usgs_df.index.intersection(param_df_sub_idx))
         da_positions_list_byseg = param_df_sub_idx.get_indexer(usgs_segs)
         usgs_df_sub = usgs_df.loc[usgs_segs]
-        lastobs_df_sub = pd.DataFrame(index=[usgs_df_sub.index],columns=["discharge","time","model_discharge"])
+        lastobs_df_sub = pd.DataFrame(index=usgs_df_sub.index,columns=["discharge","time","model_discharge"])
     else:
         usgs_df_sub = pd.DataFrame()
         lastobs_df_sub = pd.DataFrame()

--- a/src/python_routing_v02/troute/routing/compute.py
+++ b/src/python_routing_v02/troute/routing/compute.py
@@ -1046,7 +1046,6 @@ def compute_nhd_routing_v02(
                     assume_short_ts,
                     return_courant,
                     diffusive_parameters,
-                    6,
                 )
             )
 

--- a/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
@@ -287,7 +287,7 @@ cpdef object compute_network(
     cdef int buf_cols = 13
 
     cdef:
-        Py_ssize_t i  # Temporary variable
+        Py_ssize_t _i  # Temporary variable
         Py_ssize_t ireach  # current reach index
         Py_ssize_t ireach_cache  # current index of reach cache
         Py_ssize_t iusreach_cache  # current index of upstream reach cache
@@ -383,7 +383,7 @@ cpdef object compute_network(
 
                 qup = 0.0
                 quc = 0.0
-                for i in range(usreachlen):
+                for _i in range(usreachlen):
 
                     '''
                     New logic was added to handle initial conditions:
@@ -395,11 +395,11 @@ cpdef object compute_network(
                     # in upstream segments, current timestep
                     # Headwater reaches are computed before higher order reaches, so quc can
                     # be evaulated even when the timestep == 0.
-                    quc += flowveldepth[usreach_cache[iusreach_cache + i], ts_offset]
+                    quc += flowveldepth[usreach_cache[iusreach_cache + _i], ts_offset]
 
                     # upstream flow in the previous timestep is equal to the sum of flows
                     # in upstream segments, previous timestep
-                    qup += flowveldepth[usreach_cache[iusreach_cache + i], ts_offset - qvd_ts_w]
+                    qup += flowveldepth[usreach_cache[iusreach_cache + _i], ts_offset - qvd_ts_w]
                     # Remember, we have filled the first position in flowveldepth with qd0
 
                 buf_view = buf[:reachlen, :]
@@ -420,8 +420,8 @@ cpdef object compute_network(
                                    qlat_values,
                                    buf_view)
 
-                for i in range(scols.shape[0]):
-                    fill_buffer_column(srows, scols[i], drows, i + 1, data_values, buf_view)
+                for _i in range(scols.shape[0]):
+                    fill_buffer_column(srows, scols[_i], drows, _i + 1, data_values, buf_view)
 
                 # fill buffer with qdp, depthp, velp
                 fill_buffer_column(srows, ts_offset - qvd_ts_w, drows, 10, flowveldepth, buf_view)
@@ -434,13 +434,13 @@ cpdef object compute_network(
                 compute_reach_kernel(qup, quc, reachlen, buf_view, out_view, assume_short_ts, return_courant)
 
                 # copy out_buf results back to flowdepthvel
-                for i in range(qvd_ts_w):
-                    fill_buffer_column(drows, i, srows, ts_offset + i, out_view, flowveldepth)
+                for _i in range(qvd_ts_w):
+                    fill_buffer_column(drows, _i, srows, ts_offset + _i, out_view, flowveldepth)
 
                 # copy out_buf results back to courant
                 if return_courant:
-                    for i in range(qvd_ts_w,qvd_ts_w + 3):
-                        fill_buffer_column(drows, i, srows, ts_offset + (i-qvd_ts_w), out_view, courant)
+                    for _i in range(qvd_ts_w,qvd_ts_w + 3):
+                        fill_buffer_column(drows, _i, srows, ts_offset + (_i-qvd_ts_w), out_view, courant)
 
                 if reach_has_gage[ireach] > -1:
                 # we only enter this process for reaches where the
@@ -985,21 +985,21 @@ cpdef object compute_network_structured_obj(
                 segment_ids = []
 
                 #Create compute reach kernel input buffer
-                for i, segment in enumerate(r):
+                for _i, segment in enumerate(r):
                     segment_ids.append(segment['id'])
-                    buf_view[i, 0] = qlat_array[ segment['id'], int((timestep-1)/qlat_resample)]
-                    buf_view[i, 1] = segment['dt']
-                    buf_view[i, 2] = segment['dx']
-                    buf_view[i, 3] = segment['bw']
-                    buf_view[i, 4] = segment['tw']
-                    buf_view[i, 5] = segment['twcc']
-                    buf_view[i, 6] = segment['n']
-                    buf_view[i, 7] = segment['ncc']
-                    buf_view[i, 8] = segment['cs']
-                    buf_view[i, 9] = segment['s0']
-                    buf_view[i, 10] = flowveldepth[segment['id'], timestep-1, 0]
-                    buf_view[i, 11] = 0.0 #flowveldepth[segment.id, timestep-1, 1]
-                    buf_view[i, 12] = flowveldepth[segment['id'], timestep-1, 2]
+                    buf_view[_i, 0] = qlat_array[ segment['id'], int((timestep-1)/qlat_resample)]
+                    buf_view[_i, 1] = segment['dt']
+                    buf_view[_i, 2] = segment['dx']
+                    buf_view[_i, 3] = segment['bw']
+                    buf_view[_i, 4] = segment['tw']
+                    buf_view[_i, 5] = segment['twcc']
+                    buf_view[_i, 6] = segment['n']
+                    buf_view[_i, 7] = segment['ncc']
+                    buf_view[_i, 8] = segment['cs']
+                    buf_view[_i, 9] = segment['s0']
+                    buf_view[_i, 10] = flowveldepth[segment['id'], timestep-1, 0]
+                    buf_view[_i, 11] = 0.0 #flowveldepth[segment.id, timestep-1, 1]
+                    buf_view[_i, 12] = flowveldepth[segment['id'], timestep-1, 2]
 
                 compute_reach_kernel(previous_upstream_flows, upstream_flows,
                                      len(r), buf_view,
@@ -1007,10 +1007,10 @@ cpdef object compute_network_structured_obj(
                                      assume_short_ts)
 
                 #Copy the output out
-                for i, id in enumerate(segment_ids):
-                    flowveldepth[id, timestep, 0] = out_buf[i, 0]
-                    flowveldepth[id, timestep, 1] = out_buf[i, 1]
-                    flowveldepth[id, timestep, 2] = out_buf[i, 2]
+                for _i, id in enumerate(segment_ids):
+                    flowveldepth[id, timestep, 0] = out_buf[_i, 0]
+                    flowveldepth[id, timestep, 1] = out_buf[_i, 1]
+                    flowveldepth[id, timestep, 2] = out_buf[_i, 2]
 
             if reach_has_gage[reachi] > -1:
             # We only enter this process for reaches where the

--- a/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
@@ -1385,7 +1385,7 @@ cpdef object compute_network_structured(
                         routing_period,
                         da_decay_coefficient,
                         gage_maxtimestep,
-                        NAN if timestep > gage_maxtimestep else usgs_values[gage_i,timestep-1],
+                        NAN if timestep >= gage_maxtimestep else usgs_values[gage_i,timestep],
                         flowveldepth[usgs_position_i, timestep, 0],
                         lastobs_times[gage_i],
                         lastobs_values[gage_i],
@@ -1396,15 +1396,16 @@ cpdef object compute_network_structured(
                         printf("gmxt: %d\t", gage_maxtimestep)
                         printf("gage: %d\t", gage_i)
                         printf("old: %g\t", flowveldepth[usgs_position_i, timestep, 0])
-                        flowveldepth[usgs_position_i, timestep - 1, 0] = da_buf[0]
                         printf("exp_gage_val: %g\t", usgs_values[gage_i,timestep])
+
+                    flowveldepth[usgs_position_i, timestep, 0] = da_buf[0]
 
                     if gage_i == da_check_gage:
                         printf("new: %g\t", flowveldepth[usgs_position_i, timestep, 0])
                         printf("repl: %g\t", da_buf[0])
                         printf("nudg: %g\n", da_buf[1])
-                        nudge[gage_i, timestep] = da_buf[1]
 
+                    nudge[gage_i, timestep] = da_buf[1]
                     lastobs_times[gage_i] = da_buf[2]
                     lastobs_values[gage_i] = da_buf[3]
 

--- a/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
@@ -231,7 +231,7 @@ cpdef object compute_network(
     cdef int gage_maxtimestep = usgs_values.shape[1]
     cdef float a, da_decay_minutes, da_weighted_shift, replacement_val
     cdef float[:] lastobs_values, lastobs_times
-    cdef (float, float) da_buf
+    cdef (float, float, float, float) da_buf
     cdef int[:] reach_has_gage = np.full(len(reaches_wTypes), -1, dtype="int32")
     cdef float[:,:] nudge = np.zeros((gages_size, nsteps + 1), dtype="float32")
 
@@ -462,6 +462,8 @@ cpdef object compute_network(
                     )
                     flowveldepth[usgs_position_i, ts_offset] = da_buf[0]
                     nudge[gage_i, timestep+1] = da_buf[1]
+                    lastobs_times[gage_i] = da_buf[2]
+                    lastobs_values[gage_i] = da_buf[3]
 
                 # Update indexes to point to next reach
                 ireach += 1
@@ -829,7 +831,7 @@ cpdef object compute_network_structured_obj(
     cdef int gage_i, usgs_position_i
     cdef float a, da_decay_minutes, da_weighted_shift, replacement_val
     cdef float [:] lastobs_values, lastobs_times
-    cdef (float, float) da_buf
+    cdef (float, float, float, float) da_buf
     cdef int[:] reach_has_gage = np.full(len(reaches_wTypes), -1, dtype="int32")
     cdef float[:,:] nudge = np.zeros((gages_size, nsteps + 1), dtype="float32")
 
@@ -1027,6 +1029,8 @@ cpdef object compute_network_structured_obj(
                 )
                 flowveldepth[usgs_position_i, timestep, 0] = da_buf[0]
                 nudge[gage_i, timestep] = da_buf[1]
+                lastobs_times[gage_i] = da_buf[2]
+                lastobs_values[gage_i] = da_buf[3]
 
         timestep += 1
 
@@ -1227,7 +1231,7 @@ cpdef object compute_network_structured(
     cdef int gage_i, usgs_position_i
     cdef float a, da_decay_minutes, da_weighted_shift, replacement_val  # , original_val, lastobs_val,
     cdef float [:] lastobs_values, lastobs_times
-    cdef (float, float) da_buf
+    cdef (float, float, float, float) da_buf
     cdef int[:] reach_has_gage = np.full(len(reaches_wTypes), -1, dtype="int32")
     cdef float[:,:] nudge = np.zeros((gages_size, nsteps + 1), dtype="float32")
 
@@ -1394,6 +1398,9 @@ cpdef object compute_network_structured(
                         printf("repl: %g\t", da_buf[0])
                         printf("nudg: %g\n", da_buf[1])
                         nudge[gage_i, timestep] = da_buf[1]
+
+                    lastobs_times[gage_i] = da_buf[2]
+                    lastobs_values[gage_i] = da_buf[3]
 
             # TODO: Address remaining TODOs (feels existential...), Extra commented material, etc.
 

--- a/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
@@ -354,7 +354,7 @@ cpdef object compute_network(
     drows_tmp = np.arange(maxreachlen, dtype=np.intp)
     cdef Py_ssize_t[:] drows
     cdef float qup, quc
-    cdef float routing_period = data_values[0][0]  # TODO: harmonize the dt with the value from the param_df dt (see line 153)
+    cdef float routing_period = dt  # TODO: harmonize the dt with the value from the param_df dt (see line 153) #cdef float routing_period = data_values[0][0]
     cdef int timestep = 0
     cdef int ts_offset
 
@@ -809,7 +809,7 @@ cpdef object compute_network_structured_obj(
     cdef float upstream_flows, previous_upstream_flows
     #starting timestep, shifted by 1 to account for initial conditions
     cdef int timestep = 1
-    cdef float routing_period = data_values[0][0]  # TODO: harmonize the dt with the value from the param_df dt (see line 153)
+    cdef float routing_period = dt  # TODO: harmonize the dt with the value from the param_df dt (see line 153) #cdef float routing_period = data_values[0][0]
     #buffers to pass to compute_reach_kernel
     cdef float[:,:] buf_view
     cdef float[:,:] out_buf
@@ -1112,7 +1112,7 @@ cpdef object compute_network_structured(
     cdef float upstream_flows, previous_upstream_flows
     #starting timestep, shifted by 1 to account for initial conditions
     cdef int timestep = 1
-    cdef float routing_period = data_values[0][0]  # TODO: harmonize the dt with the value from the param_df dt (see line 153)
+    cdef float routing_period = dt  # TODO: harmonize the dt with the value from the param_df dt (see line 153) #cdef float routing_period = data_values[0][0]
     #buffers to pass to compute_reach_kernel
     cdef float[:,:] buf_view
     cdef float[:,:] out_buf

--- a/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
@@ -459,6 +459,7 @@ cpdef object compute_network(
                         flowveldepth[usgs_position_i, ts_offset],
                         lastobs_times[gage_i],
                         lastobs_values[gage_i],
+                        0,
                     )
                     flowveldepth[usgs_position_i, ts_offset] = da_buf[0]
                     nudge[gage_i, timestep+1] = da_buf[1]
@@ -1026,6 +1027,7 @@ cpdef object compute_network_structured_obj(
                     flowveldepth[usgs_position_i, timestep, 0],
                     lastobs_times[gage_i],
                     lastobs_values[gage_i],
+                    0,
                 )
                 flowveldepth[usgs_position_i, timestep, 0] = da_buf[0]
                 nudge[gage_i, timestep] = da_buf[1]
@@ -1387,14 +1389,18 @@ cpdef object compute_network_structured(
                         flowveldepth[usgs_position_i, timestep, 0],
                         lastobs_times[gage_i],
                         lastobs_values[gage_i],
+                        gage_i == da_check_gage,
                     )
                     if gage_i == da_check_gage:
                         printf("ts: %d\t", timestep)
+                        printf("gmxt: %d\t", gage_maxtimestep)
                         printf("gage: %d\t", gage_i)
-                        printf("old_prev: %g\t", flowveldepth[usgs_position_i, timestep - 1, 0])
                         printf("old: %g\t", flowveldepth[usgs_position_i, timestep, 0])
                         flowveldepth[usgs_position_i, timestep - 1, 0] = da_buf[0]
-                        printf("new: %g\t", flowveldepth[usgs_position_i, timestep - 1, 0])
+                        printf("exp_gage_val: %g\t", usgs_values[gage_i,timestep])
+
+                    if gage_i == da_check_gage:
+                        printf("new: %g\t", flowveldepth[usgs_position_i, timestep, 0])
                         printf("repl: %g\t", da_buf[0])
                         printf("nudg: %g\n", da_buf[1])
                         nudge[gage_i, timestep] = da_buf[1]

--- a/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
@@ -187,6 +187,7 @@ cpdef object compute_network(
     bint assume_short_ts=False,
     bint return_courant=False,
     dict diffusive_parameters=False,
+    int da_check_gage = -1,
     ):
     """
     Compute network
@@ -459,7 +460,7 @@ cpdef object compute_network(
                         flowveldepth[usgs_position_i, ts_offset],
                         lastobs_times[gage_i],
                         lastobs_values[gage_i],
-                        0,
+                        gage_i == da_check_gage,
                     )
                     flowveldepth[usgs_position_i, ts_offset] = da_buf[0]
                     nudge[gage_i, timestep+1] = da_buf[1]
@@ -767,6 +768,7 @@ cpdef object compute_network_structured_obj(
     bint assume_short_ts=False,
     bint return_courant=False,
     dict diffusive_parameters=False,
+    int da_check_gage = -1,
     ):
     """
     Compute network
@@ -1027,7 +1029,7 @@ cpdef object compute_network_structured_obj(
                     flowveldepth[usgs_position_i, timestep, 0],
                     lastobs_times[gage_i],
                     lastobs_values[gage_i],
-                    0,
+                    gage_i == da_check_gage,
                 )
                 flowveldepth[usgs_position_i, timestep, 0] = da_buf[0]
                 nudge[gage_i, timestep] = da_buf[1]
@@ -1071,7 +1073,7 @@ cpdef object compute_network_structured(
     bint assume_short_ts=False,
     bint return_courant=False,
     dict diffusive_parameters=False,
-    int da_check_gage=-1,
+    int da_check_gage = -1,
     ):
     """
     Compute network

--- a/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
@@ -458,9 +458,9 @@ cpdef object compute_network(
                     else:
                         a = da_decay_coefficient
                         if lastobs_timestep[gage_i] < 0: # Initialized to -1
-                            da_decay_minutes = (timestep * dt - time_since_lastobs_init[gage_i]) / 60 # seconds to minutes
+                            da_decay_minutes = (timestep * routing_period - time_since_lastobs_init[gage_i]) / 60 # seconds to minutes
                         else:
-                            da_decay_minutes = (timestep - lastobs_timestep[gage_i]) * dt / 60
+                            da_decay_minutes = (timestep - lastobs_timestep[gage_i]) * routing_period / 60
 
                         da_weighted_shift = obs_persist_shift(lastobs_values[gage_i], flowveldepth[usgs_position_i, ts_offset], da_decay_minutes, a)
                         nudge[gage_i, timestep] = da_weighted_shift
@@ -1029,9 +1029,9 @@ cpdef object compute_network_structured_obj(
                 else:
                     a = da_decay_coefficient
                     if lastobs_timestep[gage_i] < 0: # Initialized to -1
-                        da_decay_minutes = ((timestep - 1) * dt - time_since_lastobs_init[gage_i]) / 60 # seconds to minutes
+                        da_decay_minutes = ((timestep - 1) * routing_period - time_since_lastobs_init[gage_i]) / 60 # seconds to minutes
                     else:
-                        da_decay_minutes = ((timestep - 1) - lastobs_timestep[gage_i]) * dt / 60
+                        da_decay_minutes = ((timestep - 1) - lastobs_timestep[gage_i]) * routing_period / 60
 
                     da_weighted_shift = obs_persist_shift(lastobs_values[gage_i], flowveldepth[usgs_position_i, timestep, 0], da_decay_minutes, a)
                     nudge[gage_i, timestep] = da_weighted_shift
@@ -1400,9 +1400,9 @@ cpdef object compute_network_structured(
                     else:
                         a = da_decay_coefficient
                         if lastobs_timestep[gage_i] < 0: # Initialized to -1
-                            da_decay_minutes = (timestep * routing_period - time_since_lastobs_init[gage_i]) / 60 # seconds to minutes
+                            da_decay_minutes = ((timestep - 1) * routing_period - time_since_lastobs_init[gage_i]) / 60 # seconds to minutes
                         else:
-                            da_decay_minutes = (timestep - lastobs_timestep[gage_i]) * routing_period / 60
+                            da_decay_minutes = ((timestep - 1) - lastobs_timestep[gage_i]) * routing_period / 60
 
                         da_weighted_shift = obs_persist_shift(lastobs_values[gage_i], flowveldepth[usgs_position_i, timestep, 0], da_decay_minutes, a)
                         nudge[gage_i, timestep] = da_weighted_shift

--- a/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
@@ -233,7 +233,7 @@ cpdef object compute_network(
     cdef float a, da_decay_minutes, da_weighted_shift, replacement_val
     cdef float[:] lastobs_values, lastobs_times
     cdef (float, float, float, float) da_buf
-    cdef int[:] reach_has_gage = np.full(len(reaches_wTypes), -1, dtype="int32")
+    cdef int[:] reach_has_gage = np.full(len(reaches_wTypes), np.iinfo(np.int32).min, dtype="int32")
     cdef float[:,:] nudge = np.zeros((gages_size, nsteps + 1), dtype="float32")
 
     if gages_size:
@@ -835,7 +835,7 @@ cpdef object compute_network_structured_obj(
     cdef float a, da_decay_minutes, da_weighted_shift, replacement_val
     cdef float [:] lastobs_values, lastobs_times
     cdef (float, float, float, float) da_buf
-    cdef int[:] reach_has_gage = np.full(len(reaches_wTypes), -1, dtype="int32")
+    cdef int[:] reach_has_gage = np.full(len(reaches_wTypes), np.iinfo(np.int32).min, dtype="int32")
     cdef float[:,:] nudge = np.zeros((gages_size, nsteps + 1), dtype="float32")
 
     if gages_size:
@@ -1236,7 +1236,7 @@ cpdef object compute_network_structured(
     cdef float a, da_decay_minutes, da_weighted_shift, replacement_val  # , original_val, lastobs_val,
     cdef float [:] lastobs_values, lastobs_times
     cdef (float, float, float, float) da_buf
-    cdef int[:] reach_has_gage = np.full(len(reaches_wTypes), -1, dtype="int32")
+    cdef int[:] reach_has_gage = np.full(len(reaches_wTypes), np.iinfo(np.int32).min, dtype="int32")
     cdef float[:,:] nudge = np.zeros((gages_size, nsteps + 1), dtype="float32")
 
     if gages_size:
@@ -1369,7 +1369,7 @@ cpdef object compute_network_structured(
                 # For each reach,
                 # at the end of flow calculation, Check if there is something to assimilate
                 # by evaluating whether the reach_has_gage array has a value different from
-                # the initialized value, -1.
+                # the initialized value, np.iinfo(np.int32).min (the minimum possible integer).
 
                 # TODO: If it were possible to invert the time and reach loops
                 # (should be possible for the MC), then this check could be

--- a/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
@@ -5,8 +5,8 @@ from itertools import chain
 from operator import itemgetter
 from array import array
 from numpy cimport ndarray  # TODO: Do we need to import numpy and ndarray separately?
-from libc.math cimport exp, isnan, NAN
-cimport numpy as np
+from libc.math cimport isnan, NAN
+cimport numpy as np  # TODO: We are cimporting and importing numpy into the same symbol, 'np'. Problem?
 cimport cython
 from libc.stdlib cimport malloc, free
 from libc.stdio cimport printf

--- a/src/python_routing_v02/troute/routing/fast_reach/simple_da.pxd
+++ b/src/python_routing_v02/troute/routing/fast_reach/simple_da.pxd
@@ -1,4 +1,4 @@
-cdef (float, float) simple_da(
+cdef (float, float, float, float) simple_da(
     const float timestep,
     const float routing_period,
     const float decay_coeff,

--- a/src/python_routing_v02/troute/routing/fast_reach/simple_da.pxd
+++ b/src/python_routing_v02/troute/routing/fast_reach/simple_da.pxd
@@ -1,4 +1,4 @@
-cdef float simple_da(
+cdef (float, float) simple_da(
     const float timestep,
     const float routing_period,
     const float decay_coeff,

--- a/src/python_routing_v02/troute/routing/fast_reach/simple_da.pxd
+++ b/src/python_routing_v02/troute/routing/fast_reach/simple_da.pxd
@@ -7,6 +7,7 @@ cdef (float, float, float, float) simple_da(
     const float model_val,
     float lastobs_time,
     float lastobs_val,
+    bint da_check_gage=*,
 ) nogil
 
 

--- a/src/python_routing_v02/troute/routing/fast_reach/simple_da.pxd
+++ b/src/python_routing_v02/troute/routing/fast_reach/simple_da.pxd
@@ -1,3 +1,15 @@
+cdef float simple_da(
+    const float timestep,
+    const float routing_period,
+    const float decay_coeff,
+    const float gage_maxtimestep,
+    const float target_val,
+    const float model_val,
+    float lastobs_time,
+    float lastobs_val,
+) nogil
+
+
 cdef float simple_da_with_decay(
     const float last_valid_obs,
     const float model_val,

--- a/src/python_routing_v02/troute/routing/fast_reach/simple_da.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/simple_da.pyx
@@ -1,6 +1,7 @@
 from libc.math cimport exp, isnan
 # from libc.stdio cimport printf
 
+# TODO: remove unused math functions from mc_reach.pyx
 
 cpdef float simple_da_with_decay_py(
     const float last_valid_obs,
@@ -17,6 +18,63 @@ cpdef float simple_da_with_decay_py(
         minutes_since_last_valid,
         decay_coeff,
     )
+
+
+cdef float simple_da(
+    const float timestep,
+    const float routing_period,
+    const float decay_coeff,
+    const float gage_maxtimestep,
+    const float target_val,
+    const float model_val,
+    float lastobs_time,
+    float lastobs_val,
+) nogil:
+    """
+    wrapper function to compute all DA elements
+    """
+    cdef float replacement_val, nudge, da_weighted_shift, da_decay_minutes,
+    # cdef float lastobs_timestep, lastobs_value,
+
+    #printf("gages_size: %d\t", gages_size)
+    #printf("reach_has_gage[i]: %d\t", reach_has_gage[i])
+    #printf("num_reaches: %d\t", num_reaches)
+    #printf("i: %d\n", i)
+
+    # TODO: It is possible to remove the following branching logic if
+    # we just loop over the timesteps during DA and post-DA, if that
+    # is a major performance optimization. On the flip side, it would
+    # probably introduce unwanted code complexity.
+    if (timestep < gage_maxtimestep and not isnan(target_val)):
+        replacement_val = target_val
+        # add/update lastobs_timestep
+        lastobs_time = (timestep - 1) * routing_period
+        lastobs_val = target_val
+    else:
+        da_decay_minutes = ((timestep - 1) * routing_period - lastobs_time) / 60 # seconds to minutes
+        da_weighted_shift = obs_persist_shift(lastobs_val, model_val, da_decay_minutes, decay_coeff)
+        nudge = da_weighted_shift
+        # TODO: we need to export these values
+        replacement_val = simple_da_with_decay(lastobs_val, model_val, da_decay_minutes, decay_coeff)
+
+        # if gage_i == da_check_gage:
+        #     printf("gages_size: %d\t", gages_size)
+        #     printf("reach_has_gage[i]: %d\t", reach_has_gage[i])
+        #     printf("num_reaches: %d\t", num_reaches)
+        #     printf("i: %d\t", i)
+
+        #     printf("ts: %d\t", timestep)
+        #     printf("maxts: %d\t", gage_maxtimestep)
+        #     printf("a: %g\t", a)
+        #     printf("min: %g\t", da_decay_minutes)
+        #     printf("lo_ts: %d\t", lastobs_timestep[gage_i])
+        #     printf("ndg: %g\t", da_weighted_shift)
+        #     printf("lov: %g\t", lastobs_val)
+        #     printf("orig: %g\t", model_val)
+        #     printf("new: %g\t", replacement_val)
+        #     printf("\n")
+        return replacement_val
+        # return nudge, replacement_val
 
 
 cdef float simple_da_with_decay(

--- a/src/python_routing_v02/troute/routing/fast_reach/simple_da.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/simple_da.pyx
@@ -1,7 +1,6 @@
 from libc.math cimport exp, isnan
 from libc.stdio cimport printf
 
-# TODO: remove unused math functions from mc_reach.pyx
 
 cpdef float simple_da_with_decay_py(
     const float last_valid_obs,

--- a/src/python_routing_v02/troute/routing/fast_reach/simple_da.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/simple_da.pyx
@@ -1,5 +1,5 @@
 from libc.math cimport exp, isnan
-# from libc.stdio cimport printf
+from libc.stdio cimport printf
 
 # TODO: remove unused math functions from mc_reach.pyx
 
@@ -29,6 +29,7 @@ cdef (float, float, float, float) simple_da(
     const float model_val,
     float lastobs_time,
     float lastobs_val,
+    bint da_check_gage = 0,
 ) nogil:
     """
     wrapper function to compute all DA elements
@@ -36,22 +37,26 @@ cdef (float, float, float, float) simple_da(
     cdef float replacement_val, nudge_val, da_weighted_shift, da_decay_minutes,
     # cdef float lastobs_timestep, lastobs_value,
 
-    #printf("gages_size: %d\t", gages_size)
-    #printf("reach_has_gage[i]: %d\t", reach_has_gage[i])
-    #printf("num_reaches: %d\t", num_reaches)
-    #printf("i: %d\n", i)
-
     # TODO: It is possible to remove the following branching logic if
     # we just loop over the timesteps during DA and post-DA, if that
     # is a major performance optimization. On the flip side, it would
     # probably introduce unwanted code complexity.
     if (timestep < gage_maxtimestep and not isnan(target_val)):
+    if isnan(target_val):
+        if da_check_gage:
+            printf("THIS IS A NAN\t")
+        if da_check_gage:
+            printf("replace\t")
         replacement_val = target_val
         nudge_val = target_val - model_val
         # add/update lastobs_timestep
         lastobs_time = (timestep - 1) * routing_period
         lastobs_val = target_val
     else:
+        if da_check_gage:
+            printf("So we are fixing that...\t")
+        if da_check_gage:
+            printf("decay; target: %g\t", target_val)
         da_decay_minutes = ((timestep - 1) * routing_period - lastobs_time) / 60 # seconds to minutes
         da_weighted_shift = obs_persist_shift(lastobs_val, model_val, da_decay_minutes, decay_coeff)
         nudge_val = da_weighted_shift
@@ -59,22 +64,17 @@ cdef (float, float, float, float) simple_da(
         # replacement_val = simple_da_with_decay(lastobs_val, model_val, da_decay_minutes, decay_coeff)
         replacement_val = model_val + da_weighted_shift
 
-        # if gage_i == da_check_gage:
-        #     printf("gages_size: %d\t", gages_size)
-        #     printf("reach_has_gage[i]: %d\t", reach_has_gage[i])
-        #     printf("num_reaches: %d\t", num_reaches)
-        #     printf("i: %d\t", i)
-
-        #     printf("ts: %d\t", timestep)
-        #     printf("maxts: %d\t", gage_maxtimestep)
-        #     printf("a: %g\t", a)
-        #     printf("min: %g\t", da_decay_minutes)
-        #     printf("lo_ts: %d\t", lastobs_timestep[gage_i])
-        #     printf("ndg: %g\t", da_weighted_shift)
-        #     printf("lov: %g\t", lastobs_val)
-        #     printf("orig: %g\t", model_val)
-        #     printf("new: %g\t", replacement_val)
-        #     printf("\n")
+        if da_check_gage:
+            printf("a: %g\t", decay_coeff)
+            printf("ts: %g\t", timestep)
+            printf("dt: %g\t", routing_period)
+            printf("min: %g\t", da_decay_minutes)
+            printf("lo_t: %d\t", lastobs_time)
+            printf("lov: %g\t", lastobs_val)
+            printf("ndg: %g\t", da_weighted_shift)
+            printf("orig: %g\t", model_val)
+            printf("new: %g\t", replacement_val)
+            printf("\n")
 
     return replacement_val, nudge_val, lastobs_time, lastobs_val,
 

--- a/src/python_routing_v02/troute/routing/fast_reach/simple_da.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/simple_da.pyx
@@ -41,10 +41,10 @@ cdef (float, float, float, float) simple_da(
     # we just loop over the timesteps during DA and post-DA, if that
     # is a major performance optimization. On the flip side, it would
     # probably introduce unwanted code complexity.
-    if (timestep < gage_maxtimestep and not isnan(target_val)):
     if isnan(target_val):
         if da_check_gage:
             printf("THIS IS A NAN\t")
+    if ((timestep <= gage_maxtimestep) and not (isnan(target_val))):
         if da_check_gage:
             printf("replace\t")
         replacement_val = target_val

--- a/src/python_routing_v02/troute/routing/fast_reach/simple_da.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/simple_da.pyx
@@ -20,7 +20,7 @@ cpdef float simple_da_with_decay_py(
     )
 
 
-cdef (float, float) simple_da(
+cdef (float, float, float, float) simple_da(
     const float timestep,
     const float routing_period,
     const float decay_coeff,
@@ -76,7 +76,7 @@ cdef (float, float) simple_da(
         #     printf("new: %g\t", replacement_val)
         #     printf("\n")
 
-    return replacement_val, nudge_val
+    return replacement_val, nudge_val, lastobs_time, lastobs_val,
 
 
 cdef float simple_da_with_decay(

--- a/src/python_routing_v02/troute/routing/fast_reach/simple_da.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/simple_da.pyx
@@ -47,6 +47,7 @@ cdef (float, float) simple_da(
     # probably introduce unwanted code complexity.
     if (timestep < gage_maxtimestep and not isnan(target_val)):
         replacement_val = target_val
+        nudge_val = target_val - model_val
         # add/update lastobs_timestep
         lastobs_time = (timestep - 1) * routing_period
         lastobs_val = target_val
@@ -55,7 +56,8 @@ cdef (float, float) simple_da(
         da_weighted_shift = obs_persist_shift(lastobs_val, model_val, da_decay_minutes, decay_coeff)
         nudge_val = da_weighted_shift
         # TODO: we need to export these values
-        replacement_val = simple_da_with_decay(lastobs_val, model_val, da_decay_minutes, decay_coeff)
+        # replacement_val = simple_da_with_decay(lastobs_val, model_val, da_decay_minutes, decay_coeff)
+        replacement_val = model_val + da_weighted_shift
 
         # if gage_i == da_check_gage:
         #     printf("gages_size: %d\t", gages_size)
@@ -74,7 +76,7 @@ cdef (float, float) simple_da(
         #     printf("new: %g\t", replacement_val)
         #     printf("\n")
 
-        return replacement_val, nudge_val
+    return replacement_val, nudge_val
 
 
 cdef float simple_da_with_decay(

--- a/src/python_routing_v02/troute/routing/fast_reach/simple_da.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/simple_da.pyx
@@ -20,7 +20,7 @@ cpdef float simple_da_with_decay_py(
     )
 
 
-cdef float simple_da(
+cdef (float, float) simple_da(
     const float timestep,
     const float routing_period,
     const float decay_coeff,
@@ -33,7 +33,7 @@ cdef float simple_da(
     """
     wrapper function to compute all DA elements
     """
-    cdef float replacement_val, nudge, da_weighted_shift, da_decay_minutes,
+    cdef float replacement_val, nudge_val, da_weighted_shift, da_decay_minutes,
     # cdef float lastobs_timestep, lastobs_value,
 
     #printf("gages_size: %d\t", gages_size)
@@ -53,7 +53,7 @@ cdef float simple_da(
     else:
         da_decay_minutes = ((timestep - 1) * routing_period - lastobs_time) / 60 # seconds to minutes
         da_weighted_shift = obs_persist_shift(lastobs_val, model_val, da_decay_minutes, decay_coeff)
-        nudge = da_weighted_shift
+        nudge_val = da_weighted_shift
         # TODO: we need to export these values
         replacement_val = simple_da_with_decay(lastobs_val, model_val, da_decay_minutes, decay_coeff)
 
@@ -73,8 +73,8 @@ cdef float simple_da(
         #     printf("orig: %g\t", model_val)
         #     printf("new: %g\t", replacement_val)
         #     printf("\n")
-        return replacement_val
-        # return nudge, replacement_val
+
+        return replacement_val, nudge_val
 
 
 cdef float simple_da_with_decay(


### PR DESCRIPTION
pr #358 left a few items incomplete on the `V02-caching` and `V02-structured-obj` computation modes. Those are not target operational modes so the PR was merged in spite of that. 

This PR fixes those items (using the loop-less da procedure; using `_i` for temporary indexes) and also updates the `V02-structured` DA algorithm with a minor but important update to the timestep indexing. 

The output parity is now slightly better: 
![image](https://user-images.githubusercontent.com/53343824/130123692-ba86bc80-1fe7-4c9c-84fe-cd304a110b6d.png)
