### PR TITLE
Add MC kernel unit test

### DIFF
--- a/src/fortran_routing/mc_pylink_v00/MC_singleSeg_singleTS/MCsingleSegStime_f2py_NOLOOP.f90
+++ b/src/fortran_routing/mc_pylink_v00/MC_singleSeg_singleTS/MCsingleSegStime_f2py_NOLOOP.f90
@@ -181,6 +181,7 @@ subroutine muskingcungenwm(dt, qup, quc, qdp, ql, dx, bw, tw, twcc,&
     ! call courant subroutine here
     ! *************************************************************
     call courant(h, bfd, bw, twcc, ncc, s0, n, z, dx, dt, ck, cn)
+    !print*, "deep down", depthc
 
 end subroutine muskingcungenwm
 

--- a/src/fortran_routing/mc_pylink_v00/MC_singleSeg_singleTS/pyMCsingleSegStime_NoLoop.f90
+++ b/src/fortran_routing/mc_pylink_v00/MC_singleSeg_singleTS/pyMCsingleSegStime_NoLoop.f90
@@ -17,6 +17,7 @@ subroutine c_muskingcungenwm(dt, qup, quc, qdp, ql, dx, bw, tw, twcc,&
 
     call muskingcungenwm(dt, qup, quc, qdp, ql, dx, bw, tw, twcc,&
     n, ncc, cs, s0, velp, depthp, qdc, velc, depthc, ck, cn, X)
+    !print*, "fortran c_bind", depthc
     
 end subroutine c_muskingcungenwm
 end module muskingcunge_interface

--- a/src/fortran_routing/mc_pylink_v00/MC_singleSeg_singleTS/test_MC_kernel.py
+++ b/src/fortran_routing/mc_pylink_v00/MC_singleSeg_singleTS/test_MC_kernel.py
@@ -1,0 +1,90 @@
+import pytest
+import mc_sseg_stime_NOLOOP_demo as demo
+
+"""
+Statistics from the CONUS NWM 2.1 dataset
+            mean     std_dev      min        25%         50%          75%           max
+dx    1,947.776    1,965.625     1.000   558.000   1,549.000    2,631.000    95,714.000 
+bw        5.290        9.407     0.135     1.904       2.769        4.889       230.035 
+tw        8.817       15.678     0.225     3.173       4.615        8.148       383.392 
+twcc     26.450       47.033     0.674     9.518       13.845      24.443     1,150.175 
+n         0.058        0.003     0.040     0.060       0.060        0.060         0.060 
+ncc       0.117        0.006     0.080     0.120       0.120        0.120         0.120 
+cs        0.5857       0.1945    0.0846    0.4625      0.5944       0.7012        2.254 
+s0        0.02150      0.04585   0.00001   0.00100     0.00600      0.01900       4.600 
+qlat                              1       500000
+qup                               1       500000
+quc                               1       500000
+qdp                               1       500000
+depthp                            1       100
+dt==300
+
+*Legend*
+dt = Time step
+dx = segment length
+bw = Trapezoidal bottom width
+tw = Channel top width (at bankfull)
+twcc = Flood plain width
+n_manning = manning roughness of channel
+n_manning_cc = manning roughness of floodplain
+cs = channel trapezoidal sideslope
+s0 = downstream segment bed slope
+qlat = Lateral inflow in this time step
+qup = inflow into segment from upstream in previous timestep
+quc = inflow into segment from upstream in current timestep
+qdp = outflow from segment in previous timestep
+depthp = depth in segment in previous timestep
+qdc = outflow from segment in current timestep (MC solution yields this value)
+
+*Notes:*
+ncc == 2 * n
+
+twcc == 3 * tw
+
+tw >= bw
+
+prior tests have varied dt, even though it is always held at 300 for NWM simulations to date.
+"""
+
+input_tup = (
+    "single",  # calculation precision (NOT USED)
+    300.0,  # Time step
+    1800.0,  # segment length
+    112.0,  # Trapezoidal bottom width
+    448.0,  # Channel top width (at bankfull)
+    623.5999755859375,  # Flood plain width
+    0.02800000086426735,  # manning roughness of channel
+    0.03136000037193298,  # manning roughness of floodplain
+    1.399999976158142,  # channel trapezoidal sideslope
+    0.0017999999690800905,  # downstream segment bed slope
+    40.0,  # Lateral inflow in this time step
+    4509,
+    5098,
+    5017,
+    30,
+)
+
+qdc1, qdc2, velc1, velc2, depthc1, depthc2 = demo.compare_methods(*input_tup)
+
+
+def test_MC_kernel_q():
+# TODO: Take advantage of ranges above to build a state-space 
+# exploration of potential inputs and confirm it parity across all inputs
+
+    assert qdc1 == qdc2
+
+
+def test_MC_kernel_vel():
+# TODO: Take advantage of ranges above to build a state-space 
+# exploration of potential inputs and confirm it parity across all inputs
+
+    assert velc1 == velc2
+ 
+
+def test_MC_kernel_depth():
+# TODO: Take advantage of ranges above to build a state-space 
+# exploration of potential inputs and confirm it parity across all inputs
+
+   assert depthc1 == depthc2
+
+

--- a/src/fortran_routing/mc_pylink_v00/MC_singleSeg_singleTS/test_suite_parameters.py
+++ b/src/fortran_routing/mc_pylink_v00/MC_singleSeg_singleTS/test_suite_parameters.py
@@ -1,0 +1,58 @@
+# see https://docs.google.com/spreadsheets/d/1kRdpoY2Ul0vZP2l9XXXT4tVA7QIPi8Co/edit#gid=1870807915
+"""
+Statistics from the CONUS NWM 2.1 dataset
+            mean     std_dev      min        25%         50%          75%           max
+dx    1,947.776    1,965.625     1.000   558.000   1,549.000    2,631.000    95,714.000 
+bw        5.290        9.407     0.135     1.904       2.769        4.889       230.035 
+tw        8.817       15.678     0.225     3.173       4.615        8.148       383.392 
+twcc     26.450       47.033     0.674     9.518       13.845      24.443     1,150.175 
+n         0.058        0.003     0.040     0.060       0.060        0.060         0.060 
+ncc       0.117        0.006     0.080     0.120       0.120        0.120         0.120 
+cs        0.5857       0.1945    0.0846    0.4625      0.5944       0.7012        2.254 
+s0        0.02150      0.04585   0.00001   0.00100     0.00600      0.01900       4.600 
+qlat                              1       500000
+qup                               1       500000
+quc                               1       500000
+qdp                               1       500000
+depthp                            1       100
+dt==300
+"""
+
+dx = ( 1947.776, 1965.625, 1.000, 558.000, 1549.000, 2631.000, 95714.000,)
+bw = ( 5.290, 9.407, 0.135, 1.904, 2.769, 4.889, 230.035,)
+tw = ( 8.817, 15.678, 0.225, 3.173, 4.615, 8.148, 383.392,)
+twcc = ( 26.450, 47.033, 0.674, 9.518, 13.845, 24.443, 1150.175,)
+n = ( 0.058, 0.003, 0.040, 0.060, 0.060, 0.060, 0.060,)
+ncc = ( 0.117, 0.006, 0.080, 0.120, 0.120, 0.120, 0.120,)
+cs = ( 0.5857, 0.1945, 0.0846, 0.4625, 0.5944, 0.7012, 2.254,)
+s0 = ( 0.02150, 0.04585, 0.00001, 0.00100, 0.00600, 0.01900, 4.600,)
+qlat = (1, 500000)
+qup = (1, 500000)
+quc = (1, 500000)
+qdp = (1, 500000)
+depthp = (1, 100)
+dt = (5, 500)
+
+from itertools import zip_longest
+import numpy as np
+
+rg = 15000
+
+test_suite_parameter_set = zip_longest(
+    np.random.uniform(dx[2], dx[6], rg),
+    np.random.uniform(bw[2], dx[6], rg),
+    np.random.uniform(tw[2], tw[6], rg),
+    np.random.uniform(twcc[2], twcc[6], rg),
+    np.random.uniform(n[2], n[6], rg),
+    np.random.uniform(ncc[2], ncc[6], rg),
+    np.random.uniform(cs[2], cs[6], rg),
+    np.random.uniform(s0[2], s0[6], rg),
+    np.random.uniform(qlat[0], qlat[1], rg),
+    np.random.uniform(qup[0], qup[1], rg),
+    np.random.uniform(quc[0], quc[1], rg),
+    np.random.uniform(qdp[0], qdp[1], rg),
+    np.random.uniform(depthp[0], depthp[1], rg),
+    np.random.uniform(dt[0], dt[1], rg),
+)
+
+# print([len(t) for t in test_suite_parameter_set])

--- a/src/python_routing_v02/setup.py
+++ b/src/python_routing_v02/setup.py
@@ -25,6 +25,7 @@ reach = Extension(
         "troute/routing/fast_reach/pymc_single_seg.o",
     ],
     extra_compile_args=["-g"],
+    # libraries=["gfortran"],
 )
 
 mc_reach = Extension(

--- a/src/python_routing_v02/troute/routing/fast_reach/reach.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/reach.pyx
@@ -1,4 +1,5 @@
 import cython
+#from libc.stdio cimport printf
 
 from .fortran_wrappers cimport c_muskingcungenwm
 
@@ -28,6 +29,7 @@ cdef void muskingcunge(float dt,
         float cn = 0.0
         float X = 0.0
 
+    #printf("reach.pyx before %3.9f\t", depthc)
     c_muskingcungenwm(
         &dt,
         &qup,
@@ -50,6 +52,7 @@ cdef void muskingcunge(float dt,
         &ck,
         &cn,
         &X)
+    #printf("reach.pyx after %3.9f\t", depthc)
 
     rv.qdc = qdc
     rv.depthc = depthc


### PR DESCRIPTION
TL;DR Added a unit test and a more comprehensive test script to demonstrate parity between kernels. But... under certain conditions, parity is not demonstrated!

Execute
`src/fortran_routing/mc_pylink_v00/MC_singleSeg_singleTS/mc_sseg_stime_NOLOOP_demo.py` for a simple parity test printed to the screen. This shows that the SUBMUSKINGCUNGE function copied directly out of WRF-Hydro here produces the same kernel result for a pile of random inputs as our kernel. 
``` py
First test low-flow, showing expected result depending on precision of calculation.
real double precision expected q: 0.7570107902354513 vel: 0.12373606306742324 depth: 0.02334451646521419
real single precision expected q: 0.7570106983184814 vel: 0.12373604625463486 depth: 0.02334451675415039
real single precision computed via updated method q: 0.7570106983184814 vel: 0.12373604625463486 depth: 0.02334451675415039
real single precision computed via WRF-Hydro method q: 0.7570106983184814 vel: 0.12373604625463486 depth: 0.02334451675415039

Second set of inputs activating compound channel
original minus cython method q:  0.000000000000000 vel:  0.000000000000000 depth:  0.000000000000000
original minus cython method q:  0.000000000000000 vel:  0.000000000000000 depth:  0.000000000000000
original minus cython method q:  0.000000000000000 vel:  0.000000000000000 depth:  0.000000000000000
original minus cython method q:  0.000000000000000 vel:  0.000000000000000 depth:  0.000000000000000
original minus cython method q:  0.000000000000000 vel:  0.000000000000000 depth:  0.000000000000000
original minus cython method q:  0.000000000000000 vel:  0.000000000000000 depth:  0.000000000000000
original minus cython method q:  0.000000000000000 vel:  0.000000000000000 depth:  0.000000000000000
```
etc.

Now
Execute pytest -v  in that folder...
``` python
(base) [MC_singleSeg_singleTS]$ pytest -v
=================================================================== test session starts ====================================================================
platform linux -- Python 3.8.5, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- bin/python
cachedir: .pytest_cache
rootdir: src/fortran_routing/mc_pylink_v00/MC_singleSeg_singleTS
plugins: repeat-0.9.1
collected 3 items

test_MC_kernel.py::test_MC_kernel_q PASSED                                                                                                           [ 33%]
test_MC_kernel.py::test_MC_kernel_vel FAILED                                                                                                         [ 66%]
test_MC_kernel.py::test_MC_kernel_depth FAILED                                                                                                       [100%]

========================================================================= FAILURES =========================================================================
____________________________________________________________________ test_MC_kernel_vel ____________________________________________________________________

    def test_MC_kernel_vel():
    # TODO: Take advantage of ranges above to build a state-space
    # exploration of potential inputs and confirm it parity across all inputs

>       assert velc1 == velc2
E       assert 0.147629514336586 == 0.1286672204732895
E         +0.147629514336586
E         -0.1286672204732895

test_MC_kernel.py:81: AssertionError
___________________________________________________________________ test_MC_kernel_depth ___________________________________________________________________

    def test_MC_kernel_depth():
    # TODO: Take advantage of ranges above to build a state-space
    # exploration of potential inputs and confirm it parity across all inputs

>      assert depthc1 == depthc2
E      assert 85.61236572265625 == 39.90999984741211
E        +85.61236572265625
E        -39.90999984741211

test_MC_kernel.py:88: AssertionError
================================================================= short test summary info ==================================================================
FAILED test_MC_kernel.py::test_MC_kernel_vel - assert 0.147629514336586 == 0.1286672204732895
FAILED test_MC_kernel.py::test_MC_kernel_depth - assert 85.61236572265625 == 39.90999984741211
=============================================================== 2 failed, 1 passed in 1.32s ================================================================
(base) [MC_singleSeg_singleTS]$ pytest -v
=================================================================== test session starts ====================================================================
platform linux -- Python 3.8.5, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- bin/python
cachedir: .pytest_cache
rootdir: src/fortran_routing/mc_pylink_v00/MC_singleSeg_singleTS
plugins: repeat-0.9.1
collected 3 items

test_MC_kernel.py::test_MC_kernel_q PASSED                                                                                                           [ 33%]
test_MC_kernel.py::test_MC_kernel_vel PASSED                                                                                                         [ 66%]
test_MC_kernel.py::test_MC_kernel_depth PASSED                                                                                                       [100%]

==================================================================== 3 passed in 1.28s =====================================================================
```
Output appears to be volatile -- two identical pytest executions, different results. 

In the process of examining the errors, we added print statements to various portions of the calling stack. When the print statement is activated in the `src/fortran_routing/mc_pylink_v00/MC_singleSeg_singleTS/MCsingleSegStime_f2py_NOLOOP.f90`, the errors disappear, like what is reported [here ](https://stackoverflow.com/questions/27920043/adding-removing-a-print-statement-changes-variables) and [here](https://community.intel.com/t5/Intel-Fortran-Compiler/Adding-debugging-print-statements-changes-variable-values/td-p/740196).
