### PR TITLE
Automatically build loop sets for V3 and V4 execution pathway sims

### DIFF
--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -1081,7 +1081,31 @@ def main_v03(argv):
     # The inputs below assume a very pedantic setup
     # with each run set explicitly defined, so...
     # TODO: Make this more flexible.
-    run_sets = forcing_parameters.get("qlat_forcing_sets", False)
+    run_sets = nnu.build_forcing_sets(forcing_parameters)
+    
+    #-----------------------------------------------------------
+    '''
+    Inputs
+    - t0
+    - data_assimilation_parameters
+    - run_sets
+    Outputs
+    - da_sets
+    '''
+    
+    dt_timeslice = timedelta(minutes = 15)
+    
+    for i, set_dict in enumerate(run_sets):
+        
+        J = pd.date_range(t0, run_sets[i]['final_timestamp'], freq = dt_timeslice)
+        
+        
+        # list of file datetimes
+        
+    
+        import pdb; pdb.set_trace()
+    #-----------------------------------------------------------
+#     run_sets = forcing_parameters.get("qlat_forcing_sets", False)
 
     if "data_assimilation_parameters" in compute_parameters:
         if "data_assimilation_sets" in data_assimilation_parameters:

--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -1082,20 +1082,15 @@ def main_v03(argv):
     run_sets = nnu.build_forcing_sets(forcing_parameters, t0)
 
     # Create da_sets: sets of TimeSlice files for each loop
-    da_sets = nnu.build_da_sets(data_assimilation_parameters, run_sets, t0)
-    import pdb; pdb.set_trace()
-    
-#     if "data_assimilation_parameters" in compute_parameters:
-#         if "data_assimilation_sets" in data_assimilation_parameters:
-#             da_sets = data_assimilation_parameters.get("data_assimilation_sets", [])
-#         else:
-#             da_sets = [{} for _ in run_sets]
-
+    if "data_assimilation_parameters" in compute_parameters: 
+        da_sets = nnu.build_da_sets(data_assimilation_parameters, run_sets, t0)
+        
+    # Create parity_sets: sets of CHRTOUT files against which to compare t-route flows
     if "wrf_hydro_parity_check" in output_parameters:
-        parity_sets = parity_parameters.get("parity_check_compare_file_sets", [])
+        parity_sets = nnu.build_parity_sets(parity_parameters, run_sets)
     else:
         parity_sets = []
-
+    
     parallel_compute_method = compute_parameters.get("parallel_compute_method", None)
     subnetwork_target_size = compute_parameters.get("subnetwork_target_size", 1)
     cpu_pool = compute_parameters.get("cpu_pool", None)

--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -1081,7 +1081,7 @@ def main_v03(argv):
     # The inputs below assume a very pedantic setup
     # with each run set explicitly defined, so...
     # TODO: Make this more flexible.
-    run_sets = nnu.build_forcing_sets(forcing_parameters)
+    run_sets = nnu.build_forcing_sets(forcing_parameters, t0)
     
     #-----------------------------------------------------------
     '''

--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -1078,40 +1078,18 @@ def main_v03(argv):
         debuglevel=debuglevel,
     )
 
-    # The inputs below assume a very pedantic setup
-    # with each run set explicitly defined, so...
-    # TODO: Make this more flexible.
+    # Create run_sets: sets of forcing files for each loop
     run_sets = nnu.build_forcing_sets(forcing_parameters, t0)
-    
-    #-----------------------------------------------------------
-    '''
-    Inputs
-    - t0
-    - data_assimilation_parameters
-    - run_sets
-    Outputs
-    - da_sets
-    '''
-    
-    dt_timeslice = timedelta(minutes = 15)
-    
-    for i, set_dict in enumerate(run_sets):
-        
-        J = pd.date_range(t0, run_sets[i]['final_timestamp'], freq = dt_timeslice)
-        
-        
-        # list of file datetimes
-        
-    
-        import pdb; pdb.set_trace()
-    #-----------------------------------------------------------
-#     run_sets = forcing_parameters.get("qlat_forcing_sets", False)
 
-    if "data_assimilation_parameters" in compute_parameters:
-        if "data_assimilation_sets" in data_assimilation_parameters:
-            da_sets = data_assimilation_parameters.get("data_assimilation_sets", [])
-        else:
-            da_sets = [{} for _ in run_sets]
+    # Create da_sets: sets of TimeSlice files for each loop
+    da_sets = nnu.build_da_sets(data_assimilation_parameters, run_sets, t0)
+    import pdb; pdb.set_trace()
+    
+#     if "data_assimilation_parameters" in compute_parameters:
+#         if "data_assimilation_sets" in data_assimilation_parameters:
+#             da_sets = data_assimilation_parameters.get("data_assimilation_sets", [])
+#         else:
+#             da_sets = [{} for _ in run_sets]
 
     if "wrf_hydro_parity_check" in output_parameters:
         parity_sets = parity_parameters.get("parity_check_compare_file_sets", [])

--- a/src/nwm_routing/src/nwm_routing/preprocess.py
+++ b/src/nwm_routing/src/nwm_routing/preprocess.py
@@ -272,9 +272,9 @@ def nwm_forcing_preprocess(
     nts = forcing_parameters.get("nts", None)
     dt = forcing_parameters.get("dt", None)
     qts_subdivisions = forcing_parameters.get("qts_subdivisions", None)
-    qlat_input_folder = forcing_parameters.get("qlat_input_folder", None)
-    qlat_file_index_col = forcing_parameters.get("qlat_file_index_col", None)
-    qlat_file_value_col = forcing_parameters.get("qlat_file_value_col", None)
+    qlat_input_folder = forcing_parameters.get("qlat_input_folder", ".")
+    qlat_file_index_col = forcing_parameters.get("qlat_file_index_col", "feature_id")
+    qlat_file_value_col = forcing_parameters.get("qlat_file_value_col", "q_lateral")
 
     # TODO: find a better way to deal with these defaults and overrides.
     run["t0"] = run.get("t0", t0)

--- a/src/nwm_routing/src/nwm_routing/preprocess.py
+++ b/src/nwm_routing/src/nwm_routing/preprocess.py
@@ -272,9 +272,9 @@ def nwm_forcing_preprocess(
     nts = forcing_parameters.get("nts", None)
     dt = forcing_parameters.get("dt", None)
     qts_subdivisions = forcing_parameters.get("qts_subdivisions", None)
-    qlat_input_folder = forcing_parameters.get("qlat_input_folder", ".")
-    qlat_file_index_col = forcing_parameters.get("qlat_file_index_col", "feature_id")
-    qlat_file_value_col = forcing_parameters.get("qlat_file_value_col", "q_lateral")
+    qlat_input_folder = forcing_parameters.get("qlat_input_folder", None)
+    qlat_file_index_col = forcing_parameters.get("qlat_file_index_col", None)
+    qlat_file_value_col = forcing_parameters.get("qlat_file_value_col", None)
 
     # TODO: find a better way to deal with these defaults and overrides.
     run["t0"] = run.get("t0", t0)

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -1,5 +1,4 @@
 import zipfile
-
 import xarray as xr
 import pandas as pd
 import geopandas as gpd

--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -736,6 +736,22 @@ def build_qlateral_array(
     return qlat_df
 
 
+def build_parity_sets(parity_parameters, run_sets):
+    
+    parity_sets = parity_parameters.get("parity_check_compare_file_sets", None)
+    
+    if parity_sets:
+        pass
+    
+    else:
+    
+        parity_sets = []
+        for (i, set_dict) in enumerate(run_sets):
+            parity_sets.append({})
+            parity_sets[i]['validation_files'] = run_sets[i]['qlat_files']
+    
+    return parity_sets
+
 def build_da_sets(data_assimilation_parameters, run_sets, t0):
     
     data_assimilation_timeslices_folder = data_assimilation_parameters.get(

--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -787,15 +787,24 @@ def build_da_sets(data_assimilation_parameters, run_sets, t0):
                                        + dt_timeslice * timeslice_pad,
                                        freq=dt_timeslice)
 
-            da_sets[i]['usgs_timeslice_files'] = \
-                (timestamps.strftime('%Y-%m-%d_%H:%M:%S')
-                 + '.15min.usgsTimeSlice.ncdf').to_list()
+            filenames = (timestamps.strftime('%Y-%m-%d_%H:%M:%S') 
+                        + '.15min.usgsTimeSlice.ncdf').to_list()
+            
+            # check that all TimeSlice files in the set actually exist
+            for f in filenames:
+                try:
+                    J = pathlib.Path(data_assimilation_timeslices_folder.joinpath(f))     
+                    assert J.is_file() == True
+                except AssertionError:
+                    print("Aborting simulation because TimeSlice file", J, "cannot be not found.")
+                    raise
+            
+            da_sets[i]['usgs_timeslice_files'] = filenames
 
             t0 = run_sets[i]['final_timestamp']
 
     return da_sets
     
-
 def build_data_assimilation(data_assimilation_parameters, run_parameters):
     lastobs_df, da_parameter_dict = build_data_assimilation_lastobs(data_assimilation_parameters)
     usgs_df = build_data_assimilation_usgs_df(data_assimilation_parameters, run_parameters, lastobs_df.index)

--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -554,24 +554,25 @@ def build_channel_initial_state(
 
 
 def build_forcing_sets(
-    forcing_parameters
+    forcing_parameters,
+    t0
 ):
     
     qlat_input_folder = forcing_parameters.get("qlat_input_folder", None)
-    start_chrtout = forcing_parameters.get("start_chrtout", None)
     nts = forcing_parameters.get("nts", None)
     max_loop_size = forcing_parameters.get("max_loop_size", None)
     dt = forcing_parameters.get("dt", None)
     
     # TODO throw error messages if required parameters are not specified in yaml
-    
-    # time of first chrtout
+        
+    # name of first CHRTOUT
     qlat_input_folder = pathlib.Path(qlat_input_folder)
     start_chrtout = qlat_input_folder.joinpath(start_chrtout)
     t_start_str = nhd_io.get_param_str(start_chrtout, "model_output_valid_time")
     t_start = datetime.strptime(t_start_str, "%Y-%m-%d_%H:%M:%S")
     
     # time interval of forcing data - directly from CHRTOUT
+    
     dt_qlat = nhd_io.get_param_str(start_chrtout, "dev_NOAH_TIMESTEP").item()  
     dt_qlat_timedelta = timedelta(seconds = dt_qlat)
     

--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -563,15 +563,21 @@ def build_forcing_sets(
     nts = forcing_parameters.get("nts", None)
     max_loop_size = forcing_parameters.get("max_loop_size", 12)
     dt = forcing_parameters.get("dt", None)
-    forcing_glob_filter = forcing_parameters.get("qlat_file_pattern_filter", None)
+
+    try:
+        qlat_input_folder = pathlib.Path(qlat_input_folder)
+        assert qlat_input_folder.is_dir() == True
+    except TypeError:
+        print("Aborting simulation because no qlat_input_folder is specified in the forcing_parameters section of the .yaml control file.")
+        raise
+    except AssertionError:
+        print("Aborting simulation because the qlat_input_folder:", qlat_input_folder,"does not exist. Please check the the qlat_input_folder variable is correctly entered in the .yaml control file")
+        raise
     
+    forcing_glob_filter = forcing_parameters.get("qlat_file_pattern_filter", "*.CHRTOUT_DOMAIN1")
+        
     # TODO: Throw errors if insufficient input data are available
-    '''
-    - if qlat_input_folder is not specified
-    - if nts or dt are not specified
-    - if forcing_glob_filter is not specifid
-    - if no max_loop size specified
-    '''
+
     if run_sets:
         
         # append final_timestamp variable to each set_list

--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -626,8 +626,17 @@ def build_forcing_sets(
         # list of forcing files
         forcing_filename_list = [d_str + ".CHRTOUT_DOMAIN1" for d_str in
                                  datetime_list_str]
-
-        # buidl run sets list
+        
+        # check that all forcing files exist
+        for f in forcing_filename_list:
+            try:
+                J = pathlib.Path(qlat_input_folder.joinpath(f))     
+                assert J.is_file() == True
+            except AssertionError:
+                print("Aborting simulation because forcing file", J, "cannot be not found.")
+                raise
+                
+        # build run sets list
         run_sets = []
         k = 0
         j = 0

--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -679,7 +679,7 @@ def build_qlateral_array(
 
     qts_subdivisions = forcing_parameters.get("qts_subdivisions", 1)
     nts = forcing_parameters.get("nts", 1)
-    qlat_input_folder = forcing_parameters.get("qlat_input_folder", ".")
+    qlat_input_folder = forcing_parameters.get("qlat_input_folder", None)
     qlat_input_file = forcing_parameters.get("qlat_input_file", None)
     if qlat_input_folder:
         qlat_input_folder = pathlib.Path(qlat_input_folder)

--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -679,7 +679,7 @@ def build_qlateral_array(
 
     qts_subdivisions = forcing_parameters.get("qts_subdivisions", 1)
     nts = forcing_parameters.get("nts", 1)
-    qlat_input_folder = forcing_parameters.get("qlat_input_folder", None)
+    qlat_input_folder = forcing_parameters.get("qlat_input_folder", ".")
     qlat_input_file = forcing_parameters.get("qlat_input_file", None)
     if qlat_input_folder:
         qlat_input_folder = pathlib.Path(qlat_input_folder)

--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -766,11 +766,14 @@ def build_da_sets(data_assimilation_parameters, run_sets, t0):
     if da_sets:
         pass
         
-    else:
+    elif not data_assimilation_timeslices_folder:
+        da_sets = [{} for _ in run_sets]
         
+    else:
+        data_assimilation_timeslices_folder = pathlib.Path(data_assimilation_timeslices_folder)
         # the number of timeslice files appended to the front- and back-ends
         # of the TimeSlice file interpolation stack
-        timeslice_pad = data_assimilation_parameters.get("timeslice_pad",10)
+        timeslice_pad = data_assimilation_parameters.get("timeslice_pad",0)
 
         # timedelta of TimeSlice data - typically 15 minutes
         dt_timeslice = timedelta(minutes = 15)


### PR DESCRIPTION
This PR adds a capability to automatically create `run_sets`, `da_sets`, and `parity_sets` for V3/4 execution pathway simulations. The additional capabilities retain the ability for a user to explicitly construct sets in the .yaml file, if they wish to do so. 

One constraint of the new capability is that sets are constructed relative to the simulation `t0`. That is, if `t0 = 2021-01-01_00:00:00`, then the first TimeSlice file in `da_sets` will be timestamped at `2021-01-01_00:00:00` and the first CHRTOUT file in `run_sets` will be timestamped at `2021-01-01_01:00:00` (assuming that the time interval of qlateral data is 1-hour) .

## example of implicit `yaml` configuration
Below is an example  of how a configuration file needs to be structured to have loop sets automatically created. 
```
    forcing_parameters:
        qts_subdivisions: 12
        dt: 300
        qlat_input_folder: "/glade/work/adamw/forcing/florence_event/"
        # for automatically constructed loops, a file pattern filter is needed. Defaults to "*.CHRTOUT_DOMAIN1"
        qlat_file_pattern_filter: "*.CHRTOUT_DOMAIN1"
        qlat_file_index_col: feature_id
        qlat_file_value_col: q_lateral
        #****************** NEW *******************************
        # for automatically constructed loops, nts is the number of timesteps for the entire simulation
        nts: 48
        # max_loop_size is the maximum number of forcing files per loop
        max_loop_size: 2  
        #********************************************************    
        # !!!! NOTE !!!!
        # forcing sets are not explicitly defined! If forcing sets are specified, then the default is to utilize  them

    data_assimilation_parameters:
        data_assimilation_timeslices_folder: "/some/TimeSlice_folder"
        wrf_hydro_da_channel_ID_crosswalk_file: "/some/DOMAIN_folder/Route_Link.nc"
        #****************** NEW *******************************
        # the number of TimeSlice files appended to the front and back end of each set. Larger pads aid interpolation accuracy
        # default is zero
        #********************************************************    
        timeslice_pad: 0
        wrf_hydro_lastobs_file: "/some/LastObs_folder/nudgingLastObs.2018-09-08_00:00:00.nc"
        wrf_hydro_lastobs_lead_time_relative_to_simulation_start_time: 0
        wrf_lastobs_type: "obs-based"
        lastobs_output_folder: "/some/other_LastObs_folder/"
        # !!!! NOTE !!!!
        # DA sets are not explicitly defined. If DA sets are specified, the default is to use them

output_parameters:
    csv_output: 
        csv_output_folder:
    chrtout_output:
        wrf_hydro_channel_output_source_folder: "/some/forcing_folder/"
        wrf_hydro_channel_final_output_folder: "/some/other_forcing_folder/"
    wrf_hydro_parity_check:
        parity_check_input_folder: "/some/forcing_folder/"
        parity_check_file_index_col: feature_id
        parity_check_file_value_col: streamflow
        parity_check_compare_node: 3351081
         # !!!! NOTE !!!!
        # parity sets are not explicitly defined. If parity sets are specified, the default is to use them
```

# TEST cases
- Existing, explicit loop configuration: `projects/t-route/test/jobs/loop_chunk_dev/Tar_River_test_MC_V3_explicit.yaml`
- New, implicit loop configuration: `projects/t-route/test/jobs/loop_chunk_dev/Tar_River_test_MC_V3_implicit.yaml`
