### PR TITLE
bugfix: gages in offnetwork upstream list blows up by-subnetwork parallel simulations

### DIFF
--- a/src/python_routing_v02/troute/routing/compute.py
+++ b/src/python_routing_v02/troute/routing/compute.py
@@ -334,7 +334,7 @@ def compute_nhd_routing_v02(
                         param_df_sub.index.tolist() + lake_segs
                     ).sort_index()
 
-                    usgs_df_sub, lastobs_df_sub, da_positions_list_byseg = _prep_da_dataframes(usgs_df, lastobs_df, param_df_sub.index)
+                    usgs_df_sub, lastobs_df_sub, da_positions_list_byseg = _prep_da_dataframes(usgs_df, lastobs_df, param_df_sub.index.symmetric_difference(offnetwork_upstreams))
                     da_positions_list_byreach, da_positions_list_bygage = _prep_da_positions_byreach(subn_reach_list, lastobs_df_sub.index)
 
                     qlat_sub = qlat_sub.reindex(param_df_sub.index)
@@ -547,7 +547,7 @@ def compute_nhd_routing_v02(
                         param_df_sub.index.tolist() + lake_segs
                     ).sort_index()
 
-                    usgs_df_sub, lastobs_df_sub, da_positions_list_byseg = _prep_da_dataframes(usgs_df, lastobs_df, param_df_sub.index)
+                    usgs_df_sub, lastobs_df_sub, da_positions_list_byseg = _prep_da_dataframes(usgs_df, lastobs_df, param_df_sub.index.symmetric_difference(offnetwork_upstreams))
                     da_positions_list_byreach, da_positions_list_bygage = _prep_da_positions_byreach(subn_reach_list, lastobs_df_sub.index)
 
                     qlat_sub = qlat_sub.reindex(param_df_sub.index)
@@ -745,7 +745,7 @@ def compute_nhd_routing_v02(
                         param_df_sub.index.tolist() + lake_segs
                     ).sort_index()
 
-                    usgs_df_sub, lastobs_df_sub, da_positions_list_byseg = _prep_da_dataframes(usgs_df, lastobs_df, param_df_sub.index)
+                    usgs_df_sub, lastobs_df_sub, da_positions_list_byseg = _prep_da_dataframes(usgs_df, lastobs_df, param_df_sub.index.symmetric_difference(offnetwork_upstreams))
                     da_positions_list_byreach, da_positions_list_bygage = _prep_da_positions_byreach(subn_reach_list, lastobs_df_sub.index)
 
                     qlat_sub = qlat_sub.reindex(param_df_sub.index)

--- a/src/python_routing_v02/troute/routing/compute.py
+++ b/src/python_routing_v02/troute/routing/compute.py
@@ -73,7 +73,7 @@ def _prep_da_dataframes(
 
     """
     # segments in the subnetwork ONLY, no offnetwork upstreams included
-    subnet_segs = param_df_sub_idx.symmetric_difference(offnetwork_upstreams)
+    subnet_segs = param_df_sub_idx.difference(offnetwork_upstreams)
     
     # NOTE: Uncomment to easily test no observations...
     # usgs_df = pd.DataFrame()

--- a/src/python_routing_v02/troute/routing/compute.py
+++ b/src/python_routing_v02/troute/routing/compute.py
@@ -52,7 +52,7 @@ def _prep_da_dataframes(
     usgs_df,
     lastobs_df,
     param_df_sub_idx,
-    offnetwork_upstreams=[],
+    exclude_segments=None,
     ):
     """
     Produce, based on the segments in the param_df_sub_idx (which is a subset
@@ -60,6 +60,11 @@ def _prep_da_dataframes(
     a subset of the relevant usgs gage observation time series
     and the relevant last-valid gage observation from any
     prior model execution.
+    
+    exclude_segments (list): segments to exclude from param_df_sub when searching for gages
+                             This catches and excludes offnetwork upstreams segments from being
+                             realized as locations for DA substitution. Else, by-subnetwork
+                             parallel executions fail.
 
     Cases to consider:
     USGS_DF, LAST_OBS
@@ -72,8 +77,11 @@ def _prep_da_dataframes(
     time series is as long as the simulation.
 
     """
+    
+    subnet_segs = param_df_sub_idx
     # segments in the subnetwork ONLY, no offnetwork upstreams included
-    subnet_segs = param_df_sub_idx.difference(offnetwork_upstreams)
+    if exclude_segments:
+        subnet_segs = param_df_sub_idx.difference(set(exclude_segments))
     
     # NOTE: Uncomment to easily test no observations...
     # usgs_df = pd.DataFrame()

--- a/src/python_routing_v02/troute/routing/compute.py
+++ b/src/python_routing_v02/troute/routing/compute.py
@@ -51,7 +51,8 @@ def _build_reach_type_list(reach_list, wbodies_segs):
 def _prep_da_dataframes(
     usgs_df,
     lastobs_df,
-    param_df_sub_idx
+    param_df_sub_idx,
+    offnetwork_upstreams=[],
     ):
     """
     Produce, based on the segments in the param_df_sub_idx (which is a subset
@@ -71,18 +72,20 @@ def _prep_da_dataframes(
     time series is as long as the simulation.
 
     """
+    # segments in the subnetwork ONLY, no offnetwork upstreams included
+    subnet_segs = param_df_sub_idx.symmetric_difference(offnetwork_upstreams)
+    
     # NOTE: Uncomment to easily test no observations...
     # usgs_df = pd.DataFrame()
     if not usgs_df.empty and not lastobs_df.empty:
         # index values for last obs are not correct, but line up correctly with usgs values. Switched
-
-        lastobs_segs = list(lastobs_df.index.intersection(param_df_sub_idx))
+        lastobs_segs = list(lastobs_df.index.intersection(subnet_segs))
         lastobs_df_sub = lastobs_df.loc[lastobs_segs]
-        usgs_segs = list(usgs_df.index.intersection(param_df_sub_idx))
+        usgs_segs = list(usgs_df.index.intersection(subnet_segs))
         da_positions_list_byseg = param_df_sub_idx.get_indexer(usgs_segs)
         usgs_df_sub = usgs_df.loc[usgs_segs]
     elif usgs_df.empty and not lastobs_df.empty:
-        lastobs_segs = list(lastobs_df.index.intersection(param_df_sub_idx))
+        lastobs_segs = list(lastobs_df.index.intersection(subnet_segs))
         lastobs_df_sub = lastobs_df.loc[lastobs_segs]
         # Create a completely empty list of gages -- the .shape[1] attribute
         # will be == 0, and that will trigger a reference to the lastobs.
@@ -91,7 +94,7 @@ def _prep_da_dataframes(
         usgs_segs = lastobs_segs
         da_positions_list_byseg = param_df_sub_idx.get_indexer(lastobs_segs)
     elif not usgs_df.empty and lastobs_df.empty:
-        usgs_segs = list(usgs_df.index.intersection(param_df_sub_idx))
+        usgs_segs = list(usgs_df.index.intersection(subnet_segs))
         da_positions_list_byseg = param_df_sub_idx.get_indexer(usgs_segs)
         usgs_df_sub = usgs_df.loc[usgs_segs]
         lastobs_df_sub = pd.DataFrame(index=usgs_df_sub.index,columns=["discharge","time","model_discharge"])
@@ -334,7 +337,7 @@ def compute_nhd_routing_v02(
                         param_df_sub.index.tolist() + lake_segs
                     ).sort_index()
 
-                    usgs_df_sub, lastobs_df_sub, da_positions_list_byseg = _prep_da_dataframes(usgs_df, lastobs_df, param_df_sub.index.symmetric_difference(offnetwork_upstreams))
+                    usgs_df_sub, lastobs_df_sub, da_positions_list_byseg = _prep_da_dataframes(usgs_df, lastobs_df, param_df_sub.index, offnetwork_upstreams)
                     da_positions_list_byreach, da_positions_list_bygage = _prep_da_positions_byreach(subn_reach_list, lastobs_df_sub.index)
 
                     qlat_sub = qlat_sub.reindex(param_df_sub.index)
@@ -547,7 +550,7 @@ def compute_nhd_routing_v02(
                         param_df_sub.index.tolist() + lake_segs
                     ).sort_index()
 
-                    usgs_df_sub, lastobs_df_sub, da_positions_list_byseg = _prep_da_dataframes(usgs_df, lastobs_df, param_df_sub.index.symmetric_difference(offnetwork_upstreams))
+                    usgs_df_sub, lastobs_df_sub, da_positions_list_byseg = _prep_da_dataframes(usgs_df, lastobs_df, param_df_sub.index, offnetwork_upstreams)
                     da_positions_list_byreach, da_positions_list_bygage = _prep_da_positions_byreach(subn_reach_list, lastobs_df_sub.index)
 
                     qlat_sub = qlat_sub.reindex(param_df_sub.index)
@@ -745,7 +748,7 @@ def compute_nhd_routing_v02(
                         param_df_sub.index.tolist() + lake_segs
                     ).sort_index()
 
-                    usgs_df_sub, lastobs_df_sub, da_positions_list_byseg = _prep_da_dataframes(usgs_df, lastobs_df, param_df_sub.index.symmetric_difference(offnetwork_upstreams))
+                    usgs_df_sub, lastobs_df_sub, da_positions_list_byseg = _prep_da_dataframes(usgs_df, lastobs_df, param_df_sub.index, offnetwork_upstreams)
                     da_positions_list_byreach, da_positions_list_bygage = _prep_da_positions_byreach(subn_reach_list, lastobs_df_sub.index)
 
                     qlat_sub = qlat_sub.reindex(param_df_sub.index)


### PR DESCRIPTION
by-subnetwork parallel simulations were breaking with the Florence_Benchmark_da simulations. After some digging, I found that there was a gage link in the offnetwork upstreams list. This caused `da_positions_list_byreach` to be one item shorter than `da_positions_list_byseg`, which blew up the simulation with an indexing error in `mc_reach.compute_network_structured`. 

To fix this, I pass the `offnetwork_upstreams` list to `_prep_da_dataframes` (default  `offnetwork_upstreams = []`), in addition to `param_df_sub.index`. Then I create a new list called, `subnet_segs`, which contains ONLY the segments in the subnetwork. This list is searched for gage segments. The `param_df_sub_idx` list is handled with `get_indexer()` such that the `param_df_sub` array is correctly indexed in downstream operations. 

I tested this scheme with `Florence_Benchmark_da.yaml`, all gage segments, all parallel schemes. The same results at gage locations were observed across all parallel schemes, which proves that the fix is robust. 
