### PR TITLE
Update USGS TimeSlice interpolation scheme and include quality control flags

### DIFF
--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -518,8 +518,6 @@ def main_v02(argv):
         usgs_qual_df = pd.DataFrame()
         lastobs_df = pd.DataFrame()
         da_parameter_dict = {}
-    
-    import pdb; pdb.set_trace()
 
     ################### Main Execution Loop across ordered networks
     if showtiming:

--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -504,7 +504,7 @@ def main_v02(argv):
         if verbose:
             print("creating usgs time_slice data array ...")
 
-            usgs_df, usgs_qual_df, lastobs_df, da_parameter_dict = nnu.build_data_assimilation(
+            usgs_df, lastobs_df, da_parameter_dict = nnu.build_data_assimilation(
                 data_assimilation_parameters
             )
 

--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -504,7 +504,7 @@ def main_v02(argv):
         if verbose:
             print("creating usgs time_slice data array ...")
 
-            usgs_df, lastobs_df, da_parameter_dict = nnu.build_data_assimilation(
+            usgs_df, usgs_qual_df, lastobs_df, da_parameter_dict = nnu.build_data_assimilation(
                 data_assimilation_parameters
             )
 
@@ -515,8 +515,11 @@ def main_v02(argv):
 
     else:
         usgs_df = pd.DataFrame()
+        usgs_qual_df = pd.DataFrame()
         lastobs_df = pd.DataFrame()
         da_parameter_dict = {}
+    
+    import pdb; pdb.set_trace()
 
     ################### Main Execution Loop across ordered networks
     if showtiming:

--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -515,7 +515,6 @@ def main_v02(argv):
 
     else:
         usgs_df = pd.DataFrame()
-        usgs_qual_df = pd.DataFrame()
         lastobs_df = pd.DataFrame()
         da_parameter_dict = {}
 

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -737,18 +737,15 @@ def get_usgs_from_time_slices_folder(
 
     TODO: Add reporting interval information to the gage preprocessing (timeslice generation)
     """
-    usgs_df_T = usgs_df_T.resample('min').interpolate(limit = max_fill_1min, limit_direction = 'both').resample('5min').asfreq()
+    usgs_df_T = (usgs_df_T.resample('min').
+                 interpolate(limit = max_fill_1min, limit_direction = 'both').
+                 resample('5min').
+                 asfreq().
+                 loc[date_time_start_center:,:])
+    
     usgs_df_new = usgs_df_T.transpose()
 
-    # TODO: At this point in the code, if we had a date parameter from
-    # the input file, we could truncate this list of possible dates to
-    # the values germane to the simulation.
-    # At this point, we trim the first value, which is, in our testing, always
-    # five minutes prior to model start (i.e., at [T0-1]:55).
-    usgs_df_new = usgs_df_new.reindex(columns=dates[1:])
-
     return usgs_df_new
-
 
 # TODO: Move channel restart above usgs to keep order with execution script
 def get_channel_restart_from_csv(

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -672,7 +672,6 @@ def get_usgs_from_time_slices_folder(
 
     dates = []
     for j in pd.date_range(date_time_obj_start, date_time_obj_end, freq="5min"):
-        # dates.append(j.strftime("%Y-%m-%d_%H:%M:00"))
         dates.append(j)
 
     """
@@ -681,15 +680,7 @@ def get_usgs_from_time_slices_folder(
     # dates_to_drop = usgs_df.columns.difference(dates)
     # dates_to_add = pd.Index(dates).difference(usgs_df.columns)
     """
-
-    # usgs_df = usgs_df.reindex(columns=dates)
-    # usgs_qual_df = usgs_qual_df.reindex(columns=dates)
-    # TODO: this index shifting is a data qa issue -- the time slices come in with extra values
-    # on the front end and we have to trim those.
-    # TODO: DO NOT ACCEPT THIS PR UNTIL WE ARE SURE THE DATES LINE UP!!
-    # usgs_df = usgs_df.iloc[:, 1:]
-    # usgs_qual_df = usgs_qual_df.iloc[:, 1:]
-
+    
     # NOTE: We omit linear interpolation to allow for the decay process to provide values if needed.
     # TODO: Implement a robust test verifying the intended output of the interpolation
     """
@@ -730,8 +721,6 @@ def get_usgs_from_time_slices_folder(
     usgs_df_T.index = pd.to_datetime(usgs_df_T.index, format = "%Y-%m-%d_%H:%M:%S")
 
     max_fill_1min = 59
-    # max_fill_1min = 14
-    # max_fill = 5
     """
     Note: The max_fill is applied when the series is being considered at a 1 minute interval
     14 minutes ensures no over-interpolation with 15-minute gage records, but creates
@@ -739,13 +728,9 @@ def get_usgs_from_time_slices_folder(
 
     TODO: Add reporting interval information to the gage preprocessing (timeslice generation)
     """
+        usgs_df_T = usgs_df_T.resample('min').interpolate(limit = max_fill_1min, limit_direction = 'both').resample('5min').asfreq()
+    usgs_df_new = usgs_df_T.transpose()
 
-    usgs_df_T = usgs_df_T.resample('min').interpolate(limit = max_fill_1min, limit_direction = 'both').resample('5min').asfreq()
-    usgs_df_T_T = usgs_df_T.transpose()
-    # Note: We have the option of re-interpolation again at a 5 minute increment, like we were doing before,
-    # but that seems unnecessary.
-    # usgs_df_new = usgs_df_T_T.interpolate(method='index', axis = 1, limit = max_fill, limit_direction = 'forward')
-    usgs_df_new = usgs_df_T_T
     # TODO: At this point in the code, if we had a date parameter from
     # the input file, we could truncate this list of possible dates to
     # the values germane to the simulation.

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -722,7 +722,7 @@ def get_usgs_from_time_slices_folder(
     usgs_df = usgs_df.mask(usgs_qual_df < qc_trehsh, np.nan)
 
     # screen-out erroneous flow observations
-    usgs_df = usgs_df.mask(usgs_df < 0, np.nan)
+    usgs_df = usgs_df.mask(usgs_df <= 0, np.nan)
 
     # ---- Interpolate USGS observations to time discretization of the simulation ----
     usgs_df_T = usgs_df.transpose()

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -653,7 +653,6 @@ def get_usgs_from_time_slices_folder(
         ds = xr.Dataset(data_vars=data_var_dict, coords={"gages": gage_da})
     df = ds.to_dataframe()
 
-
     usgs_df = (df.join(df2).
                reset_index().
                rename(columns={"index": "gages"}).
@@ -710,6 +709,7 @@ def get_usgs_from_time_slices_folder(
     usgs_qual_df = usgs_qual_df.mask(usgs_qual_df > 1, np.nan)
 
     # screen-out poor quality flow observations
+    # TODO: Bring qc_thresh parameter in from yaml as user input
     qc_trehsh = 1
     usgs_df = usgs_df.mask(usgs_qual_df < qc_trehsh, np.nan)
 
@@ -720,6 +720,7 @@ def get_usgs_from_time_slices_folder(
     usgs_df_T = usgs_df.transpose()
     usgs_df_T.index = pd.to_datetime(usgs_df_T.index, format = "%Y-%m-%d_%H:%M:%S")
 
+    # TODO: Bring max_fill_lmin parameter in from yaml as user input
     max_fill_1min = 59
     """
     Note: The max_fill is applied when the series is being considered at a 1 minute interval
@@ -728,7 +729,7 @@ def get_usgs_from_time_slices_folder(
 
     TODO: Add reporting interval information to the gage preprocessing (timeslice generation)
     """
-        usgs_df_T = usgs_df_T.resample('min').interpolate(limit = max_fill_1min, limit_direction = 'both').resample('5min').asfreq()
+    usgs_df_T = usgs_df_T.resample('min').interpolate(limit = max_fill_1min, limit_direction = 'both').resample('5min').asfreq()
     usgs_df_new = usgs_df_T.transpose()
 
     # TODO: At this point in the code, if we had a date parameter from

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -700,12 +700,28 @@ def get_usgs_from_time_slices_folder(
     last_obs_NaN = {"obs":NaN, "time":NaT}  # No valid recent observation
     ```
     """
-    # usgs_df = usgs_df.interpolate(method="linear", axis=1)
-    # usgs_df = usgs_df.interpolate(method="linear", axis=1, limit_direction="backward")
+    
+    # ---- Laugh testing ------
+    # scren-out erroneous qc flags
+    usgs_qual_df = usgs_qual_df.mask(usgs_qual_df < 0, np.nan)
+    usgs_qual_df = usgs_qual_df.mask(usgs_qual_df > 1, np.nan)
+    
+    # screen-out poor quality flow observations
+    qc_trehsh = 1
+    usgs_df = usgs_df.mask(usgs_qual_df < qc_trehsh, np.nan)
+    
+    # screen-out erroneous flow observations
+    usgs_df = usgs_df.mask(usgs_df < 0, np.nan)
+        
+    # ---- Interpolate USGS observations to time discretization of the simulation ----
+    usgs_df.columns = pd.to_datetime(usgs_df.columns, format = "%Y-%m-%d_%H:%M:00")
+    max_fill = 5
+    usgs_df = usgs_df.interpolate(method='index', axis = 1, limit = max_fill, limit_direction = 'forward')
+
     usgs_df.drop(usgs_df[usgs_df.iloc[:, 0] == -999999.000000].index, inplace=True)
     usgs_qual_df.drop(usgs_df[usgs_df.iloc[:, 0] == -999999.000000].index, inplace=True)
 
-    return usgs_df, usgs_qual_df
+    return usgs_df
 
 
 # TODO: Move channel restart above usgs to keep order with execution script

--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -639,12 +639,13 @@ def build_data_assimilation(data_assimilation_parameters):
     )
 
     usgs_df = pd.DataFrame()
+    usgs_qual_df = pd.DataFrame()
     last_obs_df = pd.DataFrame()
 
     if data_assimilation_csv:
         usgs_df = build_data_assimilation_csv(data_assimilation_parameters)
     elif data_assimilation_folder:
-        usgs_df = build_data_assimilation_folder(data_assimilation_parameters)
+        usgs_df, usgs_qual_df = build_data_assimilation_folder(data_assimilation_parameters)
 
     if last_obs_file:
         last_obs_df = nhd_io.build_last_obs_df(
@@ -659,7 +660,7 @@ def build_data_assimilation(data_assimilation_parameters):
 
     da_parameter_dict = {}
     da_parameter_dict["da_decay_coefficient"] = data_assimilation_parameters.get("da_decay_coefficient", 120)
-    return usgs_df, last_obs_df, da_parameter_dict
+    return usgs_df, usgs_qual_df, last_obs_df, da_parameter_dict
 
 
 def build_data_assimilation_csv(data_assimilation_parameters):
@@ -679,10 +680,10 @@ def build_data_assimilation_folder(data_assimilation_parameters):
             data_assimilation_parameters["data_assimilation_timeslices_folder"],
         ).resolve()
 
-        usgs_df = nhd_io.get_usgs_from_time_slices_folder(
+        usgs_df, usgs_qual_df = nhd_io.get_usgs_from_time_slices_folder(
             data_assimilation_parameters["wrf_hydro_da_channel_ID_crosswalk_file"],
             usgs_timeslices_folder,
             data_assimilation_parameters["data_assimilation_filter"],
         )
 
-    return usgs_df
+    return usgs_df, usgs_qual_df

--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -640,12 +640,11 @@ def build_data_assimilation(data_assimilation_parameters):
 
     usgs_df = pd.DataFrame()
     usgs_qual_df = pd.DataFrame()
-    last_obs_df = pd.DataFrame()
 
     if data_assimilation_csv:
         usgs_df = build_data_assimilation_csv(data_assimilation_parameters)
     elif data_assimilation_folder:
-        usgs_df, usgs_qual_df = build_data_assimilation_folder(data_assimilation_parameters)
+        usgs_df = build_data_assimilation_folder(data_assimilation_parameters)
 
     if last_obs_file:
         last_obs_df = nhd_io.build_last_obs_df(
@@ -660,7 +659,7 @@ def build_data_assimilation(data_assimilation_parameters):
 
     da_parameter_dict = {}
     da_parameter_dict["da_decay_coefficient"] = data_assimilation_parameters.get("da_decay_coefficient", 120)
-    return usgs_df, usgs_qual_df, last_obs_df, da_parameter_dict
+    return usgs_df, last_obs_df, da_parameter_dict
 
 
 def build_data_assimilation_csv(data_assimilation_parameters):
@@ -680,10 +679,10 @@ def build_data_assimilation_folder(data_assimilation_parameters):
             data_assimilation_parameters["data_assimilation_timeslices_folder"],
         ).resolve()
 
-        usgs_df, usgs_qual_df = nhd_io.get_usgs_from_time_slices_folder(
+        usgs_df = nhd_io.get_usgs_from_time_slices_folder(
             data_assimilation_parameters["wrf_hydro_da_channel_ID_crosswalk_file"],
             usgs_timeslices_folder,
             data_assimilation_parameters["data_assimilation_filter"],
         )
 
-    return usgs_df, usgs_qual_df
+    return usgs_df

--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -683,6 +683,7 @@ def build_data_assimilation_folder(data_assimilation_parameters):
             data_assimilation_parameters["wrf_hydro_da_channel_ID_crosswalk_file"],
             usgs_timeslices_folder,
             data_assimilation_parameters["data_assimilation_filter"],
+            data_assimilation_parameters.get("data_assimilation_interpolation_limit", 59)
         )
 
     return usgs_df


### PR DESCRIPTION
The interpolation scheme used upon read for the USGS time slice files controls a number of aspects of the ultimate result of the data assimilation scheme. This PR will accomplish the following: 
* Revise TimeSlice file loading to eliminate duplicating observations across unique times in the file. 
* Interpolate observations from given time intervals to a 5-minute frequency with NaN threshold (interpolation does extend through NaN gaps of a specified length). 
* Trim the temporal extent of usgs_df such that the first column is temporally aligned with restart time.
* Get quality flag data from TimeSlice files, organize data into a DataFrame with same dimensions and indexing as `usgs_df`, pass this out to `__main__.py`
* Use quality flag data to screen poor observations from the DA workflow
* Implement several other screening checks to match (or improve upon) WRF-hydro DA algorithm.