### PR TITLE
Allow flexible output folder for WRF-Hydro output files

### DIFF
--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -639,10 +639,13 @@ def main_v02(argv):
             print(flowveldepth)
 
     # directory containing WRF Hydro restart files
-    wrf_hydro_restart_dir = output_parameters.get(
-        "wrf_hydro_channel_restart_directory", None
+    wrf_hydro_restart_read_dir = output_parameters.get(
+        "wrf_hydro_channel_restart_source_directory", None
     )
-    if wrf_hydro_restart_dir:
+    wrf_hydro_restart_write_dir = output_parameters.get(
+        "wrf_hydro_channel_restart_output_directory", wrf_hydro_restart_read_dir
+    )
+    if wrf_hydro_restart_read_dir:
 
         wrf_hydro_channel_restart_new_extension = output_parameters.get(
             "wrf_hydro_channel_restart_new_extension", "TRTE"
@@ -650,7 +653,7 @@ def main_v02(argv):
 
         # list of WRF Hydro restart files
         wrf_hydro_restart_files = sorted(
-            Path(wrf_hydro_restart_dir).glob(
+            Path(wrf_hydro_restart_read_dir).glob(
                 output_parameters["wrf_hydro_channel_restart_pattern_filter"]
                 + "[!"
                 + wrf_hydro_channel_restart_new_extension
@@ -670,6 +673,7 @@ def main_v02(argv):
             nhd_io.write_channel_restart_to_wrf_hydro(
                 flowveldepth,
                 wrf_hydro_restart_files,
+                Path(wrf_hydro_restart_write_dir),
                 restart_parameters.get("wrf_hydro_channel_restart_file"),
                 run_parameters.get("dt"),
                 run_parameters.get("nts"),

--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -712,6 +712,7 @@ def main_v02(argv):
             chrtout_files,
             Path(chrtout_write_folder),
             run_parameters["qts_subdivisions"],
+            wrf_hydro_channel_output_new_extension,
         )
 
     if verbose:

--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -688,8 +688,9 @@ def main_v02(argv):
             str = "WRF Hydro restart files not found - Aborting restart write sequence"
             raise AssertionError(str)
 
-    chrtout_folder = output_parameters.get("wrf_hydro_channel_output_folder", None)
-    if chrtout_folder:
+    chrtout_read_folder = output_parameters.get("wrf_hydro_channel_output_source_folder", None)
+    chrtout_write_folder = output_parameters.get("wrf_hydro_channel_final_output_folder", chrtout_read_folder)
+    if chrtout_read_folder:
         qvd_columns = pd.MultiIndex.from_product(
             [range(nts), ["q", "v", "d"]]
         ).to_flat_index()
@@ -702,12 +703,15 @@ def main_v02(argv):
             "wrf_hydro_channel_output_new_extension", "TRTE"
         )
         chrtout_files = sorted(
-            Path(chrtout_folder).glob(
+            Path(chrtout_read_folder).glob(
                 output_parameters["wrf_hydro_channel_output_file_pattern_filter"]
             )
         )
         nhd_io.write_q_to_wrf_hydro(
-            flowveldepth, chrtout_files, run_parameters["qts_subdivisions"]
+            flowveldepth,
+            chrtout_files,
+            Path(chrtout_write_folder),
+            run_parameters["qts_subdivisions"],
         )
 
     if verbose:

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -863,6 +863,7 @@ def get_channel_restart_from_wrf_hydro(
 def write_channel_restart_to_wrf_hydro(
     data,
     restart_files,
+    output_folder,
     channel_initial_states_file,
     dt_troute,
     nts_troute,
@@ -883,6 +884,7 @@ def write_channel_restart_to_wrf_hydro(
     ---------
         data (Data Frame): t-route simulated flow, velocity and depth data
         restart_files (list): globbed list of WRF-Hydro restart files
+        output_folder (pathlib.Path): folder where updated restart files will be written
         channel_initial_states_file (str): WRF-HYDRO standard restart file used to initiate t-route simulation
         dt_troute (int): timestep of t-route simulation (seconds)
         nts_troute (int): number of t-route simulation timesteps
@@ -957,7 +959,7 @@ def write_channel_restart_to_wrf_hydro(
                 ds[troute_depth_var_name] = htrt_DataArray
 
                 # write edited to disk with new filename
-                ds.to_netcdf(f.parent / (f.name + "." + new_extension))
+                ds.to_netcdf(output_folder / (f.name + "." + new_extension))
 
 
 def get_reservoir_restart_from_wrf_hydro(

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -286,7 +286,11 @@ def drop_all_coords(ds):
 
 
 def write_q_to_wrf_hydro(
-    flowveldepth, chrtout_files, qts_subdivisions, new_extension="TRTE"
+    flowveldepth,
+    chrtout_files,
+    output_folder,
+    qts_subdivisions,
+    new_extension="TRTE"
 ):
     """
     Write t-route simulated flows to WRF-Hydro CHRTOUT files.
@@ -294,6 +298,7 @@ def write_q_to_wrf_hydro(
     Arguments:
         flowveldepth (pandas Data Frame): t-route simulated flow, velocity and depth
         chrtout_files (list): chrtout filepaths
+        output_folder (pathlib.Path): folder where updated chrtout files will be written
         qts_subdivisions (int): number of t-route timesteps per WRF-hydro timesteps
     """
 
@@ -331,7 +336,7 @@ def write_q_to_wrf_hydro(
 
     # save a new set of chrtout files to disk that contail t-route simulated flow
     chrtout_files_new = [
-        s.parent / (s.name + "." + new_extension) for s in chrtout_files
+        output_folder / (s.name + "." + new_extension) for s in chrtout_files
     ]
 
     # mfdataset solution - can theoretically be parallelised via dask.distributed

--- a/test/input/yaml/CustomInput.yaml
+++ b/test/input/yaml/CustomInput.yaml
@@ -25,10 +25,12 @@ output_parameters:
     nc_output_folder: "../../test/output/text"
     # Write t-route data to WRF-Hydro restart files
     wrf_hydro_channel_output_source_folder: "../../test/input/geo/NWM_2.1_Sample_Datasets/Pocono_TEST1/example_CHRTOUT/"
+    wrf_hydro_channel_final_output_folder: "../../test/output/Pocono_TEST1/example_CHRTOUT"
     wrf_hydro_channel_output_file_pattern_filter: "*.CHRTOUT_DOMAIN1"
     wrf_hydro_channel_output_new_extension: "TROUTE"
     # Write t-route data to WRF-Hydro CHRTOUT files
     wrf_hydro_channel_restart_source_directory: "../../test/input/geo/NWM_2.1_Sample_Datasets/Pocono_TEST1/example_RESTART/"
+    wrf_hydro_channel_restart_output_directory: "../../test/output/Pocono_TEST1/example_RESTART"
     wrf_hydro_channel_restart_pattern_filter: "HYDRO_RST.*"
     wrf_hydro_channel_restart_new_extension: "TROUTE"
 #data column assignment inside supernetwork_parameters

--- a/test/input/yaml/CustomInput.yaml
+++ b/test/input/yaml/CustomInput.yaml
@@ -24,7 +24,7 @@ output_parameters:
     #out location for nc file
     nc_output_folder: "../../test/output/text"
     # Write t-route data to WRF-Hydro restart files
-    wrf_hydro_channel_output_folder: "../../test/input/geo/NWM_2.1_Sample_Datasets/Pocono_TEST1/example_CHRTOUT/"
+    wrf_hydro_channel_output_source_folder: "../../test/input/geo/NWM_2.1_Sample_Datasets/Pocono_TEST1/example_CHRTOUT/"
     wrf_hydro_channel_output_file_pattern_filter: "*.CHRTOUT_DOMAIN1"
     wrf_hydro_channel_output_new_extension: "TROUTE"
     # Write t-route data to WRF-Hydro CHRTOUT files

--- a/test/input/yaml/CustomInput.yaml
+++ b/test/input/yaml/CustomInput.yaml
@@ -28,7 +28,7 @@ output_parameters:
     wrf_hydro_channel_output_file_pattern_filter: "*.CHRTOUT_DOMAIN1"
     wrf_hydro_channel_output_new_extension: "TROUTE"
     # Write t-route data to WRF-Hydro CHRTOUT files
-    wrf_hydro_channel_restart_directory: "../../test/input/geo/NWM_2.1_Sample_Datasets/Pocono_TEST1/example_RESTART/"
+    wrf_hydro_channel_restart_source_directory: "../../test/input/geo/NWM_2.1_Sample_Datasets/Pocono_TEST1/example_RESTART/"
     wrf_hydro_channel_restart_pattern_filter: "HYDRO_RST.*"
     wrf_hydro_channel_restart_new_extension: "TROUTE"
 #data column assignment inside supernetwork_parameters

--- a/test/output/.gitignore
+++ b/test/output/.gitignore
@@ -3,9 +3,13 @@ text/*
 nc/*
 map/*
 plot/*
+Pocono_TEST1/example_CHRTOUT/*
+Pocono_TEST1/example_RESTART/*
 # Except for these empty folders
 !text/.gitkeep
 !map/.gitkeep
 !plot/.gitkeep
 !nc/.gitkeep
+!Pocono_TEST1/example_CHRTOUT/.gitkeep
+!Pocono_TEST1/example_RESTART/.gitkeep
 #


### PR DESCRIPTION
The WRF-Hydro-style output currently relies on an existing output folder, which is scanned, and then a duplicate set of output files are generated (CHRTOUT or HYDRO_RST) with the t-route streamflow values populating the results. 

This PR allows for that write to occur in a different directory than the source files which are scanned.