### PR TITLE
Reservoir Cold Start Water Elevation Check

### DIFF
--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -431,7 +431,7 @@ def main_v02(argv):
         else:
             # TODO: Consider adding option to read cold state from route-link file
             waterbodies_initial_ds_flow_const = 0.0
-            waterbodies_initial_depth_const = -1.0
+            waterbodies_initial_depth_const = -1E9
             # Set initial states from cold-state
             waterbodies_initial_states_df = pd.DataFrame(
                 0, index=waterbodies_df.index, columns=["qd0", "h0",], dtype="float32"

--- a/src/nwm_routing/src/nwm_routing/preprocess.py
+++ b/src/nwm_routing/src/nwm_routing/preprocess.py
@@ -165,7 +165,7 @@ def nwm_initial_warmstate_preprocess(
         else:
             # TODO: Consider adding option to read cold state from route-link file
             waterbodies_initial_ds_flow_const = 0.0
-            waterbodies_initial_depth_const = -1.0
+            waterbodies_initial_depth_const = -1E9
             # Set initial states from cold-state
             waterbodies_initial_states_df = pd.DataFrame(
                 0, index=waterbodies_df.index, columns=["qd0", "h0",], dtype="float32"

--- a/src/python_framework_v02/troute/network/reservoirs/hybrid/hybrid_structs.c
+++ b/src/python_framework_v02/troute/network/reservoirs/hybrid/hybrid_structs.c
@@ -55,7 +55,7 @@ init_hybrid_reach(_Reach* reach, int lake_number,
     reach->reach.hybrid.observation_lookback_hours = observation_lookback_hours;
     reach->reach.hybrid.observation_update_time_interval_seconds = observation_update_time_interval_seconds;
 
-    if(water_elevation < 0){
+    if(water_elevation < -900000000){
       //Equation below is used in wrf-hydro
       printf("WARNING: HYBRID PERSISTENCE RESERVOIR USING COLDSTART WATER ELEVATION\n");
       fflush(stdout);

--- a/src/python_framework_v02/troute/network/reservoirs/levelpool/levelpool_structs.c
+++ b/src/python_framework_v02/troute/network/reservoirs/levelpool/levelpool_structs.c
@@ -34,7 +34,7 @@ init_levelpool_reach(_Reach* reach, int lake_number,
     reach->reach.lp.weir_length = weir_length;
     reach->reach.lp.initial_fractional_depth = initial_fractional_depth;
 
-    if(water_elevation < 0){
+    if(water_elevation < -900000000){
       //Equation below is used in wrf-hydro
       printf("WARNING: LEVELPOOL USING COLDSTART WATER ELEVATION\n");
       fflush(stdout);

--- a/src/python_framework_v02/troute/network/reservoirs/rfc/rfc_structs.c
+++ b/src/python_framework_v02/troute/network/reservoirs/rfc/rfc_structs.c
@@ -49,7 +49,7 @@ init_rfc_reach(_Reach* reach, int lake_number,
 
     reach->reach.rfc.forecast_lookback_hours = forecast_lookback_hours;
 
-    if(water_elevation < 0){
+    if(water_elevation < -900000000){
       //Equation below is used in wrf-hydro
       printf("WARNING: RFC RESERVOIR USING COLDSTART WATER ELEVATION\n");
       fflush(stdout);


### PR DESCRIPTION
Change initial reservoir cold start water elevation to -1e9 and check to less than -900000000 to allow negative water elevations at warm start.

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
