### PR TITLE
Resilience to missing TimeSlice files with implicit da_sets creation

### DIFF
--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -790,12 +790,17 @@ def build_da_sets(data_assimilation_parameters, run_sets, t0):
                         + '.15min.usgsTimeSlice.ncdf').to_list()
             
             # check that all TimeSlice files in the set actually exist
+            drop_list = []
             for f in filenames:
                 try:
                     J = pathlib.Path(data_assimilation_timeslices_folder.joinpath(f))     
                     assert J.is_file() == True
                 except AssertionError:
-                    raise AssertionError("Aborting simulation because TimeSlice file", J, "cannot be not found.") from None
+                    print("Missing TimeSlice file %s", J)
+                    drop_list.append(f)
+                    
+            if drop_list:
+                filenames = [x for x in filenames if x not in drop_list]
             
             da_sets[i]['usgs_timeslice_files'] = filenames
 


### PR DESCRIPTION
Previously, if the full panel of expected TimeSlice files were missing, the simulation would end with an error notifying the user which files were not found. However, that solution is problematic because in operations TimeSlice files are not guaranteed to exist and an error that leads the simulation to abort is unacceptable. Here, we provide a more resilient solution by simply noting which of the expected TimeSlice files cannot be found and creating a `usgs_df` anyhow. Any missing information will either be interpolated through or handled by the DA implementation. 