### PR TITLE
Data Assimilation (DA) for the diffusive wave model(s)

### DIFF
--- a/src/fortran_routing/diffusive_v02frwk/diffusive.f90
+++ b/src/fortran_routing/diffusive_v02frwk/diffusive.f90
@@ -675,16 +675,29 @@ contains
             !        print*, t,i,j,newQ(i,j),newY(i,j)-z(i,j)
             !	 enddo
 	    !end do
+            ! write results, timestep 2 and beyond
             if ( (mod( (t-t0*60.)*60.  ,saveInterval) .le. TOLERANCE) .or. ( t .eq. tfin *60. ) ) then
                 do j = 1, nlinks
                     ncomp= frnw_g(j,1)
                     do i=1, ncomp
-                        q_ev_g(ts_ev, i, j)= newQ(i,j)
-                        elv_ev_g(ts_ev, i, j)= newY(i,j)
+                        q_ev_g(ts_ev+1, i, j)= newQ(i,j)
+                        elv_ev_g(ts_ev+1, i, j)= newY(i,j)
                     enddo
                 enddo
                 ts_ev=ts_ev+1
             end if
+            
+            ! write initial conditions - timestep 1
+            if ( ( t .eq. t0 + dtini/60 ) ) then
+                do j = 1, nlinks
+                    ncomp= frnw_g(j,1)
+                    do i=1, ncomp
+                        q_ev_g(1, i, j)= oldQ(i,j)
+                        elv_ev_g(1, i, j)= oldY(i,j)
+                    enddo
+                enddo
+            end if
+            
               ! update of Y, Q and Area vectors
             oldY   = newY
             newY=-999

--- a/src/fortran_routing/diffusive_v02frwk/diffusive_cnt/diffusive_cnt.f90
+++ b/src/fortran_routing/diffusive_v02frwk/diffusive_cnt/diffusive_cnt.f90
@@ -43,7 +43,7 @@ contains
 
 		implicit none
 
-		integer, intent(in) :: mxncomp_g, nrch_g
+	integer, intent(in) :: mxncomp_g, nrch_g
         integer, intent(in) :: nts_ql_g, nts_ub_g, nts_db_g, ntss_ev_g
         integer, intent(in) :: frnw_col, nhincr_m_g, nhincr_f_g
         double precision,intent(in) :: dtini_g, t0_g, tfin_g, saveinterval_ev_g, dt_ql_g, dt_ub_g, dt_db_g
@@ -63,7 +63,7 @@ contains
         integer, intent(in) :: y_opt_g  !* 1 for normal depth(kinematic); 2 for dept of diffusive wave.
 
         double precision, dimension(mxncomp_g, nrch_g), intent(inout) :: so_ar_g
-		double precision, dimension(ntss_ev_g, mxncomp_g, nrch_g), intent(out) :: q_ev_g, elv_ev_g
+	double precision, dimension(ntss_ev_g, mxncomp_g, nrch_g), intent(out) :: q_ev_g, elv_ev_g
 
         integer :: i, j, k, ppn, qqn, n, ntim, num_time, igate, pp, boundaryFileMaxEntry, saveFrequency
         integer :: linknb_ds, linknb_us, linknb, nodenb
@@ -84,52 +84,50 @@ contains
         integer :: ndata, idmy1, nts_db_g2, idxql
         double precision :: slope, y_norm, area_n, temp, tc_cnt, rmnd, saveinterval_min
 
-		! simulation timestep
+	! simulation timestep
         dtini=dtini_g  !*[sec]
         dtini_given=dtini
-		! simulation intial time (hrs)
+	! simulation intial time (hrs)
         t0=t0_g
-		! simulation final time (hrs)
+	! simulation final time (hrs)
         tfin=tfin_g
         ! saving interval (seconds)
         saveInterval=saveinterval_ev_g  !*[sec]
-		! number of simulation timesteps per save
+	! number of simulation timesteps per save
         saveFrequency=saveInterval / dtini_given
         ! Total number of timesteps in the simulation
-		totalTimeSteps = floor((tfin - t0)/dtini*3600)+1
-!        repeatInterval = int(60.*60./dtini_given)
-!		ntim= int(70.*60./dtini_given)+1d
+	totalTimeSteps = floor((tfin - t0)/dtini*3600)+1
         repeatInterval = int(saveInterval/dtini_given)
-		ntim= repeatInterval+10  !*! number of timesteps per repeatInterval; +1 because of boundary effects, at least 1 extra necessary
-
-		num_time=ntim
-		! number of reaches in the network
-		nlinks=nrch_g
-		! network metadata array
+	ntim= repeatInterval+10  !*! number of timesteps per repeatInterval; +1 because of boundary effects, at least 1 extra necessary
+	num_time=ntim
+	! number of reaches in the network
+	nlinks=nrch_g
+	! network metadata array
         allocate(frnw_g(nlinks,frnw_col))
         frnw_g=int(dfrnw_g)
-		! maximum number of segments in a single reach
+	! maximum number of segments in a single reach
         mxncomp=mxncomp_g
-		!* water depth multiplier used in readXsection
+	!* water depth multiplier used in readXsection
         timesDepth= 4.0
-		! number of rows in channel geometry attribute tables
+	! number of rows in channel geometry attribute tables
         nel= 501
-		! maximum number of segments in a single reach - redundant?
+	! maximum number of segments in a single reach - redundant?
         num_points= mxncomp
-		! number of reaches in the network - redundant?
+	! number of reaches in the network - redundant?
         totalChannels= nlinks
 
-        minDiffuLm= 50.0
+	! TODO: make these input parameters        
+	minDiffuLm= 50.0
         maxDiffuLm= 400.0
 
         allocate(area(num_points))
         allocate(bo(num_points,totalChannels))
         allocate(pere(num_points,totalChannels))
         allocate(areap(num_points,totalChannels))
-        allocate(qp(num_points,num_time,totalChannels))				! change Nazmul CNT
-        allocate(ini_q_repeat(num_points,totalChannels))			! change Nazmul CNT
-        allocate(ini_E(num_points,totalChannels))					! change Nazmul CNT
-        allocate(ini_F(num_points,totalChannels))					! change Nazmul CNT
+        allocate(qp(num_points,num_time,totalChannels))				
+        allocate(ini_q_repeat(num_points,totalChannels))
+        allocate(ini_E(num_points,totalChannels))
+        allocate(ini_F(num_points,totalChannels))
         allocate(z(num_points,totalChannels))
         allocate(dqp(num_points,totalChannels))
         allocate(dqc(num_points,totalChannels))
@@ -143,15 +141,15 @@ contains
         allocate(froud(num_points))
         allocate(courant(num_points-1))
         allocate(oldQ(num_points, totalChannels))
-        allocate(newQ(num_points, num_time, totalChannels))			! change Nazmul CNT
-        allocate(added_Q(num_points, num_time, totalChannels))	 	! change Nazmul CNT
+        allocate(newQ(num_points, num_time, totalChannels))
+        allocate(added_Q(num_points, num_time, totalChannels))
         allocate(oldArea(num_points, totalChannels))
         allocate(newArea(num_points, totalChannels))
         allocate(oldY(num_points, totalChannels))
         allocate(newY(num_points, totalChannels))
-		allocate(lateralFlow(num_points, num_time, totalChannels)) 	! change Nazmul CNT
+	allocate(lateralFlow(num_points, num_time, totalChannels))
         allocate(celerity(num_points, totalChannels))
-        allocate(velocity(num_points, totalChannels)) 				! change Nazmul CNT
+        allocate(velocity(num_points, totalChannels)) 
         allocate(diffusivity(num_points, totalChannels))
         allocate(celerity2(num_points))
         allocate(diffusivity2(num_points))
@@ -193,50 +191,50 @@ contains
         allocate(tarr_ub(nts_ub_g), varr_ub(nts_ub_g))
         allocate(tarr_db(nts_db_g), varr_db(nts_db_g))
 
-		! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-		! identify minimum dx (segment length) in the network
-		! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-		dx = 0.
+	! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+	! identify minimum dx (segment length) in the network
+	! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+	dx = 0.
         minDx = 1e10
         do j = 1,nlinks
-            ncomp= frnw_g(j,1)
-            do i = 1,ncomp-1
-                dx(i,j) = dx_ar_g(i,j)
-            end do
-            minDx = min(minDx,minval(dx(1:ncomp-1,j)))
+		ncomp= frnw_g(j,1)
+		do i = 1,ncomp-1
+			dx(i,j) = dx_ar_g(i,j)
+		end do
+		minDx = min(minDx,minval(dx(1:ncomp-1,j)))
         end do
         
         ! TO DO:
-		! * pass initial depth as initial conditions and dont arbitrarily intialize
-		z=z_ar_g
+	! * pass initial depth as initial conditions and dont arbitrarily intialize
+	z=z_ar_g
         ini_y=0.05  !* [meter]
   
         oldQ = -999; oldY = -999; newQ = -999; newY = -999
         dimensionless_Cr = -999; dimensionless_Fo = -999; dimensionless_Fi = -999
         dimensionless_Di = -999; dimensionless_Fc = -999; dimensionless_D = -999
-		! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-		! create channel geometry lookup tables
-		! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-		do j = 1,nlinks
-			ncomp= frnw_g(j,1)
-			do i=1,ncomp
+	! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+	! create channel geometry lookup tables
+	! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+	do j = 1,nlinks
+		ncomp= frnw_g(j,1)
+		do i=1,ncomp
             
-                leftBank(i,j)= (twcc_ar_g(i,j)-tw_ar_g(i,j))/2.0
-                rightBank(i,j)= (twcc_ar_g(i,j)-tw_ar_g(i,j))/2.0 + tw_ar_g(i,j)
-				skLeft(i,j)= 1.0/manncc_ar_g(i,j)
-				skRight(i,j)= 1.0/manncc_ar_g(i,j)
-				skMain(i,j)= 1.0/mann_ar_g(i,j)
+		        leftBank(i,j)= (twcc_ar_g(i,j)-tw_ar_g(i,j))/2.0
+		        rightBank(i,j)= (twcc_ar_g(i,j)-tw_ar_g(i,j))/2.0 + tw_ar_g(i,j)
+					skLeft(i,j)= 1.0/manncc_ar_g(i,j)
+					skRight(i,j)= 1.0/manncc_ar_g(i,j)
+					skMain(i,j)= 1.0/mann_ar_g(i,j)
 
-				call readXsection(i,(1.0/skLeft(i,j)),(1.0/skMain(i,j)),(1.0/skRight(i,j)),&
-									leftBank(i,j), rightBank(i,j),timesDepth, j,&
-									z_ar_g, bo_ar_g, traps_ar_g, tw_ar_g, twcc_ar_g)
+			call readXsection(i,(1.0/skLeft(i,j)),(1.0/skMain(i,j)),(1.0/skRight(i,j)),&
+					leftBank(i,j), rightBank(i,j),timesDepth, j,&
+					z_ar_g, bo_ar_g, traps_ar_g, tw_ar_g, twcc_ar_g)
 
-            end do
-		end do
+            	end do
+	end do
         ! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-		! Populate lateral inflow and upper boundary time arrays
-		! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-		! lateral inflow time
+	! Populate lateral inflow and upper boundary time arrays
+	! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+	! lateral inflow time
         do n=1, nts_ql_g
             tarr_ql(n)= t0_g*60.0 + dt_ql_g*real(n-1,KIND(dt_ql_g))/60.0 !* [min]
         end do
@@ -249,63 +247,60 @@ contains
             tarr_db(n)= t0_g*60.0 + dt_db_g*real(n-1,KIND(dt_db_g))/60.0 !* [min]
         end do
         
-        !!!! INSERT IC CODE !!!
         ! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
         ! compute boundary conditions & initial water depth, celerity, and diffusivity using iniq
         ! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-
+	do j= 1, nlinks
+		ncomp= frnw_g(j,1)
+		do i=1, ncomp
+			oldQ(i,j) = iniq(i,j)
+			newQ(i,1,j) = iniq(i,j)
+			qp(i,1,j)= iniq(i,j)
+		end do
+	end do
         
-        do j= 1, nlinks
-            ncomp= frnw_g(j,1)
-            do i=1, ncomp
-                oldQ(i,j) = iniq(i,j)
-                newQ(i,1,j) = iniq(i,j)
-                qp(i,1,j)= iniq(i,j)
-            end do
-        end do
-        
-        q_sk_multi=1.0
-        do j= nlinks, 1, -1
-            ncomp= frnw_g(j,1)
-            if (frnw_g(j,2)<0.0) then
-                ! normal depth as TW boundary condition
-                slope = (z(ncomp-1,j)-z(ncomp,j))/dx(ncomp-1,j)
-                if (slope .le. 0.0001) slope = 0.0001
-                call normal_crit_y(ncomp, j, q_sk_multi, slope, oldQ(ncomp,j), oldY(ncomp,j), temp,  oldArea(ncomp,j), temp)
-            else            
-                !* Not TW reach -> water elev at bottom node of u/s reach is equal to that at top node of d/s reach
-                linknb=frnw_g(j,2) ! reach downstream of j
-                oldY(ncomp,j)= newY(1,linknb)   ! taking the WL from the d/s reach
-            end if            
-            !* compute water elev. from top to the second last node and celerity and diffusivity for all the nodes of reach j
-            newY(ncomp,j)= oldY(ncomp,j)
-            idmy1=0
-            call mesh_diffusive_backward(j,ntim, idmy1)
-            do i=1,ncomp-1
-                oldY(i,j)=newY(i,j)
-            end do
-            !*test
-            !do i=1,ncomp
-            !       print*, i, j, oldQ(i,j), oldY(i,j), celerity(i,j), diffusivity(i,j)
-            !end do
-        end do
+	q_sk_multi=1.0
+	do j= nlinks, 1, -1
+		ncomp= frnw_g(j,1)
+		if (frnw_g(j,2)<0.0) then
+			! normal depth as TW boundary condition
+			slope = (z(ncomp-1,j)-z(ncomp,j))/dx(ncomp-1,j)
+			if (slope .le. 0.0001) slope = 0.0001
+			call normal_crit_y(ncomp, j, q_sk_multi, slope, oldQ(ncomp,j), oldY(ncomp,j), temp,  oldArea(ncomp,j), temp)
+		else            
+			!* Not TW reach -> water elev at bottom node of u/s reach is equal to that at top node of d/s reach
+			linknb=frnw_g(j,2) ! reach downstream of j
+			oldY(ncomp,j)= newY(1,linknb)   ! taking the WL from the d/s reach
+		end if            
+		!* compute water elev. from top to the second last node and celerity and diffusivity for all the nodes of reach j
+		newY(ncomp,j)= oldY(ncomp,j)
+		idmy1=0
+		call mesh_diffusive_backward(j,ntim, idmy1)
+		do i=1,ncomp-1
+			oldY(i,j)=newY(i,j)
+		end do
+		!*test
+		!do i=1,ncomp
+		!       print*, i, j, oldQ(i,j), oldY(i,j), celerity(i,j), diffusivity(i,j)
+		!end do
+	end do
 
         ! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-		!  interpolation of boundaries at the initial time step
-		! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+	!  interpolation of boundaries at the initial time step
+	! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
         t=t0*60.0     !! from now on, t is in minute
         !! Need to define which channel has terminal boundary
         ppn = 1; qqn = 1        ! ppn and qqn indicates the sequence no of the boundary data
         do j = 1, nlinks
-            ncomp= frnw_g(j,1)
-            !* upstream boundary condition for head water reach
-            if (frnw_g(j,3)==0) then !* frnw_g(j,3) indicates the number of upstream reaches.
-                do n=1,nts_ub_g
-                    varr_ub(n)= ubcd_g(n,j)
-                end do
-                newQ(1,1,j)= intp_y(nts_ub_g, tarr_ub, varr_ub, t) !* tarr_ub in min.
-            end if
-            
+		ncomp= frnw_g(j,1)
+		!* upstream boundary condition for head water reach
+		if (frnw_g(j,3)==0) then !* frnw_g(j,3) indicates the number of upstream reaches.
+			do n=1,nts_ub_g
+				varr_ub(n)= ubcd_g(n,j)
+			end do
+			newQ(1,1,j)= intp_y(nts_ub_g, tarr_ub, varr_ub, t) !* tarr_ub in min.
+		end if
+
 !            !* downstream boundary condition for TW reach
 !            if (frnw_g(j,2)<0.0) then
 !                !* 1. measured data
@@ -325,15 +320,15 @@ contains
         ! correcting the WL initial condition based on the WL boundary
         ! so that the initial WL is higher than or equal to the WL boundary, at j = nlinks, i=ncomp
         ! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-        do j = 1,nlinks
-            ncomp= frnw_g(j,1)
-            do i=1,ncomp
-                oldY(i,j) = max(oldY(i,j),oldY(frnw_g(nlinks,1),nlinks))     ! corrected 20210524
-            end do
-        end do
+	do j = 1,nlinks
+		ncomp= frnw_g(j,1)
+		do i=1,ncomp
+			oldY(i,j) = max(oldY(i,j),oldY(frnw_g(nlinks,1),nlinks))     ! corrected 20210524
+		end do
+	end do
         ! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-		! Define initial parameters for Diffusive Wave
-		! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+	! Define initial parameters for Diffusive Wave
+	! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
         theta = 1.0
         qpx = 0.
         cfl=0.9
@@ -351,53 +346,41 @@ contains
         ! parameters for diffusive vs partial diffusive
         currentRoutingNormal = 0
         routingNotChanged = 0
-		min_Q = 0.028316    ! 1 cfs = 0.028316 m3/s
+	min_Q = 0.028316    ! 1 cfs = 0.028316 m3/s
+	ini_E = 1.0
+	ini_F = 0.0
+	! Define initial discharge conditons
+	do j = 1, nlinks
+		ncomp = frnw_g(j,1)
+		do i=1,ncomp
+			ini_q_repeat(i,j) = iniq(i,j)
+		end do        
+	end do
 
-		ini_E = 1.0
-		ini_F = 0.0
-		! Define initial discharge conditons
-        do j = 1, nlinks
-            ncomp = frnw_g(j,1)
-            do i=1,ncomp
-                ini_q_repeat(i,j) = iniq(i,j)
-            end do        
-        end do
-		! initialization of Q, celerity, and diffusivity
-		celerity = 1.0
-		diffusivity = 100.0
-		do j=1,nlinks
-			ncomp = frnw_g(j,1)
-			do i=1, ncomp
-				newQ(i,1,j) = iniq(i,j)
-				!timestep=1
-				!ini_time=0.0				
-				!write(12,*) ini_time, i, timestep, j, newQ(i,1,j)
-			end do
-		end do
 
         ts_ev=0
-		do kkk = 1,totalTimeSteps-1, repeatInterval
-			! first time of kkk-th repeatInterval (minutes)
-			ini_time = real(kkk-1)*dtini/60.0+t0*60.0
-			! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-			!    Discharge computation using CNT method
-			! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-			do j = 1, nlinks
-				ncomp = frnw_g(j,1)
-				lateralFlow(:,:,j) = 0 !* initialize at each reach j
+	do kkk = 1,totalTimeSteps-1, repeatInterval
+		! first time of kkk-th repeatInterval (minutes)
+		ini_time = real(kkk-1)*dtini/60.0+t0*60.0
+		! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+		!    Discharge computation using CNT method
+		! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+		do j = 1, nlinks
+			ncomp = frnw_g(j,1)
+			lateralFlow(:,:,j) = 0 !* initialize at each reach j
 
-                do timestep=1, ntim
+                		do timestep=1, ntim
 					! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 					! applying the upstream/junction boundary conditions in the matrix newQ
 					! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-                    !* head water reach
-                    if (frnw_g(j,3)==0) then
-                        do n=1,nts_ub_g
-                            varr_ub(n)= ubcd_g(n,j)
-                        end do
-                        tc_cnt= ini_time+dtini/60.0*real(timestep-1)
-                        newQ(1, timestep, j)= intp_y(nts_ub_g, tarr_ub, varr_ub, tc_cnt) !* tarr_ub in min.
-                    end if
+					!* head water reach
+					if (frnw_g(j,3)==0) then
+						do n=1,nts_ub_g
+							varr_ub(n)= ubcd_g(n,j)
+						end do
+						tc_cnt= ini_time+dtini/60.0*real(timestep-1)
+						newQ(1, timestep, j)= intp_y(nts_ub_g, tarr_ub, varr_ub, tc_cnt) !* tarr_ub in min.
+					end if
 					!* junction boundary
 					if (frnw_g(j,3).gt.0) then  ! reach boundary originates from a junction
 						newQ(1,timestep,j) = 0.0
@@ -411,33 +394,19 @@ contains
 					! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 					! populate lateral inflow array : lateralFlow in m2/sec
 					! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-                    do i=1,ncomp-1
-				    	!* 1. linear interpolation between qlat_g values
-!				    	do n=1,nts_ql_g
-!				    	    varr_ql(n)= qlat_g(n,i,j) !* qlat_g(n,i,j) in unit of m2/sec
-!				    	enddo
-!				    	tc_cnt= ini_time+dtini/60.0*real(timestep-1) !*[min]
-!                        lateralFlow(i, timestep, j)= intp_y(nts_ql_g, tarr_ql, varr_ql, tc_cnt)
-                        !* 2. stair case form of qlat_g (i.e., constant qlat over 60 min window)
-                        tc_cnt= ini_time+dtini/60.0*real(timestep-1) !*[min]
-                        idxql= locate(tarr_ql,tc_cnt)
-                        if (idxql.lt.1) idxql=1
-                        if (idxql.gt.nts_ql_g) idxql=nts_ql_g
-                        lateralFlow(i, timestep, j)= qlat_g(idxql,i,j)
-                    end do
-                    !* test start
-!                    tc_cnt= ini_time+real(timestep-1)*dtini/60.
-!                    write(10, *) tc_cnt, j, (lateralFlow(i,timestep,j), i=1, ncomp-1)
-                    !* test end
+                    			do i=1,ncomp-1
+						!* stair case form of qlat_g (i.e., constant qlat over 60 min window)
+						tc_cnt= ini_time+dtini/60.0*real(timestep-1) !*[min]
+						idxql= locate(tarr_ql,tc_cnt)
+						if (idxql.lt.1) idxql=1
+						if (idxql.gt.nts_ql_g) idxql=nts_ql_g
+						lateralFlow(i, timestep, j)= qlat_g(idxql,i,j)
+                    			end do
 
-         			!* head water reach
-                    !if (frnw_g(j,3)==0) then
-                        newQ(1,timestep,j) = newQ(1,timestep,j)+lateralFlow(1,timestep,j)*dx(1,j)
-                        lateralFlow(1,timestep,j) = 0.0       !
-                    !endif
-!                    print*, "time", j, timestep, dtini, ini_time, tc_cnt
+				        newQ(1,timestep,j) = newQ(1,timestep,j)+lateralFlow(1,timestep,j)*dx(1,j)
+				        lateralFlow(1,timestep,j) = 0.0
+
 				end do !* do timestep=1, ntim
-				!lateralFlow(1,:,j) = 0.       ! lateral flow at i = 1 is already added
 
 				! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 				! Diffusive wave forward sweep to calculate flow at t+1
@@ -449,6 +418,7 @@ contains
 				newQ(:,:,j) = qp(:,:,j)
 				
 			end do  !* j = 1, nlinks
+
 			! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 			! DEPTH, CELERITY, and DIFFUSIVITY CALCULATION
 			! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -459,22 +429,23 @@ contains
 				! applying the downstream boundary conditions in matrix newY
 				! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 				if (frnw_g(j,2) < 0.0) then    ! use normal depth water depth calculation
-                    !* TW reach
-                    !* 1. measured data at TW
-!                    do n=1,nts_db_g
-!                        varr_db(n)= dbcd_g(n) + z(ncomp,j) !* when dbcd is water stage, channel bottom elev is added.
-!                    enddo
-!                    tc_cnt= ini_time+dtini/60.*real(repeatInterval)
-!                    newY(ncomp,j)= intp_y(nts_db_g, tarr_db, varr_db, tc_cnt)
-                   ! 2. normal depth as TW boundary condition
-                    timestep= int(saveInterval/dtini) + 1
-                    q_sk_multi=1.0
-                    slope = (z(ncomp-1,j)-z(ncomp,j))/dx(ncomp-1,j)
-                    if (slope .le. 0.0001) slope = 0.0001
-                    dmy1=newQ(ncomp,timestep,j)
-                    call normal_crit_y(ncomp, j, q_sk_multi, slope, dmy1, newY(ncomp,j), temp, newArea(ncomp,j), temp)
-                else if (frnw_g(j,2) .ge. 0.0) then    ! water level is calculated from the downstream river reach
-					!* Not TW reach
+				!* TW reach
+					!* 1. measured data at TW
+	!				do n=1,nts_db_g
+	!					varr_db(n)= dbcd_g(n) + z(ncomp,j) !* when dbcd is water stage, channel bottom elev is added.
+	!				enddo
+	!				tc_cnt= ini_time+dtini/60.*real(repeatInterval)
+	!				newY(ncomp,j)= intp_y(nts_db_g, tarr_db, varr_db, tc_cnt)
+
+			   		! 2. normal depth as TW boundary condition
+					timestep= int(saveInterval/dtini) + 1
+					q_sk_multi=1.0
+					slope = (z(ncomp-1,j)-z(ncomp,j))/dx(ncomp-1,j)
+					if (slope .le. 0.0001) slope = 0.0001
+					dmy1=newQ(ncomp,timestep,j)
+					call normal_crit_y(ncomp, j, q_sk_multi, slope, dmy1, newY(ncomp,j), temp, newArea(ncomp,j), temp)
+                		else if (frnw_g(j,2) .ge. 0.0) then    ! water level is calculated from the downstream river reach
+				!* Not TW reach
 					linknb=frnw_g(j,2) ! reach downstream of j
 					newY(ncomp,j)= newY(1,linknb)   ! taking the WL from the d/s reach
 				end if
@@ -485,19 +456,19 @@ contains
 			! Write q and depth results to q_ev_g array
 			! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 			do timestep = 1, repeatInterval+1
-                ts_ev = ((ini_time*60.0/dtini) + timestep)
-                do j = 1, nlinks
-                    ncomp = frnw_g(j,1)
-                    do i = 1, ncomp
-                        q_ev_g(ts_ev, i, j) = newQ(i, timestep, j)
-                        elv_ev_g(ts_ev, i, j) = newY(i, j) - z(i,j) ! depth (meters)
-                    end do
-                end do
-            end do
+				ts_ev = ((ini_time*60.0/dtini) + timestep)
+				do j = 1, nlinks
+					ncomp = frnw_g(j,1)
+					do i = 1, ncomp
+						q_ev_g(ts_ev, i, j) = newQ(i, timestep, j)
+						elv_ev_g(ts_ev, i, j) = newY(i, j) - z(i,j) ! depth (meters)
+					end do
+				end do
+			end do
 
 			oldY = newY
 
-		end do ! end kkk loop
+	end do ! end kkk loop
         
         deallocate(frnw_g)
         deallocate(area, bo, pere, areap, qp, z, dqp, dqc, dap, dac, depth, sk, co, dx)

--- a/src/fortran_routing/diffusive_v02frwk/diffusive_cnt/diffusive_cnt.f90
+++ b/src/fortran_routing/diffusive_v02frwk/diffusive_cnt/diffusive_cnt.f90
@@ -445,7 +445,7 @@ contains
 			! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 			! Write q and depth results to q_ev_g array
 			! +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-			do timestep = 1, repeatInterval
+			do timestep = 1, repeatInterval+1
                 ts_ev = ((ini_time*60.0/dtini) + timestep)
                 do j = 1, nlinks
                     ncomp = frnw_g(j,1)

--- a/src/python_framework_v02/troute/nhd_network.py
+++ b/src/python_framework_v02/troute/nhd_network.py
@@ -664,6 +664,7 @@ def build_subnetworks_btw_reservoirs(connections, rconn, wbodies, all_gages, ind
                         
                     else:
                         reached_gage_conn.add(x)
+                        reached_segs.add(x)
 
                     if x not in targets:
                         Q.extend(rconn.get(x, ()))

--- a/src/python_routing_v02/troute/routing/compute.py
+++ b/src/python_routing_v02/troute/routing/compute.py
@@ -636,8 +636,9 @@ def compute_nhd_routing_v02(
             print("PARALLEL TIME %s seconds." % (time.time() - start_para_time))
 
     elif parallel_compute_method == "by-subnetwork-diffusive":
+        gages = set(usgs_df.index)
         reaches_ordered_bysubntw, subnetworks, subnetworks_only_ordered_jit = nhd_network.build_subnetworks_btw_reservoirs(
-            connections, rconn, wbody_conn, independent_networks, sources=None
+            connections, rconn, wbody_conn, gages, independent_networks, sources=None
         )
 
         if 1 == 1:

--- a/src/python_routing_v02/troute/routing/compute.py
+++ b/src/python_routing_v02/troute/routing/compute.py
@@ -636,11 +636,11 @@ def compute_nhd_routing_v02(
             print("PARALLEL TIME %s seconds." % (time.time() - start_para_time))
 
     elif parallel_compute_method == "by-subnetwork-diffusive":
-        gages = set(usgs_df.index)
+        gages = set(usgs_df.index).intersection(set(param_df.index))
         reaches_ordered_bysubntw, subnetworks, subnetworks_only_ordered_jit = nhd_network.build_subnetworks_btw_reservoirs(
             connections, rconn, wbody_conn, gages, independent_networks, sources=None
         )
-
+        
         if 1 == 1:
             print("JIT Preprocessing time %s seconds." % (time.time() - start_time))
             print("starting Parallel JIT calculation")

--- a/src/python_routing_v02/troute/routing/diffusive_utils.py
+++ b/src/python_routing_v02/troute/routing/diffusive_utils.py
@@ -673,7 +673,7 @@ def diffusive_input_data_v02(
     #                  Prepare lateral inflow data
     # ---------------------------------------------------------------------------------
     nts_ql_g = (
-        int((tfin_g - t0_g) * 3600.0 / dt_ql_g)+1
+        int((tfin_g - t0_g) * 3600.0 / dt_ql_g)
     )  # the number of the entire time steps of lateral flow data
 
     qlat_g = np.zeros((nts_ql_g, mxncomp_g, nrch_g))

--- a/src/python_routing_v02/troute/routing/diffusive_utils.py
+++ b/src/python_routing_v02/troute/routing/diffusive_utils.py
@@ -742,7 +742,7 @@ def diffusive_input_data_v02(
 
     #                       Build input dictionary
     # ---------------------------------------------------------------------------------
-    ntss_ev_g = int((tfin_g - t0_g) * 3600.0 / dt)
+    ntss_ev_g = int((tfin_g - t0_g) * 3600.0 / dt) + 1
 
     # build a dictionary of diffusive model inputs and helper variables
     diff_ins = {}

--- a/src/python_routing_v02/troute/routing/diffusive_utils.py
+++ b/src/python_routing_v02/troute/routing/diffusive_utils.py
@@ -321,10 +321,10 @@ def fp_ubcd_map(frnw_g, pynw, nts_ub_g, nrch_g, geo_index, upstream_inflows):
             
             head_segment = pynw[frj]
             
-            if head_segment in geo_index:
+            if head_segment in set(geo_index):
                 
-                idx_segID = np.where(np.asarray(geo_index) == head_segment)
-                
+                idx_segID = np.where(np.asarray(list(set(geo_index))) == head_segment)
+
                 for tsi in range(0, nts_ub_g):
                     
                     ubcd_g[tsi, frj] = upstream_inflows[idx_segID, tsi]  # [m^3/s]

--- a/src/python_routing_v02/troute/routing/diffusive_utils.py
+++ b/src/python_routing_v02/troute/routing/diffusive_utils.py
@@ -427,7 +427,9 @@ def diffusive_input_data_v02(
     upstream_results,
     qts_subdivisions,
     nsteps,
-    dt
+    dt,
+    lake_segs,
+    wbody_params,
 ):
     """
     Build input data objects for diffusive wave model

--- a/src/python_routing_v02/troute/routing/fast_reach/diffusive.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/diffusive.pyx
@@ -264,7 +264,8 @@ cpdef object compute_diffusive_tst(
                                 )
         
     # re-index the flowveldepth_unorder array returned by diff_utils
-    flowveldepth_test = np.zeros((data_idx.shape[0], nsteps*3), dtype='float32')
+    # TODO return depth not elevation from Tulane model
+    flowveldepth_test = np.zeros((data_idx.shape[0], ntss_ev_g*3), dtype='float32')
     flowveldepth_test = (pd.DataFrame(data = flowveldepth_unorder, index = index_array).
                     reindex(index = data_idx).
                     to_numpy(dtype = 'float32'))
@@ -281,7 +282,7 @@ cpdef object compute_diffusive_tst(
     cdef float[:,:] nudge = np.zeros((gages_size, nsteps + 1), dtype="float32")
     cdef int qvd_ts_w = 3
     cdef int ts_offset
-    cdef float[:,:] flowveldepth_row_fill_buf = np.zeros((1, nsteps), dtype="float32")
+    cdef float[:,:] flowveldepth_row_fill_buf = np.zeros((1, ntss_ev_g), dtype="float32")
     cdef np.ndarray fill_index_mask = np.ones_like(data_idx, dtype=bool)
     
     if gages_size:
@@ -290,8 +291,9 @@ cpdef object compute_diffusive_tst(
         lastobs_time = time_since_lastobs_init[0]
         usgs_positions_i = usgs_positions[0]
                    
+        # timestep 0 is the initial condition b/c diffusive wave writes out nsteps + 1 timesteps
         timestep = 0
-        while timestep <= nsteps-1:
+        while timestep <= ntss_ev_g-1:
             
             ts_offset = timestep * qvd_ts_w
 

--- a/src/python_routing_v02/troute/routing/fast_reach/diffusive.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/diffusive.pyx
@@ -255,7 +255,6 @@ cpdef object compute_diffusive_tst(
      out_elv)
 
     # re-format outputs from the diffusive Fortran kernel
-    # TODO: elevation is returned by Tulane model, not depth
     index_array, flowveldepth_unorder = diff_utils.unpack_output(
                                 diff_inputs["pynw"],
                                 diff_inputs["ordered_reaches"],

--- a/src/python_routing_v02/troute/routing/fast_reach/diffusive.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/diffusive.pyx
@@ -322,4 +322,5 @@ cpdef object compute_diffusive_tst(
         fill_index = tmp["position_index"]
         fill_index_mask[fill_index] = False
         
-    return np.asarray(data_idx, dtype=np.intp)[fill_index_mask], np.asarray(flowveldepth)[fill_index_mask]
+    # drop the initial conditions columns from the flowveldepth array before returning 
+    return np.asarray(data_idx, dtype=np.intp)[fill_index_mask], np.asarray(flowveldepth[:,3:])[fill_index_mask]

--- a/src/python_routing_v02/troute/routing/fast_reach/diffusive.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/diffusive.pyx
@@ -301,7 +301,7 @@ cpdef object compute_diffusive_tst(
                 dt,
                 da_decay_coefficient,
                 gage_maxtimestep,
-                NAN if timestep >= gage_maxtimestep else usgs_values[0,timestep+1],
+                NAN if timestep >= gage_maxtimestep else usgs_values[0,timestep],
                 flowveldepth[usgs_positions_i, ts_offset],
                 lastobs_time,
                 lastobs_value,

--- a/src/python_routing_v02/troute/routing/fast_reach/diffusive.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/diffusive.pyx
@@ -162,7 +162,9 @@ cpdef object compute_diffusive_tst(
         upstream_results,
         qts_subdivisions,
         nsteps,
-        dt
+        dt,
+        np.asarray(lake_numbers_col),
+        np.asarray(wbody_cols),
         )
 
     # unpack/declare diffusive input variables

--- a/src/python_routing_v02/troute/routing/fast_reach/diffusive.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/diffusive.pyx
@@ -250,12 +250,71 @@ cpdef object compute_diffusive_tst(
      out_q,
      out_elv)
 
-    # re-format outputs
-    index_array, flowvelelv = diff_utils.unpack_output(
+    # re-format outputs from the diffusive Fortran kernel
+    # TODO: elevation is returned by Tulane model, not depth
+    index_array, flowveldepth_unorder = diff_utils.unpack_output(
                                 diff_inputs["pynw"],
                                 diff_inputs["ordered_reaches"],
                                 out_q,
                                 out_elv
                                 )
+        
+    # re-index the flowveldepth_unorder array returned by diff_utils
+    flowveldepth_test = np.zeros((data_idx.shape[0], nsteps*3), dtype='float32')
+    flowveldepth_test = (pd.DataFrame(data = flowveldepth_unorder, index = index_array).
+                    reindex(index = data_idx).
+                    to_numpy(dtype = 'float32'))
+    
+    cdef float[:,:] flowveldepth = flowveldepth_test
+    cdef int gages_size = usgs_positions.shape[0]
+    cdef int gage_maxtimestep = usgs_values.shape[1]
+    cdef int gage_i, usgs_position_i, timestep
+    cdef float lastosbs_value, lastobs_time
+    cdef float a, da_decay_minutes, da_weighted_shift, replacement_val  # , original_val, lastobs_val,
+    cdef float [:] lastobs_values, lastobs_times
+    cdef (float, float, float, float) da_buf
+    cdef int[:] reach_has_gage = np.full(len(reaches_wTypes), np.iinfo(np.int32).min, dtype="int32")
+    cdef float[:,:] nudge = np.zeros((gages_size, nsteps + 1), dtype="float32")
+    cdef int qvd_ts_w = 3
+    cdef int ts_offset
+    cdef float[:,:] flowveldepth_row_fill_buf = np.zeros((1, nsteps), dtype="float32")
+    cdef np.ndarray fill_index_mask = np.ones_like(data_idx, dtype=bool)
+    
+    if gages_size:
+        
+        lastobs_value = lastobs_values_init[0]
+        lastobs_time = time_since_lastobs_init[0]
+        usgs_positions_i = usgs_positions[0]
+                   
+        timestep = 0
+        while timestep <= nsteps-1:
+            
+            ts_offset = timestep * qvd_ts_w
 
-    return index_array, flowvelelv
+            da_buf = simple_da(
+                timestep,
+                dt,
+                da_decay_coefficient,
+                gage_maxtimestep,
+                NAN if timestep >= gage_maxtimestep else usgs_values[0,timestep+1],
+                flowveldepth[usgs_positions_i, ts_offset],
+                lastobs_time,
+                lastobs_value,
+                False,
+            )
+            
+            # fill buffer for all timesteps at gage locations
+            flowveldepth_row_fill_buf[0, timestep] = da_buf[0]
+            
+            timestep += 1
+        
+        # insert buffer
+        flowveldepth[usgs_positions_i,::3] = flowveldepth_row_fill_buf
+        
+    # create mask array
+    for upstream_tw_id in upstream_results:
+        tmp = upstream_results[upstream_tw_id]
+        fill_index = tmp["position_index"]
+        fill_index_mask[fill_index] = False
+        
+    return np.asarray(data_idx, dtype=np.intp)[fill_index_mask], np.asarray(flowveldepth)[fill_index_mask]

--- a/src/python_routing_v02/troute/routing/fast_reach/diffusive.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/diffusive.pyx
@@ -2,11 +2,13 @@ import cython
 import numpy as np
 import pandas as pd
 cimport numpy as np
+from libc.math cimport isnan, NAN
 
 from .fortran_wrappers cimport c_diffnw
 from .. import diffusive_utils as diff_utils
 import troute.nhd_network_utilities_v02 as nnu
 import troute.nhd_network as nhd_network
+from troute.routing.fast_reach.simple_da cimport obs_persist_shift, simple_da_with_decay, simple_da
 
 # TO DO load some example inputs to test the module
 

--- a/src/python_routing_v02/troute/routing/fast_reach/diffusive_cnt.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/diffusive_cnt.pyx
@@ -266,9 +266,7 @@ cpdef object compute_diffusive_tst(
                     reindex(index = data_idx).
                     to_numpy(dtype = 'float32'))
     
-    # create memory view of flowveldepth_test 
     cdef float[:,:] flowveldepth = flowveldepth_test
-    
     cdef int gages_size = usgs_positions.shape[0]
     cdef int gage_maxtimestep = usgs_values.shape[1]
     cdef int gage_i, usgs_position_i, timestep

--- a/src/python_routing_v02/troute/routing/fast_reach/diffusive_cnt.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/diffusive_cnt.pyx
@@ -321,4 +321,5 @@ cpdef object compute_diffusive_tst(
         fill_index = tmp["position_index"]
         fill_index_mask[fill_index] = False
         
-    return np.asarray(data_idx, dtype=np.intp)[fill_index_mask], np.asarray(flowveldepth)[fill_index_mask]
+    # drop the initial conditions columns from the flowveldepth array before returning 
+    return np.asarray(data_idx, dtype=np.intp)[fill_index_mask], np.asarray(flowveldepth[:,3:])[fill_index_mask]

--- a/src/python_routing_v02/troute/routing/fast_reach/diffusive_cnt.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/diffusive_cnt.pyx
@@ -263,7 +263,7 @@ cpdef object compute_diffusive_tst(
                                 )
         
     # re-index the flowveldepth_unorder array returned by diff_utils
-    flowveldepth_test = np.zeros((data_idx.shape[0], nsteps*3), dtype='float32')
+    flowveldepth_test = np.zeros((data_idx.shape[0], ntss_ev_g*3), dtype='float32')
     flowveldepth_test = (pd.DataFrame(data = flowveldepth_unorder, index = index_array).
                     reindex(index = data_idx).
                     to_numpy(dtype = 'float32'))
@@ -280,7 +280,7 @@ cpdef object compute_diffusive_tst(
     cdef float[:,:] nudge = np.zeros((gages_size, nsteps + 1), dtype="float32")
     cdef int qvd_ts_w = 3
     cdef int ts_offset
-    cdef float[:,:] flowveldepth_row_fill_buf = np.zeros((1, nsteps), dtype="float32")
+    cdef float[:,:] flowveldepth_row_fill_buf = np.zeros((1, ntss_ev_g), dtype="float32")
     cdef np.ndarray fill_index_mask = np.ones_like(data_idx, dtype=bool)
     
     if gages_size:
@@ -289,8 +289,9 @@ cpdef object compute_diffusive_tst(
         lastobs_time = time_since_lastobs_init[0]
         usgs_positions_i = usgs_positions[0]
                    
+        # timestep 0 is the initial condition b/c diffusive wave writes out nsteps + 1 timesteps
         timestep = 0
-        while timestep <= nsteps-1:
+        while timestep <= ntss_ev_g-1:
             
             ts_offset = timestep * qvd_ts_w
 

--- a/src/python_routing_v02/troute/routing/fast_reach/diffusive_cnt.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/diffusive_cnt.pyx
@@ -162,7 +162,9 @@ cpdef object compute_diffusive_tst(
         upstream_results,
         qts_subdivisions,
         nsteps,
-        dt
+        dt,
+        np.asarray(lake_numbers_col),
+        np.asarray(wbody_cols),
         )
 
     # unpack/declare diffusive input variables

--- a/src/python_routing_v02/troute/routing/fast_reach/diffusive_cnt.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/diffusive_cnt.pyx
@@ -300,7 +300,7 @@ cpdef object compute_diffusive_tst(
                 dt,
                 da_decay_coefficient,
                 gage_maxtimestep,
-                NAN if timestep >= gage_maxtimestep else usgs_values[0,timestep+1],
+                NAN if timestep >= gage_maxtimestep else usgs_values[0,timestep],
                 flowveldepth[usgs_positions_i, ts_offset],
                 lastobs_time,
                 lastobs_value,

--- a/src/python_routing_v02/troute/routing/fast_reach/diffusive_cnt.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/diffusive_cnt.pyx
@@ -133,7 +133,7 @@ cpdef object compute_diffusive_tst(
     dict upstream_results={},
     bint assume_short_ts=False,
     bint return_courant=False,
-    dict diffusive_parameters=False
+    dict diffusive_parameters=False,
     ):
 
     # segment connections dictionary

--- a/src/python_routing_v02/troute/routing/fast_reach/diffusive_cnt.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/diffusive_cnt.pyx
@@ -251,11 +251,49 @@ cpdef object compute_diffusive_tst(
      out_elv)
 
     # re-format outputs
-    index_array, flowvelelv = diff_utils.unpack_output(
+    index_array, flowveldepth = diff_utils.unpack_output(
                                 diff_inputs["pynw"],
                                 diff_inputs["ordered_reaches"],
                                 out_q,
                                 out_elv
                                 )
+        
+    # TODO: reindex flowveldepth array to match data_idx, else we will end up
+    # assimilating data to the wron segment. 
+    
+    cdef int gages_size = usgs_positions.shape[0]
+    cdef int gage_maxtimestep = usgs_values.shape[1]
+    cdef int gage_i, usgs_position_i, timestep
+    cdef float lastosbs_value, lastobs_time
+    cdef float a, da_decay_minutes, da_weighted_shift, replacement_val  # , original_val, lastobs_val,
+    cdef float [:] lastobs_values, lastobs_times
+    cdef (float, float, float, float) da_buf
+    cdef int[:] reach_has_gage = np.full(len(reaches_wTypes), np.iinfo(np.int32).min, dtype="int32")
+    cdef float[:,:] nudge = np.zeros((gages_size, nsteps + 1), dtype="float32")
 
-    return index_array, flowvelelv
+    if gages_size:
+        lastobs_value = lastobs_values_init[0]
+        lastobs_time = time_since_lastobs_init[0]
+        routing_period = dt
+        usgs_positions_i = usgs_positions[0]
+        
+        timestep = 0
+        while timestep <= nsteps:
+
+#             da_buf = simple_da(
+#                 timestep,
+#                 dt,
+#                 da_decay_coefficient,
+#                 gage_maxtimestep,
+#                 NAN if timestep >= gage_maxtimestep else usgs_values[0,timestep],
+#                 flowveldepth[usgs_positions_i, timestep, 0],
+#                 lastobs_time,
+#                 lastobs_value,
+#                 False,
+#             )
+
+            timestep += 1
+        
+        
+
+    return index_array, flowveldepth


### PR DESCRIPTION
# Executive Summary
This PR adds the capability to do data assimilation (DA) with the diffusive wave model. At gage locations, simulated flows are either replaced with interpolated USGS observations, or nudged by some amount (in the event that observations are missing). Replaced/nudged flows at gage locations are then routed downstream. The DA scheme does not propagate any gage information upstream. Instead gage information (flow) is only passed in the downstream direction. The approach used for observation interpolation, DA substitution, and DA decay is exactly the same as is used with Muskingum-Cunge. 

# Technical Details
- DA with the diffusive wave model is facilitated by subnetwork creation. The spatial unit of analysis for the diffusive wave Fortran kernel is a stand-alone stream network, as opposed to a single segment in the case of Muskingum-Cunge. Therefore, it is necessary to break networks into subnetworks that reside between gages and reservoirs. Subnetwork tailwaters are either gages, reservoir inflows, or network tailwaters. This allows downstream flow conditions from one subnetwork to be passed as upstream boundary conditions to the subsequent subnetwork (either a stream network or reservoir). Subnetwork creation between gages and reservoirs is done by revisions in [`nhd_network.build_subnetworks_btw_reservoirs`](https://github.com/awlostowski-noaa/t-route/blob/5c9fed318caeef2588131b8c2b1da49ee8af3422/src/python_framework_v02/troute/nhd_network.py#L610-L765). When handed a list of gages in the network (from `usgs_df`) the function builds subnetworks between reservoirs and gages. Otherwise, the function only build subnetworks between reservoirs. 
- The DA substitution and decay processes are very similar to that used with Muskingum-Cunge, in that they both use the [`simple_da.simple_da_with_decay`](https://github.com/awlostowski-noaa/t-route/blob/5c9fed318caeef2588131b8c2b1da49ee8af3422/src/python_routing_v02/troute/routing/fast_reach/simple_da.pyx#L81-L117) function called from a cython compute kernel. However, the DA scheme differs from Muskingum-Cunge in that the diffusive DA occurs [AFTER](https://github.com/awlostowski-noaa/t-route/blob/5c9fed318caeef2588131b8c2b1da49ee8af3422/src/python_routing_v02/troute/routing/fast_reach/diffusive_cnt.pyx#L255-L315) all segments have been simulated for all timesteps. 
- [Changes to `diffusive_utils.py`](https://github.com/awlostowski-noaa/t-route/blob/5c9fed318caeef2588131b8c2b1da49ee8af3422/src/python_routing_v02/troute/routing/diffusive_utils.py#L500-L523) allow multiple off-network upstream inflows to a single subnetwork headwater as an upstream boundary condition. Gages frequently exist on junction inflow segments. So, the segment immediately below that junction (subnetwork headwater), needs to receive boundary condition flows from the gage segment and all other segments influent to the junction.  

# Demonstration
The figure below demonstrates diffusive wave data assimilation in action. The mainstem of the Eno River, between Hillsborough and Durham, North Carolina has two gages. Gage segments are colored red. Above the upstream most gage at Hillsborough, the open loop simulation is shown - this solution is replaced at the gage segment near Hillsborough. Here, we can see that the assimilation routine is properly replacing routed flows with interpolated observations. Between the two gages, the assimilated observations are routed downstream. At the downstream gage, the simulations are again replaced with interpolated observations.
![diffusive_da_demo_eno](https://user-images.githubusercontent.com/66840445/133653435-fb71dee5-5ad8-4aad-96f0-1795b1732d7a.png)


# Testing
1. Ensure that simulation results are stable throughout the domain - no negative or NaNs in the result arrays
- Results are stable. With a dt parameter of 300 seconds, the diffusive_cnt code exhibits numerical oscillations at headwater locations. Though with a dt = 600 seconds, this behavior is minimized. Despite some numerical oscillations, the simulation does not blow up at any point. Numerical oscillations near headwaters are ultimately less concerning because the diffusive wave model is not intended for use in headwater areas. 
2. Ensure that DA is happening correctly at gage locations - should see same exact substitution result and similar nudge pattern as with Muskingum-Cunge
- passed
3. Results for all segments and reservoirs above gages should be identical to no DA simulation result
- passed

## TODO
- [x] copy capability to Tulane diffusive version, not just CNT
- [x] proof of concept figures/charts
- [x] comprehensive explaination
- [x] test that workflow still works when no DA parameters are specified in YAML (i.e. dw with reservoirs, no da)
- [x] clean cython code
- [x] use upstream boundary data at native time resolution - why sub-sample to timestep of qlaterals?
- [x] what is going on when nts is set to limit of available CHRTOUT files?
