### PR TITLE
Adaptive chrt fix

### DIFF
--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -627,16 +627,22 @@ def build_forcing_sets(
         # list of forcing files
         forcing_filename_list = []
         for element in datetime_list:
-            forcing_filename_list.append(all_files[file_dates.index(element)])
-
+            try:
+                J = all_files[file_dates.index(element)]
+                assert J.is_file() == True
+                forcing_filename_list.append(all_files[file_dates.index(element)])
+            except AssertionError:
+                raise AssertionError("Aborting simulation because forcing file with date", element, "cannot be found.") from None
+            except ValueError:
+                raise ValueError("Aborting simulation because forcing file with date", element, "cannot be found") from None
         # forcing_filename_list = [d_str + ".CHRTOUT_DOMAIN1" for d_str in datetime_list_str]
         
         # check that all forcing files exist
-        for f in forcing_filename_list:
-            try:   
-                assert f.is_file() == True
-            except AssertionError:
-                raise AssertionError("Aborting simulation because forcing file", J, "cannot be not found.") from None
+        # for f in forcing_filename_list:
+        #     try:   
+        #         assert f.is_file() == True
+        #     except AssertionError:
+        #         raise AssertionError("Aborting simulation because forcing file", J, "cannot be not found.") from None
                 
         # build run sets list
         run_sets = []


### PR DESCRIPTION
I believe this should handle different naming conventions of chrt files and always look to see if they are available. There is some extra logger information here, but if we merge that first it should go away. In NNU.py i just added some code that finds the dates and times that need to exist and compares them and pulls the naming conventions from the original list of all file names by indexing. 

This is the main fix. 

        file_dates = [datetime.strptime(nhd_io.get_param_str(current_file, "model_output_valid_time"),'%Y-%m-%d_%H:%M:%S') for current_file in all_files]
        # list of forcing files
        forcing_filename_list = []
        for element in datetime_list:
            forcing_filename_list.append(all_files[file_dates.index(element)])
