### PR TITLE
allow different intervals for data assimilation

### DIFF
--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -575,8 +575,8 @@ def _run_everything_v02(
             print("creating usgs time_slice data array ...")
 
             usgs_df, lastobs_df, da_parameter_dict = nnu.build_data_assimilation(
-                data_assimilation_parameters
-                data_assimilation_parameters,run_parameters
+                data_assimilation_parameters,
+                run_parameters
             )
 
         if verbose:

--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -576,6 +576,7 @@ def _run_everything_v02(
 
             usgs_df, lastobs_df, da_parameter_dict = nnu.build_data_assimilation(
                 data_assimilation_parameters
+                data_assimilation_parameters,run_parameters
             )
 
         if verbose:

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -666,10 +666,10 @@ def get_usgs_df_from_csv(usgs_csv, routelink_subset_file, index_col="link"):
 
 def get_usgs_from_time_slices_folder(
     routelink_subset_file,
-    run_parameters,
+    dt,
     usgs_files,
-    data_assimilation_parameters,
-    max_fill_1min = 14,
+    qc_trehsh,
+    max_fill_1min,
     t0 = None,
 ):
     """
@@ -682,9 +682,7 @@ def get_usgs_from_time_slices_folder(
           the interpolated values are truncated so that the first value returned
           corresponds to the first center date of the first provided file.
     """
-    max_fill_1min = data_assimilation_parameters.get("data_assimilation_interpolation_limit", 59)
-    qc_trehsh = data_assimilation_parameters.get("QC_threshold", 1)
-    frequency = str(int(run_parameters['dt']/60))+"min"
+    frequency = str(int(dt/60))+"min"
     with read_netcdfs(usgs_files, "time", preprocess_time_station_index,) as ds2:
 
         # dataframe containing discharge observations

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -666,7 +666,9 @@ def get_usgs_df_from_csv(usgs_csv, routelink_subset_file, index_col="link"):
 
 def get_usgs_from_time_slices_folder(
     routelink_subset_file,
+    run_parameters,
     usgs_files,
+    data_assimilation_parameters,
     max_fill_1min = 14,
     t0 = None,
 ):
@@ -680,6 +682,9 @@ def get_usgs_from_time_slices_folder(
           the interpolated values are truncated so that the first value returned
           corresponds to the first center date of the first provided file.
     """
+    max_fill_1min = data_assimilation_parameters.get("data_assimilation_interpolation_limit", 59)
+    qc_trehsh = data_assimilation_parameters.get("QC_threshold", 1)
+    frequency = str(int(run_parameters['dt']/60))+"min"
     with read_netcdfs(usgs_files, "time", preprocess_time_station_index,) as ds2:
 
         # dataframe containing discharge observations
@@ -736,7 +741,7 @@ def get_usgs_from_time_slices_folder(
     date_time_center_end = datetime.strptime(last_center_time, "%Y-%m-%d_%H:%M:%S")
 
     dates = []
-    for j in pd.date_range(date_time_center_start, date_time_center_end, freq="5min"):
+    for j in pd.date_range(date_time_center_start, date_time_center_end, freq=frequency):
         dates.append(j)
 
     """
@@ -800,7 +805,7 @@ def get_usgs_from_time_slices_folder(
     # TODO: Add reporting interval information to the gage preprocessing (timeslice generation)
     usgs_df_T = (usgs_df_T.resample('min').
                  interpolate(limit = max_fill_1min, limit_direction = 'both').
-                 resample('5min').
+                 resample(frequency).
                  asfreq().
                  loc[date_time_center_start:,:])
 

--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -711,12 +711,15 @@ def build_data_assimilation_folder(data_assimilation_parameters,run_parameters,t
     else:
         print("No Files Found for DA")
         # TODO: Handles this with a real exception
+    max_fill_1min = data_assimilation_parameters.get("data_assimilation_interpolation_limit", 59)
+    qc_trehsh = data_assimilation_parameters.get("qc_threshold", 1)
 
     usgs_df = nhd_io.get_usgs_from_time_slices_folder(
         data_assimilation_parameters["wrf_hydro_da_channel_ID_crosswalk_file"],
-        run_parameters,
+        run_parameters['dt'],
         usgs_files,
-        data_assimilation_parameters,
+        qc_trehsh,
+        max_fill_1min,
         t0,
     )
 

--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -618,14 +618,14 @@ def build_qlateral_array(
     return qlat_df
 
 
-def build_data_assimilation(data_assimilation_parameters):
+def build_data_assimilation(data_assimilation_parameters,run_parameters):
     lastobs_df, da_parameter_dict = build_data_assimilation_lastobs(data_assimilation_parameters)
-    usgs_df = build_data_assimilation_usgs_df(data_assimilation_parameters, lastobs_df.index)
+    usgs_df = build_data_assimilation_usgs_df(data_assimilation_parameters,run_parameters, lastobs_df.index)
     return usgs_df, lastobs_df, da_parameter_dict
-
 
 def build_data_assimilation_usgs_df(
     data_assimilation_parameters,
+    run_parameters,
     lastobs_index=None,
     t0=None,
 ):
@@ -643,7 +643,7 @@ def build_data_assimilation_usgs_df(
     if data_assimilation_csv:
         usgs_df = build_data_assimilation_csv(data_assimilation_parameters)
     elif data_assimilation_folder:
-        usgs_df = build_data_assimilation_folder(data_assimilation_parameters, t0)
+        usgs_df = build_data_assimilation_folder(data_assimilation_parameters,run_parameters,t0)
 
     if not lastobs_index.empty:
         if not usgs_df.empty and not usgs_df.index.equals(lastobs_index):
@@ -697,8 +697,7 @@ def build_data_assimilation_csv(data_assimilation_parameters):
 
     return usgs_df
 
-
-def build_data_assimilation_folder(data_assimilation_parameters, t0=None):
+def build_data_assimilation_folder(data_assimilation_parameters,run_parameters,t0=None):
 
     usgs_timeslices_folder = pathlib.Path(
         data_assimilation_parameters["data_assimilation_timeslices_folder"],
@@ -715,8 +714,9 @@ def build_data_assimilation_folder(data_assimilation_parameters, t0=None):
 
     usgs_df = nhd_io.get_usgs_from_time_slices_folder(
         data_assimilation_parameters["wrf_hydro_da_channel_ID_crosswalk_file"],
+        run_parameters,
         usgs_files,
-        data_assimilation_parameters.get("data_assimilation_interpolation_limit", 59),
+        data_assimilation_parameters,
         t0,
     )
 


### PR DESCRIPTION
This PR is built off of the fixes found in jameshalgren/long-term-looping-all.

This PR should address the feature requests in:
**https://github.com/NOAA-OWP/t-route/issues/433**

marked at:

- https://github.com/NOAA-OWP/t-route/blob/4ec74cc70d4f1ca407d20a6764b3f89facb43a96/src/python_framework_v02/troute/nhd_io.py#L757

- https://github.com/NOAA-OWP/t-route/blob/4ec74cc70d4f1ca407d20a6764b3f89facb43a96/src/python_framework_v02/troute/nhd_io.py#L652

- https://github.com/NOAA-OWP/t-route/blob/4ec74cc70d4f1ca407d20a6764b3f89facb43a96/src/python_framework_v02/troute/nhd_io.py#L776

The frequency needed to be calculated using the run_parameters['dt']. I made a few changes to pass run_parameters through the necessary functions to get it there. Additionally, a slight modification to data_assimilation_parameters to add both data_assimilation_interpolation_limit: 14 and QC_threshold: 1. These can now be specified and passed from the YAML to the functions found in .io.

The files I made changes to are the Florence_fcast_da_5min, main, nhd_io, and nhd_network_utilities. Added new yaml named Florence_fcast_da_5min_frequency_test.yaml to the shared folder on Cheyenne for simplicity.

Some of the new t0 stuff James added is showing as new I am not sure why that is occurring as it has both been rebased and merged along with some lines that are the same. I think some of it may be from when I originally branched off of James's branch. 