### PR TITLE
add relative difference as a statistic in parity output

### DIFF
--- a/src/python_routing_v02/build_tests.py
+++ b/src/python_routing_v02/build_tests.py
@@ -262,6 +262,9 @@ def parity_check(
         compare["absdiff"] = np.abs(
             compare["flow, wrf (cms)"] - compare["flow, t-route (cms)"]
         )
+        compare["rel_absdiff"] = np.abs(
+            (compare["flow, wrf (cms)"] - compare["flow, t-route (cms)"]) / compare["flow, wrf (cms)"]
+        )
 
         print(compare)
         print(compare.describe())

--- a/src/python_routing_v02/build_tests.py
+++ b/src/python_routing_v02/build_tests.py
@@ -258,6 +258,7 @@ def parity_check(
         # compare dataframes
         compare = pd.concat([wrf, trt], axis=1, sort=False, join="inner")
         compare["diff"] = compare["flow, wrf (cms)"] - compare["flow, t-route (cms)"]
+        compare["rel_diff"] = (compare["flow, wrf (cms)"] - compare["flow, t-route (cms)"]) / compare["flow, wrf (cms)"]
         compare["absdiff"] = np.abs(
             compare["flow, wrf (cms)"] - compare["flow, t-route (cms)"]
         )


### PR DESCRIPTION
The relative difference value is useful in determining significance of flow errors. 