### PR TITLE
v03 diffusive 

### DIFF
--- a/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/mc_reach.pyx
@@ -1130,7 +1130,7 @@ cpdef object compute_network_structured(
     #Preprocess the raw reaches, creating MC_Reach/MC_Segments
 
     for reach, reach_type in reaches_wTypes:
-        upstream_reach = upstream_connections.get(reach[0], ())
+        upstream_reach = upstream_connections.get(reach[0], [])
         upstream_ids = binary_find(data_idx, upstream_reach)
         #Check if reach_type is 1 for reservoir
         if (reach_type == 1):


### PR DESCRIPTION
Florence_test2_loop_CNT.yaml is the new yaml that is configured to work with v03. However, with diffusive engaged, I am hitting errors within the mc_reach code. The first issue was receiving tuples instead of a list. This small change at least moves past it.       
 `upstream_reach = upstream_connections.get(reach[0], ())`
to
 `upstream_reach = upstream_connections.get(reach[0], [])`

I can confirm diffusive parameters are being passed over. 
However, I am having some trouble figuring out what is taking place in mc_reach related to diffusive. Below is the new error. 

  File "troute/routing/fast_reach/diffusive_cnt.pyx", line 109, in troute.routing.fast_reach.diffusive_cnt.compute_diffusive_tst
    cpdef object compute_diffusive_tst(
  File "troute/routing/fast_reach/diffusive_cnt.pyx", line 151, in troute.routing.fast_reach.diffusive_cnt.compute_diffusive_tst
    diff_inputs = diff_utils.diffusive_input_data_v02(
  File "/glade/u/home/jhreha/t-route/src/python_routing_v02/troute/routing/diffusive_utils.py", line 613, in diffusive_input_data_v02
    frnw_g = fp_network_map(
  File "/glade/u/home/jhreha/t-route/src/python_routing_v02/troute/routing/diffusive_utils.py", line 114, in fp_network_map
    frnw_g[frj, 2 + i] = j
IndexError: index 8 is out of bounds for axis 1 with size 8
