### PR TITLE
bug fixes: CHRTOUT writing, run_set creation

### DIFF
--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -302,47 +302,54 @@ def write_q_to_wrf_hydro(
         output_folder (pathlib.Path): folder where updated chrtout files will be written
         qts_subdivisions (int): number of t-route timesteps per WRF-hydro timesteps
     """
+    
+    # count the number of simulated timesteps
+    nsteps = len(flowveldepth.loc[:,::3].columns)
+    
+    # determine how many files to write results out to
+    nfiles_to_write = int(np.floor(nsteps / qts_subdivisions))
+    
+    if nfiles_to_write > 1:
+    
+        # open all CHRTOUT files as a single xarray dataset
+        with xr.open_mfdataset(chrtout_files[:nfiles_to_write], combine="by_coords") as chrtout:
 
-    # open all CHRTOUT files as a single xarray dataset
-    with xr.open_mfdataset(chrtout_files, combine="by_coords") as chrtout:
+            # !!NOTE: If break_at_waterbodies == True, segment feature_ids coincident with water bodies do
+            # not show up in the flowveldepth dataframe. Re-indexing inserts these missing feature_ids and
+            # populates columns with NaN values.
+            flowveldepth_reindex = flowveldepth.reindex(chrtout.feature_id.values)
 
-        # !!NOTE: If break_at_waterbodies == True, segment feature_ids coincident with water bodies do
-        # not show up in the flowveldepth dataframe. Re-indexing inserts these missing feature_ids and
-        # populates columns with NaN values.
-        flowveldepth_reindex = flowveldepth.reindex(chrtout.feature_id.values)
-        
-        # unpack, subset, and transpose t-route flow data
-        qtrt = flowveldepth_reindex.loc[:, ::3].to_numpy().astype("float32")
-        qtrt = qtrt[:, qts_subdivisions-1::qts_subdivisions]
-        qtrt = np.transpose(qtrt)
-        
-        # construct DataArray for t-route flows, dims, coords, and attrs consistent with CHRTOUT
-        qtrt_DataArray = xr.DataArray(
-            data=da.from_array(qtrt),
-            dims=["time", "feature_id"],
-            coords=dict(time=chrtout.time.values, feature_id=chrtout.feature_id.values),
-            attrs=dict(description="River Flow, t-route", units="m3 s-1",),
-        )
+            # unpack, subset, and transpose t-route flow data
+            qtrt = flowveldepth_reindex.loc[:, ::3].to_numpy().astype("float32")
+            qtrt = qtrt[:, qts_subdivisions-1::qts_subdivisions]
+            qtrt = np.transpose(qtrt)
 
-        # add t-route DataArray to CHRTOUT dataset
-        chrtout["streamflow_troute"] = qtrt_DataArray
+            # construct DataArray for t-route flows, dims, coords, and attrs consistent with CHRTOUT
+            qtrt_DataArray = xr.DataArray(
+                data=da.from_array(qtrt),
+                dims=["time", "feature_id"],
+                coords=dict(time=chrtout.time.values, feature_id=chrtout.feature_id.values),
+                attrs=dict(description="River Flow, t-route", units="m3 s-1",),
+            )
 
-        # group by time
-        grp_object = chrtout.groupby("time")
+            # add t-route DataArray to CHRTOUT dataset
+            chrtout["streamflow_troute"] = qtrt_DataArray
 
-    # build a list of datasets, one for each timestep
-    dataset_list = []
-    for grp, vals in iter(grp_object):
-        dataset_list.append(vals)
+            # group by time
+            grp_object = chrtout.groupby("time")
 
-    # save a new set of chrtout files to disk that contail t-route simulated flow
-    chrtout_files_new = [
-        output_folder / (s.name + "." + new_extension) for s in chrtout_files
-    ]
+        # build a list of datasets, one for each timestep
+        dataset_list = []
+        for grp, vals in iter(grp_object):
+            dataset_list.append(vals)
 
-    # mfdataset solution - can theoretically be parallelised via dask.distributed
-    xr.save_mfdataset(dataset_list, paths=chrtout_files_new)
+        # save a new set of chrtout files to disk that contail t-route simulated flow
+        chrtout_files_new = [
+            output_folder / (s.name + "." + new_extension) for s in chrtout_files
+        ]
 
+        # mfdataset solution - can theoretically be parallelised via dask.distributed
+        xr.save_mfdataset(dataset_list, paths=chrtout_files_new)
 
 #     # pure serial solution - saving for timing tests against mfdataset
 #     for i, dat in enumerate(dataset_list):

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -310,12 +310,12 @@ def write_q_to_wrf_hydro(
         # not show up in the flowveldepth dataframe. Re-indexing inserts these missing feature_ids and
         # populates columns with NaN values.
         flowveldepth_reindex = flowveldepth.reindex(chrtout.feature_id.values)
-
+        
         # unpack, subset, and transpose t-route flow data
         qtrt = flowveldepth_reindex.loc[:, ::3].to_numpy().astype("float32")
-        qtrt = qtrt[:, ::qts_subdivisions]
+        qtrt = qtrt[:, qts_subdivisions-1::qts_subdivisions]
         qtrt = np.transpose(qtrt)
-
+        
         # construct DataArray for t-route flows, dims, coords, and attrs consistent with CHRTOUT
         qtrt_DataArray = xr.DataArray(
             data=da.from_array(qtrt),

--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -638,6 +638,7 @@ def build_forcing_sets(
         k = 0
         j = 0
         nts_accum = 0
+        nts_last = 0
         while k < len(forcing_filename_list):
             run_sets.append({})
 
@@ -652,7 +653,7 @@ def build_forcing_sets(
                 run_sets[j]['nts'] = int(len(run_sets[j]['qlat_files'])
                                          * qts_subdivisions)
             else:
-                run_sets[j]['nts'] = int(nts - nts_accum)
+                run_sets[j]['nts'] = int(nts - nts_last)
 
             final_chrtout = qlat_input_folder.joinpath(run_sets[j]['qlat_files'
                     ][-1])
@@ -661,6 +662,7 @@ def build_forcing_sets(
             run_sets[j]['final_timestamp'] = \
                 datetime.strptime(final_timestamp_str, '%Y-%m-%d_%H:%M:%S')
 
+            nts_last = nts_accum
             k += max_loop_size
             j += 1
     


### PR DESCRIPTION
Two bug fixes are addressed with this PR

1. Correctly time-indexed data are now written to CHRTOUT. Prior to the changes to `nhd_io.write_q_to_wrf_hydro`, the data being written to CHRTOUT files was time-lagged by 1-hour. This is the likely explanation for why NCAR has been observing very different flow results from WRF and t-route. 
2. Fixed how the `nts` variable in each loop set is calculated. 
