### PR TITLE
change list of waterbodies to sets in split_at_waterbodies_and_juncti…

### DIFF
--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -313,6 +313,9 @@ def main_v02(argv):
     break_network_at_waterbodies = run_parameters.get(
         "break_network_at_waterbodies", False
     )
+    break_network_at_gages = supernetwork_parameters.get(
+        "break_network_at_gages", False
+    )
 
     if showtiming:
         main_start_time = time.time()
@@ -394,11 +397,13 @@ def main_v02(argv):
     if verbose:
         print("organizing connections into reaches ...")
 
+    network_break_segments = set()
+    if break_network_at_waterbodies:
+        network_break_segments = network_break_segments.union(wbody_conn.values())
+    if break_network_at_gages:
+        network_break_segments = network_break_segments.union(gages.keys())
     independent_networks, reaches_bytw, rconn = nnu.organize_independent_networks(
-        connections,
-        list(waterbodies_df.index.values)
-        if break_network_at_waterbodies
-        else None,
+        connections, network_break_segments,
     )
     if verbose:
         print("reach organization complete")

--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -499,7 +499,7 @@ def organize_independent_networks(connections, wbodies=None):
     for tw, net in independent_networks.items():
         if wbodies:
             path_func = partial(
-                nhd_network.split_at_waterbodies_and_junctions, wbodies, net
+                nhd_network.split_at_waterbodies_and_junctions, set(wbodies), net
             )
         else:
             path_func = partial(nhd_network.split_at_junction, net)

--- a/src/python_routing_v02/troute/routing/compute.py
+++ b/src/python_routing_v02/troute/routing/compute.py
@@ -178,7 +178,7 @@ def compute_nhd_routing_v02(
                 else:
                     path_func = partial(
                         nhd_network.split_at_waterbodies_and_junctions,
-                        list(waterbodies_df.index.values),
+                        set(waterbodies_df.index.values),
                         rconn_subn
                         )
                 reaches_ordered_bysubntw[order][
@@ -436,7 +436,7 @@ def compute_nhd_routing_v02(
                 else:
                     path_func = partial(
                         nhd_network.split_at_waterbodies_and_junctions,
-                        list(waterbodies_df.index.values),
+                        set(waterbodies_df.index.values),
                         rconn_subn
                         )
                 reaches_ordered_bysubntw[order][

--- a/src/python_routing_v02/troute/routing/diffusive_utils.py
+++ b/src/python_routing_v02/troute/routing/diffusive_utils.py
@@ -505,7 +505,7 @@ def diffusive_input_data_v02(
                     upstream_flow_array[j, int(i/qts_subdivisions)] = val
  
     # Order reaches by junction depth
-    path_func = partial(nhd_network.split_at_waterbodies_and_junctions, offnet_wbodies, rconn)
+    path_func = partial(nhd_network.split_at_waterbodies_and_junctions, set(offnet_wbodies), rconn)
     tr = nhd_network.dfs_decomposition_depth_tuple(rconn, path_func)    
     
     jorder_reaches = sorted(tr, key=lambda x: x[0])


### PR DESCRIPTION
This PR addresses the issue of very long evaluation times needed to run `nnu.organize_independent_networks` at CONUS scale with splitting at waterbodies (#391). This function was taking hours to run, and now takes seconds. The root cause of the issue was that `nhd_network.split_at_waterbodies_and_junctions` was searching through LISTS of waterbodies, which, when large, are burdensome to search. The fix implemented is to make sure that SETS of waterbodies are passed to this function. 

Before this fix, the  `nnu.organize_independent_networks` took over an hour to evaluate. Now, it takes 21 seconds. 