### PR TITLE
Timestamp bugfix

### DIFF
--- a/src/python_routing_v02/troute/routing/compute.py
+++ b/src/python_routing_v02/troute/routing/compute.py
@@ -28,6 +28,17 @@ _compute_func_map = defaultdict(
 )
 
 
+def _format_qlat_start_time(qlat_start_time):
+    if not isinstance(qlat_start_time,datetime):
+        try:
+            return datetime.strptime(qlat_start_time, '%Y-%m-%d %H:%M:%S')
+        except:  # TODO: make sure this doesn't introduce a silent error
+            return datetime.now()
+
+    else:
+        return qlat_start_time
+
+
 def _build_reach_type_list(reach_list, wbodies_segs):
 
     reach_type_list = [
@@ -315,10 +326,7 @@ def compute_nhd_routing_v02(
 
                     qlat_time_step_seconds = qts_subdivisions * dt
 
-                    if not isinstance(qlat_start_time,datetime):
-                        qlat_start_time_datetime_object = datetime.strptime(qlat_start_time, '%Y-%m-%d %H:%M:%S')
-                    else:
-                        qlat_start_time_datetime_object =  qlat_start_time
+                    qlat_start_time_datetime_object =  _format_qlat_start_time(qlat_start_time)
 
                     model_start_time_datetime_object = qlat_start_time_datetime_object \
                     - timedelta(seconds=qlat_time_step_seconds)
@@ -530,10 +538,7 @@ def compute_nhd_routing_v02(
 
                     qlat_time_step_seconds = qts_subdivisions * dt
 
-                    if not isinstance(qlat_start_time,datetime):
-                        qlat_start_time_datetime_object = datetime.strptime(qlat_start_time, '%Y-%m-%d %H:%M:%S')
-                    else:
-                        qlat_start_time_datetime_object =  qlat_start_time
+                    qlat_start_time_datetime_object =  _format_qlat_start_time(qlat_start_time)
 
                     model_start_time_datetime_object = qlat_start_time_datetime_object \
                     - timedelta(seconds=qlat_time_step_seconds)
@@ -730,10 +735,7 @@ def compute_nhd_routing_v02(
 
                     qlat_time_step_seconds = qts_subdivisions * dt
 
-                    if not isinstance(qlat_start_time,datetime):
-                        qlat_start_time_datetime_object = datetime.strptime(qlat_start_time, '%Y-%m-%d %H:%M:%S')
-                    else:
-                        qlat_start_time_datetime_object =  qlat_start_time
+                    qlat_start_time_datetime_object =  _format_qlat_start_time(qlat_start_time)
 
                     model_start_time_datetime_object = qlat_start_time_datetime_object \
                     - timedelta(seconds=qlat_time_step_seconds)
@@ -880,10 +882,7 @@ def compute_nhd_routing_v02(
 
                 qlat_time_step_seconds = qts_subdivisions * dt
 
-                if not isinstance(qlat_start_time,datetime):
-                    qlat_start_time_datetime_object = datetime.strptime(qlat_start_time, '%Y-%m-%d %H:%M:%S')
-                else:
-                    qlat_start_time_datetime_object =  qlat_start_time
+                qlat_start_time_datetime_object =  _format_qlat_start_time(qlat_start_time)
 
                 model_start_time_datetime_object = qlat_start_time_datetime_object \
                 - timedelta(seconds=qlat_time_step_seconds)
@@ -998,10 +997,7 @@ def compute_nhd_routing_v02(
 
             qlat_time_step_seconds = qts_subdivisions * dt
 
-            if not isinstance(qlat_start_time,datetime):
-                qlat_start_time_datetime_object = datetime.strptime(qlat_start_time, '%Y-%m-%d %H:%M:%S')
-            else:
-                qlat_start_time_datetime_object =  qlat_start_time
+            qlat_start_time_datetime_object =  _format_qlat_start_time(qlat_start_time)
 
             model_start_time_datetime_object = qlat_start_time_datetime_object \
             - timedelta(seconds=qlat_time_step_seconds)


### PR DESCRIPTION
The timestamp in the qlateral files is sometimes a datetime object, sometimes a string. So, we had logic in each parallel execution mode that handled both cases. 

But if qlat_const is used to supply a constant qlateral, there is no date of any kind in the dataframe. This fixes the issues where that lack of a date value threw an error and also encapsulates the logic into a function (`_format_qlat_start_time`) to reduce the duplication.

~~*Note: The commits suggested in #380 are contained in this PR. If needed  (i.e., if that PR is determined to be un-needed), the single relevant commit for this PR, [027f5a548b6d6a96eade154494a0540ecb37ef3b](https://github.com/NOAA-OWP/t-route/pull/388/commits/027f5a548b6d6a96eade154494a0540ecb37ef3b) could be rebased on something more useful.~~
The relevant commit was rebased.