### PR TITLE
substitute read_netcdfs for open_mfdataset

### DIFF
--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -252,17 +252,20 @@ def get_ql_from_wrf_hydro_mf(
     ```
     """
 
-    with xr.open_mfdataset(
-        qlat_files,
-        combine="by_coords",
-        # combine="nested",
-        # concat_dim="time",
-        # data_vars="minimal",
-        # coords="minimal",
-        # compat="override",
-        preprocess=drop_all_coords,
-        # parallel=True,
-    ) as ds:
+    #ds_tmp = read_netcdfs(qlat_files, "feature_id", drop_all_coords)
+    ds = read_netcdfs(qlat_files, "time", drop_all_coords)
+    if 1 == 1:
+    # with xr.open_mfdataset(
+    #     qlat_files,
+    #     combine="by_coords",
+    #     # combine="nested",
+    #     # concat_dim="time",
+    #     # data_vars="minimal",
+    #     # coords="minimal",
+    #     # compat="override",
+    #     preprocess=drop_all_coords,
+    #     # parallel=True,
+    # ) as ds:
         try:
             ql = pd.DataFrame(
                 ds[value_col].values.T,


### PR DESCRIPTION
With #443 , there was initially some concern that the asyncio calls would conflict with sub-thread calls with the data read and write functions (`xarray.open_mfdataset` and `xarray.write_mfdataset`). Ultimately, once the asynchronous thread pools were being shut down properly, there no longer appeared to be a conflict, and this commit because unnecessary for that purpose.

There remain two reasons to continue considering the switch -- 1) there is the possibility that the dask dependencies of the open_mfdataset and write_mfdataset calls are not allowed on WCOSS and if that is the case, then something like what is represented here might be needed, at least as an option; and 2) depending on the comparative performance of the methods, the more parismonious `read_netcdfs` or a corresponding (as-yet-unwritten) function for writing might be preferable over the xarray methods. 
