### PR TITLE
correct waterbody indexing in mc_reach with binary search

### DIFF
--- a/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
@@ -1134,14 +1134,13 @@ cpdef object compute_network_structured(
     #pr.enable()
     #Preprocess the raw reaches, creating MC_Reach/MC_Segments
 
-    wbody_index = 0
-
     for reach, reach_type in reaches_wTypes:
         upstream_reach = upstream_connections.get(reach[0], ())
         upstream_ids = binary_find(data_idx, upstream_reach)
         #Check if reach_type is 1 for reservoir
         if (reach_type == 1):
             my_id = binary_find(data_idx, reach)
+            wbody_index = binary_find(lake_numbers_col,reach)[0]
             #Reservoirs should be singleton list reaches, TODO enforce that here?
 
             # write initial reservoir flows to flowveldepth array
@@ -1157,7 +1156,6 @@ cpdef object compute_network_structured(
                                    array('l',upstream_ids),
                                    wbody_parameters[wbody_index])
                     )
-                wbody_index += 1
 
             else:
                 #If reservoir_type is 1, then initialize Level Pool reservoir
@@ -1169,7 +1167,6 @@ cpdef object compute_network_structured(
                                        array('l',upstream_ids),
                                        wbody_parameters[wbody_index])
                         )
-                    wbody_index += 1
 
                 #If reservoir_type is 2 for USGS or 3 for USACE, then initialize Hybrid reservoir
                 elif (reservoir_types[wbody_index][0] == 2 or reservoir_types[wbody_index][0] == 3):
@@ -1188,7 +1185,6 @@ cpdef object compute_network_structured(
                           waterbody_parameters["hybrid_and_rfc"]["reservoir_observation_lookback_hours"],
                           waterbody_parameters["hybrid_and_rfc"]["reservoir_observation_update_time_interval_seconds"])
                         )
-                    wbody_index += 1
 
                 #If reservoir_type is 4, then initialize RFC reservoir
                 elif (reservoir_types[wbody_index][0] == 4):
@@ -1205,7 +1201,6 @@ cpdef object compute_network_structured(
                           waterbody_parameters["hybrid_and_rfc"]["reservoir_rfc_forecasts_time_series_path"],
                           waterbody_parameters["hybrid_and_rfc"]["reservoir_rfc_forecasts_lookback_hours"])
                         )
-                    wbody_index += 1
 
         else:
             segment_ids = binary_find(data_idx, reach)

--- a/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
@@ -855,14 +855,13 @@ cpdef object compute_network_structured_obj(
             if not np.isnan(usgs_values[gage_i, 0]):
                 flowveldepth[usgs_position_i, 0] = usgs_values[gage_i, 0]
 
-    wbody_index = 0
-
     for reach, reach_type in reaches_wTypes:
         upstream_reach = upstream_connections.get(reach[0], ())
         upstream_ids = binary_find(data_idx, upstream_reach)
         #Check if reach_type is 1 for reservoir
         if (reach_type == 1):
             my_id = binary_find(data_idx, reach)
+            wbody_index = binary_find(lake_numbers_col,reach)[0]
             #Reservoirs should be singleton list reaches, TODO enforce that here?
 
             #Check if reservoir_type is not specified, then initialize default Level Pool reservoir
@@ -876,7 +875,6 @@ cpdef object compute_network_structured_obj(
                       array('l',upstream_ids), wbody_parameters[wbody_index]),
                       reach_type)#lp_reservoir)
                     )
-                wbody_index += 1
 
             else:
                 #If reservoir_type is 1, then initialize Level Pool reservoir
@@ -889,7 +887,6 @@ cpdef object compute_network_structured_obj(
                           array('l',upstream_ids), wbody_parameters[wbody_index]),
                           reach_type)#lp_reservoir)
                         )
-                    wbody_index += 1
 
                 #If reservoir_type is 2 for USGS or 3 for USACE, then initialize Hybrid reservoir
                 elif (reservoir_types[wbody_index][0] == 2 or reservoir_types[wbody_index][0] == 3):
@@ -909,7 +906,6 @@ cpdef object compute_network_structured_obj(
                           waterbody_parameters["hybrid_and_rfc"]["reservoir_observation_update_time_interval_seconds"]),
                           reach_type)#hybrid_reservoir)
                         )
-                    wbody_index += 1
 
                 #If reservoir_type is 4, then initialize RFC reservoir
                 elif (reservoir_types[wbody_index][0] == 4):
@@ -927,7 +923,6 @@ cpdef object compute_network_structured_obj(
                           waterbody_parameters["hybrid_and_rfc"]["reservoir_rfc_forecasts_lookback_hours"]),
                           reach_type)#rfc_reservoir)
                         )
-                    wbody_index += 1
 
         else:
             segment_ids = binary_find(data_idx, reach)


### PR DESCRIPTION
# problem summary
This PR corrects the indexing of waterbodies in `mc_reach.compute_network_structured`. There was an assumption being made that the rows in the `wbody_parameters` array were ordered in-line with the reservoir reaches in `reaches_wTypes` tuples. This assumption is manifested in the `wbody_index` variable, which is initialized at 0 and increases by 1 after each time the `reach_objects` variable is appended for a waterbody. This was resulting in reservoirs being incorrectly initialized and parameterized, causing obvious downstream issues. 

# change summary
The `wbody_index` variable is now defined by a binary search used to identify the index location of reservoir reach ID in the `lake_numbers_col` list. This fix ensures that we are taking the parameters and initial conditions from the correct row positions in the `wbody_parameters` array. 

# testing
To test this, I first set up a test simulation in a domain that contained 9 reservoirs. Then I inserted the following print statement immediately below line [1144 of `mc_reach.pyx`](https://github.com/NOAA-OWP/t-route/blob/48ad823467bcd81d4e8c3236cebc71e2a101945a/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx#L1144):

``` cython
print("reach:", reach) # the reservoir ID we want to parameterize
print("Waterbody ID:", lake_numbers_col[wbody_index]) # the reservoir ID that we end up getting parameters for
```
With this print statement included, I recompiled the cython routing code and ran the simulation to completion. 

Before my fix (current t-route/master), the print statements clearly show that the waterbody parameters array is being incorrectly indexed, which results in the initial conditions and parameters of one reservoir being erroneously assigned to another:
```
reach: [8776313]        <----- this number....
Waterbody ID: 8776273   <----- is different than this number
reach: [8776273]
Waterbody ID: 8776313
reach: [166737717]
Waterbody ID: 8781977
reach: [8781977]
Waterbody ID: 8782015
reach: [8782015]
Waterbody ID: 8789039
reach: [8789039]
Waterbody ID: 8789149
reach: [8789149]
Waterbody ID: 11571088
reach: [11572508]
Waterbody ID: 11572508
reach: [11571088]
Waterbody ID: 166737717
```

After my fix, we are correctly indexing the `wbody_parameters` array:
```
reach: [8776313]        <----- this number....
Waterbody ID: 8776313   <----- is the same as this number
reach: [8776273]
Waterbody ID: 8776273
reach: [166737717]
Waterbody ID: 166737717
reach: [8781977]
Waterbody ID: 8781977
reach: [8782015]
Waterbody ID: 8782015
reach: [8789039]
Waterbody ID: 8789039
reach: [8789149]
Waterbody ID: 8789149
reach: [11572508]
Waterbody ID: 11572508
reach: [11571088]
Waterbody ID: 11571088

```