### PR TITLE
[WIP] allow different intervals for data assimilation

### DIFF
--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -574,7 +574,8 @@ def _run_everything_v02(
             print("creating usgs time_slice data array ...")
 
             usgs_df, lastobs_df, da_parameter_dict = nnu.build_data_assimilation(
-                data_assimilation_parameters
+                data_assimilation_parameters,
+                run_parameters,
             )
 
         if verbose:

--- a/src/nwm_routing/src/nwm_routing/preprocess.py
+++ b/src/nwm_routing/src/nwm_routing/preprocess.py
@@ -293,6 +293,8 @@ def nwm_forcing_preprocess(
         lastobs_type = data_assimilation_parameters.get("wrf_lastobs_type", "error-based")
         lastobs_crosswalk_file = data_assimilation_parameters.get("wrf_hydro_da_channel_ID_crosswalk_file", None)
         da_decay_coefficient = data_assimilation_parameters.get("da_decay_coefficient", 120)
+        qc_threshold = data_assimilation_parameters.get("qc_threshold", 1.0)
+        da_max_fill = data_assimilation_parameters.get("da_max_fill", 59)
 
         da_run["data_assimilation_timeslices_folder"] = da_run.get("data_assimilation_timeslices_folder", data_assimilation_folder)
         da_run["data_assimilation_csv"] = da_run.get("data_assimilation_csv", data_assimilation_csv)
@@ -301,6 +303,8 @@ def nwm_forcing_preprocess(
         da_run["wrf_lastobs_type"] = da_run.get("wrf_lastobs_type", lastobs_type)
         da_run["wrf_hydro_da_channel_ID_crosswalk_file"] = da_run.get("wrf_hydro_da_channel_ID_crosswalk_file", lastobs_crosswalk_file)
         da_run["da_decay_coefficient"] = da_run.get("da_decay_coefficient", da_decay_coefficient)
+        da_run["qc_threshold"] = da_run.get("QC_threshold", qc_threshold)
+        da_run["da_max_fill"] = da_run.get("da_max_fill", da_max_fill)
 
     # STEP 5: Read (or set) QLateral Inputs
     if showtiming:
@@ -333,7 +337,7 @@ def nwm_forcing_preprocess(
         if verbose:
             print("creating usgs time_slice data array ...")
 
-        usgs_df = nnu.build_data_assimilation_usgs_df(da_run, lastobs_index, run["t0"])
+        usgs_df = nnu.build_data_assimilation_usgs_df(da_run, run, lastobs_index)
 
         if verbose:
             print("usgs array complete")

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -653,7 +653,9 @@ def get_usgs_from_time_slices_folder(
     routelink_subset_file,
     usgs_files,
     max_fill_1min = 14,
+    dt = 300,
     t0 = None,
+    qc_threshold = 1.0,
 ):
     """
     routelink_subset_file - provides the gage-->segment crosswalk
@@ -663,6 +665,7 @@ def get_usgs_from_time_slices_folder(
           the interpolated values are truncated so that the first value returned
           corresponds to the first center date of the first provided file.
     """
+    frequency = str(dt/60))+"min"
     with read_netcdfs(usgs_files, "time", preprocess_time_station_index,) as ds2:
 
         # dataframe containing discharge observations
@@ -718,7 +721,7 @@ def get_usgs_from_time_slices_folder(
     date_time_center_end = datetime.strptime(last_center_time, "%Y-%m-%d_%H:%M:%S")
 
     dates = []
-    for j in pd.date_range(date_time_center_start, date_time_center_end, freq="5min"):
+    for j in pd.date_range(date_time_center_start, date_time_center_end, freq=frequency):
         dates.append(j)
 
     """
@@ -760,9 +763,7 @@ def get_usgs_from_time_slices_folder(
     usgs_qual_df = usgs_qual_df.mask(usgs_qual_df > 1, np.nan)
 
     # screen-out poor quality flow observations
-    # TODO: Bring qc_thresh parameter in from yaml as user input
-    qc_trehsh = 1
-    usgs_df = usgs_df.mask(usgs_qual_df < qc_trehsh, np.nan)
+    usgs_df = usgs_df.mask(usgs_qual_df < qc_threshold, np.nan)
 
     # screen-out erroneous flow observations
     usgs_df = usgs_df.mask(usgs_df <= 0, np.nan)
@@ -782,7 +783,7 @@ def get_usgs_from_time_slices_folder(
     # TODO: Add reporting interval information to the gage preprocessing (timeslice generation)
     usgs_df_T = (usgs_df_T.resample('min').
                  interpolate(limit = max_fill_1min, limit_direction = 'both').
-                 resample('5min').
+                 resample(frequency).
                  asfreq().
                  loc[date_time_center_start:,:])
 

--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -626,16 +626,16 @@ def build_qlateral_array(
     return qlat_df
 
 
-def build_data_assimilation(data_assimilation_parameters):
+def build_data_assimilation(data_assimilation_parameters, run_parameters):
     lastobs_df, da_parameter_dict = build_data_assimilation_lastobs(data_assimilation_parameters)
-    usgs_df = build_data_assimilation_usgs_df(data_assimilation_parameters, lastobs_df.index)
+    usgs_df = build_data_assimilation_usgs_df(data_assimilation_parameters, run_parameters, lastobs_df.index)
     return usgs_df, lastobs_df, da_parameter_dict
 
 
 def build_data_assimilation_usgs_df(
     data_assimilation_parameters,
+    run_parameters,
     lastobs_index=None,
-    t0=None,
 ):
     data_assimilation_csv = data_assimilation_parameters.get(
         "data_assimilation_csv", None
@@ -651,7 +651,7 @@ def build_data_assimilation_usgs_df(
     if data_assimilation_csv:
         usgs_df = build_data_assimilation_csv(data_assimilation_parameters)
     elif data_assimilation_folder:
-        usgs_df = build_data_assimilation_folder(data_assimilation_parameters, t0)
+        usgs_df = build_data_assimilation_folder(data_assimilation_parameters, run_parameters)
 
     if not lastobs_index.empty:
         if not usgs_df.empty and not usgs_df.index.equals(lastobs_index):
@@ -706,8 +706,10 @@ def build_data_assimilation_csv(data_assimilation_parameters):
     return usgs_df
 
 
-def build_data_assimilation_folder(data_assimilation_parameters, t0=None):
+def build_data_assimilation_folder(data_assimilation_parameters, run_parameters=None):
 
+    if not run_parameters:
+        run_parameters = {}
     usgs_timeslices_folder = pathlib.Path(
         data_assimilation_parameters["data_assimilation_timeslices_folder"],
     ).resolve()
@@ -725,7 +727,9 @@ def build_data_assimilation_folder(data_assimilation_parameters, t0=None):
         data_assimilation_parameters["wrf_hydro_da_channel_ID_crosswalk_file"],
         usgs_files,
         data_assimilation_parameters.get("data_assimilation_interpolation_limit", 59),
-        t0,
+        run.get("dt", 300),
+        run.get("t0", None)
+        data_assimilation_parameters.get("qc_threshold", 1.0),
     )
 
     return usgs_df


### PR DESCRIPTION
This PR is built off of the fixes found in jameshalgren/long-term-looping-all.

This PR should address the feature requests in:
**https://github.com/NOAA-OWP/t-route/issues/433**

marked at:

- https://github.com/NOAA-OWP/t-route/blob/4ec74cc70d4f1ca407d20a6764b3f89facb43a96/src/python_framework_v02/troute/nhd_io.py#L757

- https://github.com/NOAA-OWP/t-route/blob/4ec74cc70d4f1ca407d20a6764b3f89facb43a96/src/python_framework_v02/troute/nhd_io.py#L652

- https://github.com/NOAA-OWP/t-route/blob/4ec74cc70d4f1ca407d20a6764b3f89facb43a96/src/python_framework_v02/troute/nhd_io.py#L776

The frequency needed to be calculated using the run_parameters['dt']. I made a few changes to pass run_parameters through the necessary functions to get it there. Additionally, a slight modification to data_assimilation_parameters to add both data_assimilation_interpolation_limit: 14 and QC_threshold: 1. These can now be specified and passed from the YAML to the functions found in .io.

The files I made changes to are the Florence_fcast_da_5min, main, nhd_io, and nhd_network_utilities. Added new yaml named Florence_fcast_da_5min_frequency_test.yaml to the shared folder on Cheyenne for simplicity.