### PR TITLE
Handle nonnumeric gage ids

### DIFF
--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -442,6 +442,22 @@ def get_attribute(nc_file, attribute):
         return xd.attrs[attribute]
 
 
+def build_filtered_gage_df(segment_gage_df, gage_col="gages"):
+    """
+    segment_gage_df - dataframe indexed by segment with at least
+        one column, gage_col, with the gage ids by segment.
+    gage_col - the name of the column containing the gages
+        to filter.
+    """
+    # TODO: use this function to filter the inputs
+    # coming into the da read routines below.
+    gage_list = list(map(bytes.strip, segment_gage_df[gage_col].values))
+    gage_mask = list(map(bytes.isalnum, gage_list))
+    segment_gage_df = segment_gage_df.loc[gage_mask, [gage_col]]
+    segment_gage_df[gage_col] = segment_gage_df[gage_col].map(bytes.strip)
+    return segment_gage_df.to_dict()
+
+
 def build_lastobs_df(
         lastobsfile,
         routelink,
@@ -655,7 +671,7 @@ def get_usgs_from_time_slices_folder(
     t0 = None,
 ):
     """
-    routelink_subset_file - provides the gage-->segment crosswalk. 
+    routelink_subset_file - provides the gage-->segment crosswalk.
         Only gages that are represented in the
         crosswalk will be brought into the evaluation.
     usgs_files - list of "time-slice" files containing observed values

--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -698,9 +698,9 @@ def build_data_assimilation_lastobs(data_assimilation_parameters):
 
 def build_data_assimilation_csv(data_assimilation_parameters):
 
-    usgs_df = nhd_io.get_usgs_from_time_slices_csv(
-        data_assimilation_parameters["wrf_hydro_da_channel_ID_crosswalk_file"],
+    usgs_df = nhd_io.get_usgs_df_from_csv(
         data_assimilation_parameters["data_assimilation_csv"],
+        data_assimilation_parameters["wrf_hydro_da_channel_ID_crosswalk_file"],
     )
 
     return usgs_df

--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -449,7 +449,7 @@ def build_connections(supernetwork_parameters):
 
     gages = {}
     if "gages" in cols:
-        gages = build_gages(param_df[["gages"]])
+        gages = nhd_io.build_filtered_gage_df(param_df[["gages"]])
         param_df = param_df.drop("gages", axis=1)
 
     # There can be an externally determined terminal code -- that's this first value
@@ -472,14 +472,6 @@ def build_connections(supernetwork_parameters):
 
     # datasub = data[['dt', 'bw', 'tw', 'twcc', 'dx', 'n', 'ncc', 'cs', 's0']]
     return connections, param_df, wbodies, gages
-
-
-def build_gages(segment_gage_df,):
-    gage_list = list(map(bytes.strip, segment_gage_df.gages.values))
-    gage_mask = list(map(bytes.isdigit, gage_list))
-    gages = segment_gage_df.loc[gage_mask, "gages"].to_dict()
-
-    return gages
 
 
 def build_waterbodies(


### PR DESCRIPTION
Gage IDs in the NWM 2.1 dataset include gages in Canada with non-numeric IDs. Based on gages from the USGS numbering system, only numeric gage IDs were being accepted and the alphanumeric Canadian gages were being removed. Those gages should now be properly handled and retained. 