### PR TITLE
Allow forcing datasets to load asynchronously during model execution

### DIFF
--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -1322,6 +1322,7 @@ async def main_v03_async(argv):
         debuglevel,
     )
 
+    run_set_iterator = 0
     for run_set_iterator, run in enumerate(run_sets[:-1]):
 
         t0 = run.get("t0")

--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -7,6 +7,9 @@ import numpy as np
 import pandas as pd
 import math
 
+import asyncio
+import concurrent.futures
+
 ## network and reach utilities
 import troute.nhd_network as nhd_network
 import troute.nhd_io as nhd_io
@@ -960,7 +963,7 @@ def get_waterbody_water_elevation(waterbodies_df, q0):
     return waterbodies_df
 
 
-def update_lookback_hours(dt, nts, waterbody_parameters): 
+def update_lookback_hours(dt, nts, waterbody_parameters):
     """
     Update the lookback hours that an RFC type reservoir searches in reverse
     from the model start time to find a time series file. The update is based
@@ -1154,9 +1157,8 @@ def main_v03(argv):
             debuglevel,
         )
 
-        if (
-            run_set_iterator < len(run_sets) - 1
-        ):  # No forcing to prepare for the last loop
+        # No forcing to prepare for the last loop
+        if run_set_iterator < len(run_sets) - 1:
             qlats, usgs_df = nwm_forcing_preprocess(
                 run_sets[run_set_iterator + 1],
                 forcing_parameters,
@@ -1180,7 +1182,7 @@ def main_v03(argv):
             waterbodies_df = get_waterbody_water_elevation(waterbodies_df, q0)
 
             if waterbody_type_specified:
-                waterbody_parameters = update_lookback_hours(dt, nts, waterbody_parameters) 
+                waterbody_parameters = update_lookback_hours(dt, nts, waterbody_parameters)
 
         nwm_output_generator(
             run,
@@ -1204,6 +1206,299 @@ def main_v03(argv):
     if showtiming:
         print("%s seconds." % (time.time() - main_start_time))
 
+
+async def main_v03_async(argv):
+    """
+    Handles the creation of the input parameter dictionaries
+    from an input file and then sequences the execution of the
+    t-route routing agorithm on a series of execution loops.
+    """
+    args = _handle_args_v03(argv)  # async shares input framework with non-async
+    (
+        log_parameters,
+        supernetwork_parameters,
+        waterbody_parameters,
+        compute_parameters,
+        forcing_parameters,
+        restart_parameters,
+        diffusive_parameters,
+        output_parameters,
+        parity_parameters,
+        data_assimilation_parameters,
+    ) = _input_handler_v03(args)
+
+    verbose = log_parameters.get("verbose", None)
+    showtiming = log_parameters.get("showtiming", None)
+    debuglevel = log_parameters.get("debuglevel", 0)
+
+    if showtiming:
+        main_start_time = time.time()
+
+    (
+        connections,
+        param_df,
+        wbody_conn,
+        waterbodies_df,
+        waterbody_types_df,
+        break_network_at_waterbodies,
+        waterbody_type_specified,
+        independent_networks,
+        reaches_bytw,
+        rconn,
+    ) = nwm_network_preprocess(
+        supernetwork_parameters,
+        waterbody_parameters,
+        showtiming=showtiming,
+        verbose=verbose,
+        debuglevel=debuglevel,
+    )
+
+    # TODO: This function modifies one of its arguments (waterbodies_df), which is somewhat poor practice given its otherwise functional nature. Consider refactoring
+    waterbodies_df, q0, t0, lastobs_df, da_parameter_dict = nwm_initial_warmstate_preprocess(
+        break_network_at_waterbodies,
+        restart_parameters,
+        data_assimilation_parameters,
+        param_df.index,
+        waterbodies_df,
+        segment_list=None,
+        wbodies_list=None,
+        showtiming=showtiming,
+        verbose=verbose,
+        debuglevel=debuglevel,
+    )
+
+    # The inputs below assume a very pedantic setup
+    # with each run set explicitly defined, so...
+    # TODO: Make this more flexible.
+    run_sets = forcing_parameters.get("qlat_forcing_sets", False)
+
+    if "data_assimilation_parameters" in compute_parameters:
+        if "data_assimilation_sets" in data_assimilation_parameters:
+            da_sets = data_assimilation_parameters.get("data_assimilation_sets", [])
+        else:
+            da_sets = [{} for _ in run_sets]
+
+    if "wrf_hydro_parity_check" in output_parameters:
+        parity_sets = parity_parameters.get("parity_check_compare_file_sets", [])
+    else:
+        parity_sets = []
+
+    parallel_compute_method = compute_parameters.get("parallel_compute_method", None)
+    subnetwork_target_size = compute_parameters.get("subnetwork_target_size", 1)
+    # TODO: Determine parameterization of the CPU and Threading pools
+    # TODO: Make sure default values from dict.get for pool sizes work
+    # e.g., is this valid: `ThreadPoolExecutor(max_workers=None)`?
+    COMPUTE_cpu_pool = compute_parameters.get("cpu_pool", None)
+    # IO_cpu_pool = compute_parameters.get("cpu_pool_IO", None)
+    IO_cpu_pool = COMPUTE_cpu_pool
+    qts_subdivisions = forcing_parameters.get("qts_subdivisions", 1)
+    compute_kernel = compute_parameters.get("compute_kernel", "V02-caching")
+    assume_short_ts = compute_parameters.get("assume_short_ts", False)
+    return_courant = compute_parameters.get("return_courant", False)
+
+    FORCE_KERNEL_THREAD = False
+    if FORCE_KERNEL_THREAD:
+        pool_IO = None
+        pool_Processing = None
+    else:
+        pool_IO = concurrent.futures.ThreadPoolExecutor(max_workers=IO_cpu_pool)
+        pool_Processing = concurrent.futures.ThreadPoolExecutor(max_workers=COMPUTE_cpu_pool)
+
+    loop = asyncio.get_running_loop()
+
+    forcings_task = loop.run_in_executor(
+        pool_IO,
+        nwm_forcing_preprocess,
+        run_sets[0],
+        forcing_parameters,
+        da_sets[0] if data_assimilation_parameters else {},
+        data_assimilation_parameters,
+        break_network_at_waterbodies,
+        param_df.index,
+        lastobs_df.index,
+        t0,
+        showtiming,
+        verbose,
+        debuglevel,
+    )
+
+    for run_set_iterator, run in enumerate(run_sets[:-1]):
+
+        t0 = run.get("t0")
+        dt = run.get("dt")
+        nts = run.get("nts")
+
+        qlats, usgs_df = await forcings_task
+
+        # TODO: confirm utility of visual parity check in async execution
+        if parity_sets:
+            parity_sets[run_set_iterator]["dt"] = dt
+            parity_sets[run_set_iterator]["nts"] = nts
+
+        model_task = loop.run_in_executor(
+            pool_Processing,
+            nwm_route,
+            connections,
+            rconn,
+            wbody_conn,
+            reaches_bytw,
+            parallel_compute_method,
+            compute_kernel,
+            subnetwork_target_size,
+            COMPUTE_cpu_pool,
+            dt,
+            nts,
+            qts_subdivisions,
+            independent_networks,
+            param_df,
+            q0,
+            qlats,
+            usgs_df,
+            lastobs_df,
+            da_parameter_dict,
+            assume_short_ts,
+            return_courant,
+            waterbodies_df,
+            waterbody_parameters,
+            waterbody_types_df,
+            waterbody_type_specified,
+            diffusive_parameters,
+            showtiming,
+            verbose,
+            debuglevel,
+        )
+
+        forcings_task = loop.run_in_executor(
+            pool_IO,
+            nwm_forcing_preprocess,
+            run_sets[run_set_iterator + 1],
+            forcing_parameters,
+            da_sets[run_set_iterator + 1] if data_assimilation_parameters else {},
+            data_assimilation_parameters,
+            break_network_at_waterbodies,
+            param_df.index,
+            lastobs_df.index,
+            t0 + timedelta(seconds = dt * nts),
+            showtiming,
+            verbose,
+            debuglevel,
+        )
+
+        run_results = await model_task
+
+        q0 = new_nwm_q0(run_results)
+
+        if data_assimilation_parameters:
+            lastobs_df = new_lastobs(run_results, dt * nts)
+
+        # TODO: Confirm this works with Waterbodies turned off
+        waterbodies_df = get_waterbody_water_elevation(waterbodies_df, q0)
+
+        if waterbody_type_specified:
+            waterbody_parameters = update_lookback_hours(dt, nts, waterbody_parameters)
+
+        output_task = loop.run_in_executor(
+            pool_IO,
+            nwm_output_generator,
+            run,
+            run_results,
+            supernetwork_parameters,
+            output_parameters,
+            parity_parameters,
+            restart_parameters,
+            parity_sets[run_set_iterator] if parity_parameters else {},
+            qts_subdivisions,
+            compute_parameters.get("return_courant", False),
+            showtiming,
+            verbose,
+            debuglevel,
+        )
+
+    # For the last loop, no next forcing or warm state is needed for execution.
+    run_set_iterator += 1
+    run = run_sets[run_set_iterator]
+
+    t0 = run.get("t0")
+    dt = run.get("dt")
+    nts = run.get("nts")
+
+    qlats, usgs_df = await forcings_task
+
+    # TODO: confirm utility of visual parity check in async execution
+    if parity_sets:
+        parity_sets[run_set_iterator]["dt"] = dt
+        parity_sets[run_set_iterator]["nts"] = nts
+
+    model_task = loop.run_in_executor(
+        pool_Processing,
+        nwm_route,
+        connections,
+        rconn,
+        wbody_conn,
+        reaches_bytw,
+        parallel_compute_method,
+        compute_kernel,
+        subnetwork_target_size,
+        COMPUTE_cpu_pool,
+        dt,
+        nts,
+        qts_subdivisions,
+        independent_networks,
+        param_df,
+        q0,
+        qlats,
+        usgs_df,
+        lastobs_df,
+        da_parameter_dict,
+        assume_short_ts,
+        return_courant,
+        waterbodies_df,
+        waterbody_parameters,
+        waterbody_types_df,
+        waterbody_type_specified,
+        diffusive_parameters,
+        showtiming,
+        verbose,
+        debuglevel,
+    )
+
+    # nwm_final_output_generator()
+    run_results = await model_task
+
+    # These warmstates are never used for modeling, but
+    # should be availble for last outputs.
+    q0 = new_nwm_q0(run_results)
+
+    if data_assimilation_parameters:
+        lastobs_df = new_lastobs(run_results, dt * nts)
+
+    waterbodies_df = get_waterbody_water_elevation(waterbodies_df, q0)
+
+    if waterbody_type_specified:
+        waterbody_parameters = update_lookback_hours(dt, nts, waterbody_parameters)
+
+    output_task = await loop.run_in_executor(
+        pool_IO,
+        nwm_output_generator,
+        run,
+        run_results,
+        supernetwork_parameters,
+        output_parameters,
+        parity_parameters,
+        restart_parameters,
+        parity_sets[run_set_iterator] if parity_parameters else {},
+        qts_subdivisions,
+        compute_parameters.get("return_courant", False),
+        showtiming,
+        verbose,
+        debuglevel,
+    )
+
+    if verbose:
+        print("process complete")
+    if showtiming:
+        print("%s seconds." % (time.time() - main_start_time))
+
         """
         Asynchronous execution Psuedocode
         Sync1: Prepare first warmstate from files
@@ -1218,6 +1513,9 @@ def main_v03(argv):
                   if next forcing prepared
         """
 
+    pool_IO.shutdown(wait=True)
+    pool_Processing.shutdown(wait=True)
+
 
 if __name__ == "__main__":
     v_parser = argparse.ArgumentParser(
@@ -1228,11 +1526,15 @@ if __name__ == "__main__":
         "--input-version",
         default=3,
         nargs="?",
-        choices=[2, 3],
+        choices=[2, 3, 4],
         type=int,
         help="Use version 2 or 3 of the input format. Default 3",
     )
     v_args = v_parser.parse_known_args()
+    if v_args[0].input_version == 4:
+        coroutine = main_v03_async(v_args[1])
+        asyncio.run(coroutine)
+        # loop.run_until_complete(coroutine)
     if v_args[0].input_version == 3:
         main_v03(v_args[1])
     if v_args[0].input_version == 2:


### PR DESCRIPTION
### TL; DR
This PR introduces asynchronous IO to the looped execution capability recently demonstrated in the t-route code (see #429). 

### Looping and Async Looping
The idea behind the looping execution is that, with proper garbage collection, T-route can provide a solution of arbitrary length (because T-Route loads all variables for a particular loop in memory, the length and size are limited by system resources). But with the looping execution, the idea of asynchronous data loading is that after the first block of data has been loaded and the simulation started with that block, the reading of subsequent blocks can begin immediately. If the read and execution sequences are staggered on different process pools, the simulation can proceed without overwhelming the memory -- but also without waiting too much for the data to load between chunks. Likewise, once the simulation completes, the next simulation can proceed without waiting for the output of the prior process to be output to disk or to the screen, because the variables for restarting are all held internally. 

This basic idea is illustrated as follows:
_(Note: The lengths of the bars in the diagram show the data reading taking longer than the process execution -- this is not always the case, but the asynchronous IO implementation used here can handle both situations.)_
![image](https://user-images.githubusercontent.com/53343824/117145596-ef747680-ad78-11eb-91d5-c90a59bde457.png)

### Progress and Status
In initial testing, the asyncio.run(coroutine) was prematurely closing the loop -- the premature closure interefered with at least the threaded call of the reading function. By adding an explicit call to `ThreadPoolExecutor.shutdown(wait=True)`, all threads appear now to be properly gathered and closed. Notes below have been updated to reflect remaining concerns, but these probably do not merit further effort in this PR. 

A test on Cheyenne showed clear improvement in overall wall time
- [x] Add Screenshots showing performance comparison. 
To run a test from materials available in the repository, execute `python -m nwm_routing -V4 -f ../../test/input/yaml/CustomInput_loop.yaml` from the `src/python_routing_v02` directory. 

~~There are concerns that the implicit returns from the forcing preprocessor function are possibly not threadsafe.~~

~~The way things are committed, the async is not happening correctly -- `asyncio.run(coroutine)` (which properly loads things in an asynchronous manner) sometimes (often) prematurely closes the loop which crashes the program so loop.run_until_complete is in the current commit.~~

There are concerns that the implicit returns from the forcing preprocessor function are possibly not
threadsafe. (There is a similar issue with the mixed explicit/implicit returns from the warmstate
preprocessor, but this is called and completes prior to the complex threading.)

Also, there are possible conflicts with the sub-threading calls that happen under the xarray.open_mfdataset and xarray.write_mfdataset calls. If needed, we can transition to using read_netcdfs for the multifunction read. There is currently no alternative write method.

We also observed that if the coroutine was wrapped as `run_until_complete(coroutine)` instead of using
`asyncio.run(coroutine)`, the threads reliably completed, though they did not actually execute asynchronously.

### Async Concept Example
The basic outline of the asynchronous capability is outlined in the fully functional code sample below. (See https://github.com/jameshalgren/t-route/pull/22 for additional comments on the example script.)

```
        '''
        Asynchronous execution Psuedocode
        Requires python 3.8+
        Sync1: Prepare first warmstate from files
        Sync1: Prepare first forcing from files

        For first forcing set
            Sync2a: run model
            Sync2b: begin preparing next forcing
            Sync3a - AFTER Sync2a, prepare next warmstate (last state of model run)
            Sync3b: write any output from Sync2a
            Loop has to wait for Sync2a+b+Sync3a, does not have to wait for Sync3b
                  if next forcing prepared
        '''
```

The following script (based first [on this gist](https://gist.github.com/groutr/7f09488220de622ccfa40c126e91e15c
)) provides a useful demonstration of how this can be accomplished with functions that would otherwise block truly concurrent threading: 

``` py
print("Requires python 3.8+")
print("usage, e.g.,:")
print("`python async_test.py 3 1 1 0 1`")
print("arg1 -- number of loops")
print("arg2 -- 1/0 use asyncio or not -- currently makes no difference, it seems")
print("arg3 -- 1/0 use CPU-heavy model imitator or not")
print(
    "arg4 -- 0/1 force (0 allows separate threads) all threads to the main kernel thread"
)
print("arg5 -- 0/1 run async in debug mode")

"""
Useful references:
https://gist.github.com/groutr/7f09488220de622ccfa40c126e91e15c
https://www.joeltok.com/blog/2021-2/python-async-sync
https://docs.python.org/3/library/asyncio-task.html#asyncio.to_thread
https://trio.readthedocs.io/en/stable/design.html
https://curio.readthedocs.io/en/latest/
"""

import asyncio
import time
import random
import hashlib
import sys
import concurrent.futures
import os
import logging

logging.basicConfig(
    level=logging.DEBUG,
    format="%(levelname)7s: %(message)s",
    stream=sys.stderr,
)
LOG = logging.getLogger("")

is_async = bool(int(sys.argv[2]))
use_cpu = bool(int(sys.argv[3]))
force_kernel_thread = bool(int(sys.argv[4]))

# create_thread_pool_here
if force_kernel_thread:
    pool_IO = None
    pool_Processing = None
else:
    pool_IO = concurrent.futures.ThreadPoolExecutor(max_workers=12)
    pool_Processing = concurrent.futures.ThreadPoolExecutor(max_workers=12)

LONGTIME = 6
MEDIUMTIME = 2
SHORTTIME = 0.5


def warm_state(t, loop):
    LOG.info(f"Execution loop {loop}: Starting to prepare warm state...")
    rv = random.getrandbits(64)
    time.sleep(t)
    LOG.info(f"Execution loop {loop}: Finished preparing warm state in {t} seconds.")
    # messages to show that input is received
    LOG.debug(f" warmstate {loop} produced this Warm state: {rv}")
    return rv


def read_forcing(t, loop):
    LOG.info(f"Execution loop {loop}: Beginning to read forcings...")
    rv = random.getrandbits(64)
    time.sleep(t)
    LOG.info(f"Execution loop {loop}: Finished reading forcings in {t} seconds.")
    # messages to show that input is received
    LOG.debug(f" forcing {loop} produced this Forcing info: {rv}")
    return rv


def run_model_sleep(t, loop, w, f):
    LOG.info(f"Execution loop {loop}: Running model...")
    # messages to show that input is received
    LOG.debug(f" model {loop} recieved this Warm state: {w}")
    LOG.debug(f" model {loop} received this Forcing info: {f}")
    time.sleep(t)
    LOG.info(f"Execution loop {loop}: Finished running model in {t} seconds.")
    return [f"this is a unique result from loop {loop}: warm {w} forcing {f}"]


def run_model_CPU(t, loop, w, f):
    LOG.info(f"Execution loop {loop}: Running model...")
    # messages to show that input is received
    LOG.debug(f" model {loop} recieved this Warm state: {w}")
    LOG.debug(f" model {loop} received this Forcing info: {f}")
    start_time = time.perf_counter()
    m = hashlib.sha512()
    while time.perf_counter() - start_time < t:
        m.update(os.urandom(4098))
    LOG.info(f"Execution loop {loop}: Finished running model in {t} seconds.")
    return [f"this is a unique result from loop {loop}: warm {w} forcing {f}"]


def write_output(t, loop, result):
    LOG.info(f"Execution loop {loop}: Writing output")
    LOG.debug(f"{loop}: Writing {result}")
    time.sleep(t)
    LOG.info(f"Execution loop {loop}: Finished writing output in {t} seconds.")


async def main(loops, warmtime, forcingtime, executetime, outputtime):

    if use_cpu:
        run_model = run_model_CPU
    else:
        run_model = run_model_sleep

    loop_i = 0

    w = warm_state(warmtime, loop_i)
    loop = asyncio.get_running_loop()
    forcings = loop.run_in_executor(pool_IO, read_forcing, forcingtime, loop_i)

    for loop_i in range(loops - 1):
        f = await forcings
        mtask = loop.run_in_executor(
            pool_Processing, run_model, executetime, loop_i, w, f
        )

        forcings = loop.run_in_executor(pool_IO, read_forcing, forcingtime, loop_i + 1)

        m = await mtask
        w = warm_state(warmtime, loop_i + 1)
        write = loop.run_in_executor(pool_IO, write_output, outputtime, loop_i, m)

    loop_i += 1
    f = await forcings
    mtask = loop.run_in_executor(pool_Processing, run_model, executetime, loop_i, w, f)
    m = await mtask
    write = await loop.run_in_executor(pool_IO, write_output, outputtime, loop_i, m)

    pool_IO.shutdown(wait=True)
    pool_Processing.shutdown(wait=True)


if __name__ == "__main__":
    loops = int(sys.argv[1])
    async_debug = True if int(sys.argv[5]) > 0 else False

    start_time = time.perf_counter()

    coroutine = main(loops, SHORTTIME, MEDIUMTIME, LONGTIME, LONGTIME)
    loop = asyncio.get_event_loop()

    if is_async:
        asyncio.run(coroutine, debug=async_debug)
    else:
        # This was a test to see if run_until_complete would force
        # serial execution on underlying calls... it doesn't, at
        # least in our example here.
        loop.run_until_complete(coroutine)

    LOG.info(f"Elapsed Time {time.perf_counter() - start_time}")
```