### PR TITLE
stability addition to CNT for smaller simulation time step

### DIFF
--- a/src/fortran_routing/diffusive_v02frwk/diffusive_cnt/diffusive_cnt.f90
+++ b/src/fortran_routing/diffusive_v02frwk/diffusive_cnt/diffusive_cnt.f90
@@ -83,7 +83,7 @@ contains
         double precision :: dmy1, dmy2
         integer :: ndata, idmy1, nts_db_g2, idxql
         double precision :: slope, y_norm, area_n, temp, tc_cnt, rmnd, saveinterval_min
-
+	open(unit=1, file="./forran diffusive discharge water depth.txt")
 	! simulation timestep
         dtini=dtini_g  !*[sec]
         dtini_given=dtini
@@ -98,7 +98,7 @@ contains
         ! Total number of timesteps in the simulation
 	totalTimeSteps = floor((tfin - t0)/dtini*3600)+1
         repeatInterval = int(saveInterval/dtini_given)
-	ntim= repeatInterval+10  !*! number of timesteps per repeatInterval; +1 because of boundary effects, at least 1 extra necessary
+	ntim= repeatInterval+2  !*! number of timesteps per repeatInterval; +1 because of boundary effects, at least 1 extra necessary
 	num_time=ntim
 	! number of reaches in the network
 	nlinks=nrch_g
@@ -184,7 +184,6 @@ contains
         allocate(rightBank(num_points, totalChannels), leftBank(num_points, totalChannels))
         allocate(skLeft(num_points, totalChannels), skMain(num_points, totalChannels), skRight(num_points, totalChannels))
         allocate(currentSquareDepth(nel))
-        allocate(ini_y(nlinks))
         allocate(notSwitchRouting(nlinks))
         allocate(currentROutingDiffusive(nlinks))
         allocate(tarr_ql(nts_ql_g), varr_ql(nts_ql_g))
@@ -207,8 +206,7 @@ contains
         ! TO DO:
 	! * pass initial depth as initial conditions and dont arbitrarily intialize
 	z=z_ar_g
-        ini_y=0.05  !* [meter]
-  
+    
         oldQ = -999; oldY = -999; newQ = -999; newY = -999
         dimensionless_Cr = -999; dimensionless_Fo = -999; dimensionless_Fi = -999
         dimensionless_Di = -999; dimensionless_Fc = -999; dimensionless_D = -999
@@ -462,7 +460,7 @@ contains
 				do i = 1, ncomp
 					q_ev_g(ts_ev, i, j) = newQ(i, timestep, j)
 					elv_ev_g(ts_ev, i, j) = newY(i, j) - z(i,j) ! depth (meters)
-				end do
+   				end do
 			end do
 		end do
 
@@ -481,7 +479,7 @@ contains
         deallocate(elevTable, areaTable, pereTable, rediTable, convTable, topwTable)
         deallocate( skkkTable, nwi1Table, dPdATable, ncompElevTable, ncompAreaTable)
         deallocate(xsec_tab, rightBank, leftBank, skLeft, skMain, skRight)
-        deallocate(currentSquareDepth, ini_y, notSwitchRouting, currentROutingDiffusive )
+        deallocate(currentSquareDepth, notSwitchRouting, currentROutingDiffusive )
         deallocate(tarr_ql, varr_ql, tarr_ub, varr_ub)
         deallocate(ini_q_repeat, ini_E, ini_F, added_Q, velocity)
 
@@ -871,6 +869,14 @@ contains
             if (diffusivity(i,j) .lt. minDiffuLm) diffusivity(i,j) = minDiffuLm !!! Applying diffusivity lower limit
 !            write(21,*) "Y/C/D", i,j, newY(i,j),  celerity(i,j), diffusivity(i,j)
         end do
+
+	do i=1,ncomp-1
+            if (celerity(i,j)/diffusivity(i,j)*dx(i,j) .le. 0.1) diffusivity(1:ncomp,j) = celerity(i,j)/0.1*dx(i,j)
+            if (celerity(i,j)*celerity(i,j)/diffusivity(i,j)*dtini .le. 0.3) &
+                diffusivity(1:ncomp,j) = celerity(i,j)*celerity(i,j)/0.3*dtini
+        end do
+	
+
 	end subroutine mesh_diffusive_backward
     !**-----------------------------------------------------------------------------------------
     !*      Create lookup tables at each node storing computed values of channel geometries

--- a/src/fortran_routing/diffusive_v02frwk/diffusive_cnt/diffusive_cnt.f90
+++ b/src/fortran_routing/diffusive_v02frwk/diffusive_cnt/diffusive_cnt.f90
@@ -83,7 +83,6 @@ contains
         double precision :: dmy1, dmy2
         integer :: ndata, idmy1, nts_db_g2, idxql
         double precision :: slope, y_norm, area_n, temp, tc_cnt, rmnd, saveinterval_min
-	open(unit=1, file="./forran diffusive discharge water depth.txt")
 	! simulation timestep
         dtini=dtini_g  !*[sec]
         dtini_given=dtini

--- a/test/input/yaml/Florence_Benchmark_diff.yaml
+++ b/test/input/yaml/Florence_Benchmark_diff.yaml
@@ -15,10 +15,10 @@ run_parameters:
     debuglevel: 1
     assume_short_ts: true
     subnetwork_target_size: 100
-    qts_subdivisions: 6
+    qts_subdivisions: 12
     return_courant: false
     # NOTE: diffusive_cnt does not work with dt < 600 secs
-    dt: 600
+    dt: 300
     nts: 4308 
     cpu_pool: 12
     #Use the parallel computation engine (omit flag for serial computation)


### PR DESCRIPTION
[Short description explaining the high-level reason for the pull request]
Four lines of code made to subroutine mesh_diffusive_backward in diffusive_cnt.f90 enable the use of dtini (simulation time step) smaller than 600sec. Now, with dtini=300sec, CNT runs without instability.    Note that it is recommend to use saveinterval_cnt in diffusive_utils.py in the form of multiplier*dt, where multiplier close to 12.  Further test on the multiplier is on the way.

## Additions

-

## Removals

-

## Changes

-

## Testing

1. python3 -m nwm_routing -V2 -f ../../test/input/yaml/Florence_Benchmark_diff.yaml

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
