### PR TITLE
Framework updates to facilitate testing with WCOSS operations output

### DIFF
--- a/doc/v3_doc.yaml
+++ b/doc/v3_doc.yaml
@@ -340,12 +340,22 @@ compute_parameters:
         # field name of segment ID in qlateral data
         # (!!) mandatory
         # TODO: change default `feature_id`
-        qlat_file_index_col: qlat_forcing_sets
+        qlat_file_index_col:
         # ---------------
-        # field name of lateral inflow in qlateral data
-        # (!!) mandatory
-        # TODO: change default `q_lateral`
+        # lateral inflow variable name in forcing file
+        # typical forcing files are WRF Hydro channel route out files (CHRTOUT)
+        # optional, defaults to `q_lateral`
         qlat_file_value_col:
+        # ---------------
+        # Groundwater bucket flux (to channel) variable name in forcing file
+        # typical forcing files are WRF Hydro channel route out files (CHRTOUT)
+        # optional, defaults to 'qBucket'
+        qlat_file_gw_bucket_flux_col:
+        # ---------------
+        # Surface terrain runoff (to channel) variable name in forcing file
+        # typical forcing files are WRF Hydro channel route out files (CHRTOUT)
+        # optional, defaults to `qSfcLatRunoff`
+        qlat_file_terrain_runoff_col:
         # ---------------
         # forcing files and number of timesteps associated with each simulation loop
         # optional, only include if explicitly listing the forcing files in each set.

--- a/doc/v3_doc.yaml
+++ b/doc/v3_doc.yaml
@@ -234,7 +234,7 @@ compute_parameters:
     # ---------------
     # number of CPUs used for parallel computations
     # (!!) optional, defaults to None
-    cpu-pool:
+    cpu_pool:
     # ---------------
     # logical, if True Courant metrics are returnd with simulations
     # this only works for MC simulations

--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -1315,19 +1315,16 @@ async def main_v03_async(argv):
         debuglevel=debuglevel,
     )
 
-    # The inputs below assume a very pedantic setup
-    # with each run set explicitly defined, so...
-    # TODO: Make this more flexible.
-    run_sets = forcing_parameters.get("qlat_forcing_sets", False)
+    # Create run_sets: sets of forcing files for each loop
+    run_sets = nnu.build_forcing_sets(forcing_parameters, t0)
 
-    if "data_assimilation_parameters" in compute_parameters:
-        if "data_assimilation_sets" in data_assimilation_parameters:
-            da_sets = data_assimilation_parameters.get("data_assimilation_sets", [])
-        else:
-            da_sets = [{} for _ in run_sets]
-
+    # Create da_sets: sets of TimeSlice files for each loop
+    if "data_assimilation_parameters" in compute_parameters: 
+        da_sets = nnu.build_da_sets(data_assimilation_parameters, run_sets, t0)
+        
+    # Create parity_sets: sets of CHRTOUT files against which to compare t-route flows
     if "wrf_hydro_parity_check" in output_parameters:
-        parity_sets = parity_parameters.get("parity_check_compare_file_sets", [])
+        parity_sets = nnu.build_parity_sets(parity_parameters, run_sets)
     else:
         parity_sets = []
 

--- a/src/nwm_routing/src/nwm_routing/preprocess.py
+++ b/src/nwm_routing/src/nwm_routing/preprocess.py
@@ -274,8 +274,10 @@ def nwm_forcing_preprocess(
     dt = forcing_parameters.get("dt", None)
     qts_subdivisions = forcing_parameters.get("qts_subdivisions", None)
     qlat_input_folder = forcing_parameters.get("qlat_input_folder", None)
-    qlat_file_index_col = forcing_parameters.get("qlat_file_index_col", None)
-    qlat_file_value_col = forcing_parameters.get("qlat_file_value_col", None)
+    qlat_file_index_col = forcing_parameters.get("qlat_file_index_col", "feature_id")
+    qlat_file_value_col = forcing_parameters.get("qlat_file_value_col", "q_lateral")
+    qlat_file_gw_bucket_flux_col = forcing_parameters.get("qlat_file_gw_bucket_flux_col", "qBucket")
+    qlat_file_terrain_runoff_col = forcing_parameters.get("qlat_file_terrain_runoff_col", "qSfcLatRunoff")
 
     # TODO: find a better way to deal with these defaults and overrides.
     run["t0"] = run.get("t0", t0)
@@ -285,6 +287,8 @@ def nwm_forcing_preprocess(
     run["qlat_input_folder"] = run.get("qlat_input_folder", qlat_input_folder)
     run["qlat_file_index_col"] = run.get("qlat_file_index_col", qlat_file_index_col)
     run["qlat_file_value_col"] = run.get("qlat_file_value_col", qlat_file_value_col)
+    run["qlat_file_gw_bucket_flux_col"] = run.get("qlat_file_gw_bucket_flux_col", qlat_file_gw_bucket_flux_col)
+    run["qlat_file_terrain_runoff_col"] = run.get("qlat_file_terrain_runoff_col", qlat_file_terrain_runoff_col)
 
     if data_assimilation_parameters:
         data_assimilation_folder = data_assimilation_parameters.get("data_assimilation_timeslices_folder", None)

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -324,7 +324,11 @@ def write_q_to_wrf_hydro(
     if nfiles_to_write > 1:
     
         # open all CHRTOUT files as a single xarray dataset
-        with xr.open_mfdataset(chrtout_files[:nfiles_to_write], combine="by_coords") as chrtout:
+        with xr.open_mfdataset(
+            chrtout_files[:nfiles_to_write], 
+            combine="nested",
+            concat_dim="time"
+        ) as chrtout:
 
             # !!NOTE: If break_at_waterbodies == True, segment feature_ids coincident with water bodies do
             # not show up in the flowveldepth dataframe. Re-indexing inserts these missing feature_ids and

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -255,9 +255,9 @@ def get_ql_from_wrf_hydro_mf(
 
     with xr.open_mfdataset(
         qlat_files,
-        combine="by_coords",
-        # combine="nested",
-        # concat_dim="time",
+#         combine="by_coords",
+        combine="nested",
+        concat_dim="time",
         # data_vars="minimal",
         # coords="minimal",
         # compat="override",

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -268,12 +268,12 @@ def get_ql_from_wrf_hydro_mf(
         preprocess=drop_all_coords,
         # parallel=True,
     ) as ds:
-        
+
         # if forcing file contains a variable with the specified value_col name, 
         # then use it, otherwise compute q_lateral as the sum of qBucket and qSfcLatRunoff
-        try:
+        if ds.variables.get(value_col, None):
             qlateral_data = ds[value_col].values.T
-        except:
+        else:
             qlateral_data = ds[gw_col].values.T + ds[runoff_col].values.T
             
         try:

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -327,7 +327,7 @@ def write_q_to_wrf_hydro(
         with xr.open_mfdataset(
             chrtout_files[:nfiles_to_write], 
             combine="nested",
-            concat_dim="time"
+            concat_dim="time",
         ) as chrtout:
 
             # !!NOTE: If break_at_waterbodies == True, segment feature_ids coincident with water bodies do

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -266,14 +266,14 @@ def get_ql_from_wrf_hydro_mf(
     ) as ds:
         try:
             ql = pd.DataFrame(
-                ds[value_col].values.T,
+                ds['qBucket'].values.T + ds['qSfcLatRunoff'].values.T,
                 index=ds[index_col].values[0],
                 columns=ds.time.values,
                 # dtype=float,
             )
         except:
             ql = pd.DataFrame(
-                ds[value_col].values.T,
+                ds['qBucket'].values.T + ds['qSfcLatRunoff'].values.T,
                 index=ds[index_col].values,
                 columns=ds.time.values,
                 # dtype=float,

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -271,9 +271,9 @@ def get_ql_from_wrf_hydro_mf(
 
         # if forcing file contains a variable with the specified value_col name, 
         # then use it, otherwise compute q_lateral as the sum of qBucket and qSfcLatRunoff
-        if ds.variables.get(value_col, None):
+        try:
             qlateral_data = ds[value_col].values.T
-        else:
+        except:
             qlateral_data = ds[gw_col].values.T + ds[runoff_col].values.T
             
         try:

--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -695,6 +695,8 @@ def build_qlateral_array(
             "qlat_file_index_col", "feature_id"
         )
         qlat_file_value_col = forcing_parameters.get("qlat_file_value_col", "q_lateral")
+        gw_bucket_col = forcing_parameters.get("qlat_file_gw_bucket_flux_col","qBucket")
+        terrain_ro_col = forcing_parameters.get("qlat_file_terrain_runoff_col","qSfcLatRunoff")
 
         qlat_df = nhd_io.get_ql_from_wrf_hydro_mf(
             qlat_files=qlat_files,
@@ -702,6 +704,8 @@ def build_qlateral_array(
             #file_run_size=file_run_size,
             index_col=qlat_file_index_col,
             value_col=qlat_file_value_col,
+            gw_col = gw_bucket_col,
+            runoff_col = terrain_ro_col,
         )
 
         qlat_df = qlat_df[qlat_df.index.isin(segment_index)]

--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -907,13 +907,16 @@ def build_data_assimilation_folder(data_assimilation_parameters, run_parameters)
         print("No Files Found for DA")
         # TODO: Handle this with a real exception
 
-    usgs_df = nhd_io.get_usgs_from_time_slices_folder(
-        data_assimilation_parameters["wrf_hydro_da_channel_ID_crosswalk_file"],
-        usgs_files,
-        data_assimilation_parameters.get("qc_threshold", 1),
-        data_assimilation_parameters.get("data_assimilation_interpolation_limit", 59),
-        run_parameters["dt"],
-        run_parameters["t0"],
-    )
+    if usgs_files:
+        usgs_df = nhd_io.get_usgs_from_time_slices_folder(
+            data_assimilation_parameters["wrf_hydro_da_channel_ID_crosswalk_file"],
+            usgs_files,
+            data_assimilation_parameters.get("qc_threshold", 1),
+            data_assimilation_parameters.get("data_assimilation_interpolation_limit", 59),
+            run_parameters["dt"],
+            run_parameters["t0"],
+        )
+    else:
+        usgs_df = pd.DataFrame()
 
     return usgs_df


### PR DESCRIPTION
This PR proposes several changes that facilitate running simulations with WCOSS operational (transient)outputs.

- WRF simulations on WCOSS does not write a `q_lateral` variable to `CHRTOUT` files. Therefore, a `q_lateral` variable is not available to t-route for channel forcings. As a work around, we are introducing the capability to calculate `q_lateral` as `qBucket + qSfcLatRunoff`. Here, `qBucket` is the flux to the stream channel from the groundwater bucket model and `qSfcLatRunoff` is the flux to the channel from overland flow runoff.
- Default parameter value for `qlat_file_value_col` changed to `q_lateral` in `preprocess.py`
- A new capability is added that allows simulations to continue if all of the TimeSlice files in a particular loop set are missing. Previously, simulations would fail if no TimeSlices were found. 
- The capability to automatically build run, da, and parity sets is ported over to the v3 async. However, the async execution pathway appears broken by the changes above. 