### PR TITLE
Preprocess network graph data

### DIFF
--- a/doc/v3_doc.yaml
+++ b/doc/v3_doc.yaml
@@ -28,6 +28,37 @@ log_parameters:
 # parameters controlling how the stream network is synthesized
 network_topology_parameters:
     # ---------------
+    # Parameters controlling the creation and use of preprocessed network graph data
+    preprocessing_parameters:
+        # ---------------
+        # boolean. If True, then network graph objects will be created, saved to disk
+        # and then the execution will stop. 
+        # optional, defaults to False
+        preprocess_only:
+        # ---------------
+        # string. path to folder where preprocessed data will be saved as .npy
+        # mandatory if preprocess_only = True. Unnecessary if preprocess_only = False
+        preprocess_output_folder:
+        # ---------------
+        # string. Name of preprocessed file created by preprocessing routine. 
+        # Do not include a file extension, just the name.
+        # optional, defaults to 'preprocess_output'. Unecessary if preprocess_only = False 
+        preprocess_output_filename:
+        # ---------------
+        # boolean. If True, then the simulation will attempt to get network graph data directly
+        # from an existing preprocessd .npy file.
+        # optional, defaults to False.
+        #
+        # if use_preprocessed_data = True and preprocess_only = True, then the execution will ignore 
+        # preprocess_only and try to find and use existing preprocessed data. However, this condition is
+        # caught in the input check routine (log_level = DEBUG) and the execution is terminated early. 
+        use_preprocessed_data:
+        # ---------------
+        # string. Name of file containing preprocessed network graph objects. Must be a .npy file
+        # created by the t-route preprocessing routine.
+        # mandatory if use_preprocessed_data = True. Unnecessary if use_preprocessed_data = False
+        preprocess_source_file:
+    # ---------------
     supernetwork_parameters:
         # ---------------
         # string, Used for simulation identification

--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -26,6 +26,7 @@ from .preprocess import (
     nwm_network_preprocess,
     nwm_initial_warmstate_preprocess,
     nwm_forcing_preprocess,
+    unpack_nwm_preprocess_data,
 )
 from .output import nwm_output_generator
 

--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -1052,22 +1052,40 @@ def main_v03(argv):
     if showtiming:
         network_start_time = time.time()
         
-    (
-        connections,
-        param_df,
-        wbody_conn,
-        waterbodies_df,
-        waterbody_types_df,
-        break_network_at_waterbodies,
-        waterbody_type_specified,
-        independent_networks,
-        reaches_bytw,
-        rconn,
-        link_gage_df,
-    ) = nwm_network_preprocess(
-        supernetwork_parameters,
-        waterbody_parameters,
-    )
+    if preprocessing_parameters.get('use_preprocessed_data', False): 
+        (
+            connections,
+            param_df,
+            wbody_conn,
+            waterbodies_df,
+            waterbody_types_df,
+            break_network_at_waterbodies,
+            waterbody_type_specified,
+            independent_networks,
+            reaches_bytw,
+            rconn,
+            link_gage_df,
+        ) = unpack_nwm_preprocess_data(
+            preprocessing_parameters
+        )
+    else:
+        (
+            connections,
+            param_df,
+            wbody_conn,
+            waterbodies_df,
+            waterbody_types_df,
+            break_network_at_waterbodies,
+            waterbody_type_specified,
+            independent_networks,
+            reaches_bytw,
+            rconn,
+            link_gage_df,
+        ) = nwm_network_preprocess(
+            supernetwork_parameters,
+            waterbody_parameters,
+            preprocessing_parameters,
+        )
     
     if showtiming:
         network_end_time = time.time()

--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -1027,6 +1027,7 @@ def main_v03(argv):
     args = _handle_args_v03(argv)
     (
         log_parameters,
+        preprocessing_parameters,
         supernetwork_parameters,
         waterbody_parameters,
         compute_parameters,

--- a/src/nwm_routing/src/nwm_routing/input.py
+++ b/src/nwm_routing/src/nwm_routing/input.py
@@ -58,6 +58,7 @@ def _input_handler_v03(args):
         # don't forget to add input checks on user's preprocessing_parameters
         check_inputs(
                 log_parameters,
+                preprocessing_parameters,
                 supernetwork_parameters,
                 waterbody_parameters,
                 compute_parameters,
@@ -265,6 +266,7 @@ def _does_path_exist(parameter_name, directory_path_input):
     
 def check_inputs(
             log_parameters,
+            preprocessing_parameters,
             supernetwork_parameters,
             waterbody_parameters,
             compute_parameters,
@@ -277,6 +279,53 @@ def check_inputs(
             ):
 
     LOG.debug('***** Begining configuration file (.YAML) check *****')
+    
+    if preprocessing_parameters.get('preprocess_only', None):
+        
+        LOG.debug('Preparing a preprocessing only execution: preprocess_only = True')
+        
+        # if pre-processing the network graph data, check to make sure the destination
+        # folder is specified
+        if preprocessing_parameters.get('preprocess_output_folder',False):
+            pass
+        else:
+            LOG.error(
+                "No destination folder specified for preprocessing. Please specify preprocess_output_folder in the configuration file"
+            )
+            quit()
+            
+        # ... and check to make sure the destination folder exists
+        _does_path_exist(
+            'preprocess_output_folder', 
+            preprocessing_parameters['preprocess_output_folder']
+        )
+        
+    if preprocessing_parameters.get('preprocess_only', None) and preprocessing_parameters.get('use_preprocessed_data', None):
+        
+        LOG.critical(
+            "preprocess_only = True and use_preprocessed_data = True. Aborting execution. Both variables cannot be True"
+        )
+        quit
+        
+    if preprocessing_parameters.get('use_preprocessed_data', None):
+        
+        LOG.debug('Preparing a simlation that uses already preprocessed network graph data: use_preprocessed_data = True')
+        
+        # if user requests to use ready preprocessed data, check to make sure that the .npy file
+        # containing network graph objects is specified.
+        if preprocessing_parameters.get('preprocess_source_file',False):
+            pass
+        else:
+            LOG.error(
+                "No preprocessed data file specified. Please specify preprocess_source_file in the configuration file"
+            )
+            quit()
+        
+        # ... and check to make sure the source file exists
+        _does_file_exist(
+            'preprocess_source_file', 
+            preprocessing_parameters['preprocess_source_file']
+        )
     
     _does_file_exist('geo_file_path', 
                      supernetwork_parameters['geo_file_path'])

--- a/src/nwm_routing/src/nwm_routing/input.py
+++ b/src/nwm_routing/src/nwm_routing/input.py
@@ -35,6 +35,7 @@ def _input_handler_v03(args):
     if custom_input_file:
         (
             log_parameters,
+            preprocessing_parameters,
             supernetwork_parameters,
             waterbody_parameters,
             compute_parameters,
@@ -54,6 +55,7 @@ def _input_handler_v03(args):
     LOG = logging.getLogger('')
 
     if LOG.level <= 10: # DEBUG
+        # don't forget to add input checks on user's preprocessing_parameters
         check_inputs(
                 log_parameters,
                 supernetwork_parameters,
@@ -68,6 +70,7 @@ def _input_handler_v03(args):
                 )
     return (
         log_parameters,
+        preprocessing_parameters,
         supernetwork_parameters,
         waterbody_parameters,
         compute_parameters,

--- a/src/nwm_routing/src/nwm_routing/input.py
+++ b/src/nwm_routing/src/nwm_routing/input.py
@@ -23,6 +23,7 @@ def _input_handler_v03(args):
     custom_input_file = args.custom_input_file
     log_parameters = {}
     supernetwork_parameters = None
+    preprocessing_parameters = {}
     waterbody_parameters = {}
     compute_parameters = {}
     forcing_parameters = {}

--- a/src/nwm_routing/src/nwm_routing/preprocess.py
+++ b/src/nwm_routing/src/nwm_routing/preprocess.py
@@ -16,6 +16,7 @@ LOG = logging.getLogger('')
 def nwm_network_preprocess(
     supernetwork_parameters,
     waterbody_parameters,
+    preprocessing_parameters,
 ):
 
 
@@ -130,6 +131,52 @@ def nwm_network_preprocess(
     )
     
     LOG.debug("reach organization complete in %s seconds." % (time.time() - start_time))
+    
+    if preprocessing_parameters:
+        if preprocessing_parameters.get('preprocess_only', False):
+            
+            LOG.debug("saving preprocessed network data to disk for future use")
+            # todo: consider a better default than None
+            destination_folder = preprocessing_parameters.get('preprocess_output_folder', None)
+            if destination_folder:
+                
+                output_filename = preprocessing_parameters.get(
+                    'preprocess_output_filename', 
+                    'preprocess_output'
+                )
+                
+                outputs = {}
+                outputs.update(
+                    {'connections': connections,
+                     'param_df': param_df,
+                     'wbody_conn': wbody_conn,
+                     'waterbodies_df': waterbodies_df,
+                     'waterbody_types_df': waterbody_types_df,
+                     'break_network_at_waterbodies': break_network_at_waterbodies,
+                     'waterbody_type_specified': waterbody_type_specified,
+                     'independent_networks': independent_networks,
+                     'reaches_bytw': reaches_bytw,
+                     'rconn': rconn,
+                     'link_gage_df': pd.DataFrame.from_dict(gages)
+                    }
+                )
+                np.save(
+                    pathlib.Path(destination_folder).joinpath(output_filename),
+                    outputs
+                )
+                LOG.debug(
+                    "writing preprocessed network data to %s"\
+                    % pathlib.Path(destination_folder).joinpath(output_filename + '.npy'))
+                LOG.critical(
+                    "Preprocessed network data written do %s aborting preprocessing sequence" \
+                    % pathlib.Path(destination_folder).joinpath(output_filename + '.npy'))
+                quit()
+                
+            else:
+                LOG.critical(
+                    "No destination folder specified for preprocessing. Please specify preprocess_output_folder in configuration file"
+                )
+                quit()
 
     return (
         connections,

--- a/src/nwm_routing/src/nwm_routing/preprocess.py
+++ b/src/nwm_routing/src/nwm_routing/preprocess.py
@@ -132,51 +132,55 @@ def nwm_network_preprocess(
     
     LOG.debug("reach organization complete in %s seconds." % (time.time() - start_time))
     
-    if preprocessing_parameters:
-        if preprocessing_parameters.get('preprocess_only', False):
-            
-            LOG.debug("saving preprocessed network data to disk for future use")
-            # todo: consider a better default than None
-            destination_folder = preprocessing_parameters.get('preprocess_output_folder', None)
-            if destination_folder:
-                
-                output_filename = preprocessing_parameters.get(
-                    'preprocess_output_filename', 
-                    'preprocess_output'
-                )
-                
-                outputs = {}
-                outputs.update(
-                    {'connections': connections,
-                     'param_df': param_df,
-                     'wbody_conn': wbody_conn,
-                     'waterbodies_df': waterbodies_df,
-                     'waterbody_types_df': waterbody_types_df,
-                     'break_network_at_waterbodies': break_network_at_waterbodies,
-                     'waterbody_type_specified': waterbody_type_specified,
-                     'independent_networks': independent_networks,
-                     'reaches_bytw': reaches_bytw,
-                     'rconn': rconn,
-                     'link_gage_df': pd.DataFrame.from_dict(gages)
-                    }
-                )
+    if preprocessing_parameters.get('preprocess_only', False):
+
+        LOG.debug("saving preprocessed network data to disk for future use")
+        # todo: consider a better default than None
+        destination_folder = preprocessing_parameters.get('preprocess_output_folder', None)
+        if destination_folder:
+
+            output_filename = preprocessing_parameters.get(
+                'preprocess_output_filename', 
+                'preprocess_output'
+            )
+
+            outputs = {}
+            outputs.update(
+                {'connections': connections,
+                 'param_df': param_df,
+                 'wbody_conn': wbody_conn,
+                 'waterbodies_df': waterbodies_df,
+                 'waterbody_types_df': waterbody_types_df,
+                 'break_network_at_waterbodies': break_network_at_waterbodies,
+                 'waterbody_type_specified': waterbody_type_specified,
+                 'independent_networks': independent_networks,
+                 'reaches_bytw': reaches_bytw,
+                 'rconn': rconn,
+                 'link_gage_df': pd.DataFrame.from_dict(gages)
+                }
+            )
+            try:
                 np.save(
                     pathlib.Path(destination_folder).joinpath(output_filename),
                     outputs
                 )
-                LOG.debug(
-                    "writing preprocessed network data to %s"\
-                    % pathlib.Path(destination_folder).joinpath(output_filename + '.npy'))
-                LOG.critical(
-                    "Preprocessed network data written do %s aborting preprocessing sequence" \
-                    % pathlib.Path(destination_folder).joinpath(output_filename + '.npy'))
+            except:
+                LOG.critical('Canonot find %s. Aborting preprocessing routine' % pathlib.Path(destination_folder))
                 quit()
                 
-            else:
-                LOG.critical(
-                    "No destination folder specified for preprocessing. Please specify preprocess_output_folder in configuration file"
-                )
-                quit()
+            LOG.debug(
+                "writing preprocessed network data to %s"\
+                % pathlib.Path(destination_folder).joinpath(output_filename + '.npy'))
+            LOG.critical(
+                "Preprocessed network data written to %s aborting preprocessing sequence" \
+                % pathlib.Path(destination_folder).joinpath(output_filename + '.npy'))
+            quit()
+
+        else:
+            LOG.critical(
+                "No destination folder specified for preprocessing. Please specify preprocess_output_folder in configuration file. Aborting preprocessing routine"
+            )
+            quit()
 
     return (
         connections,

--- a/src/nwm_routing/src/nwm_routing/preprocess.py
+++ b/src/nwm_routing/src/nwm_routing/preprocess.py
@@ -192,6 +192,48 @@ def nwm_network_preprocess(
         pd.DataFrame.from_dict(gages),
     )
 
+def unpack_nwm_preprocess_data(preprocessing_parameters):
+    
+    preprocess_filepath = preprocessing_parameters.get('preprocess_source_file',None)
+    if preprocess_filepath:
+        try:
+            inputs = np.load(pathlib.Path(preprocess_filepath),allow_pickle='TRUE').item()
+        except:
+            LOG.critical('Canonot find %s' % pathlib.Path(preprocess_filepath))
+            quit()
+              
+        connections = inputs.get('connections',None)            
+        param_df = inputs.get('param_df',None)
+        wbody_conn = inputs.get('wbody_conn',None)
+        waterbodies_df = inputs.get('waterbodies_df',None)
+        waterbody_types_df = inputs.get('waterbody_types_df',None)
+        break_network_at_waterbodies = inputs.get('break_network_at_waterbodies',None)
+        waterbody_type_specified = inputs.get('waterbody_type_specified',None)
+        independent_networks = inputs.get('independent_networks',None)
+        reaches_bytw = inputs.get('reaches_bytw',None)
+        rconn = inputs.get('rconn',None)
+        gages = inputs.get('gages',None)
+        
+        # todo: if any of the abocve variables are none, throw a critical error and quit the simulation. 
+        
+    else:
+        LOG.critical("use_preprocessed_data = True, but no preprocess_source_file is specified. Aborting the simulation.")
+        quit()
+                         
+    return (
+        connections,
+        param_df,
+        wbody_conn,
+        waterbodies_df,
+        waterbody_types_df,
+        break_network_at_waterbodies,
+        waterbody_type_specified,
+        independent_networks,
+        reaches_bytw,
+        rconn,
+        gages,
+    )
+
 
 def nwm_initial_warmstate_preprocess(
     break_network_at_waterbodies,

--- a/src/nwm_routing/src/nwm_routing/preprocess.py
+++ b/src/nwm_routing/src/nwm_routing/preprocess.py
@@ -1,5 +1,7 @@
 import time
 import pandas as pd
+import numpy as np
+import pathlib
 import xarray as xr
 from datetime import datetime
 from collections import defaultdict

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -60,6 +60,9 @@ def read_custom_input_new(custom_input_file):
     supernetwork_parameters = network_topology_parameters.get(
         "supernetwork_parameters", None
     )
+    preprocessing_parameters = network_topology_parameters.get(
+        "preprocessing_parameters", None
+    )
     waterbody_parameters = network_topology_parameters.get("waterbody_parameters", None)
     compute_parameters = data.get("compute_parameters", {})
     forcing_parameters = compute_parameters.get("forcing_parameters", {})
@@ -74,6 +77,7 @@ def read_custom_input_new(custom_input_file):
     # TODO: add error trapping for potentially missing files
     return (
         log_parameters,
+        preprocessing_parameters,
         supernetwork_parameters,
         waterbody_parameters,
         compute_parameters,

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -63,6 +63,8 @@ def read_custom_input_new(custom_input_file):
     preprocessing_parameters = network_topology_parameters.get(
         "preprocessing_parameters", {}
     )
+    if not preprocessing_parameters:
+        preprocessing_parameters = {}
     waterbody_parameters = network_topology_parameters.get("waterbody_parameters", None)
     compute_parameters = data.get("compute_parameters", {})
     forcing_parameters = compute_parameters.get("forcing_parameters", {})

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -61,7 +61,7 @@ def read_custom_input_new(custom_input_file):
         "supernetwork_parameters", None
     )
     preprocessing_parameters = network_topology_parameters.get(
-        "preprocessing_parameters", None
+        "preprocessing_parameters", {}
     )
     waterbody_parameters = network_topology_parameters.get("waterbody_parameters", None)
     compute_parameters = data.get("compute_parameters", {})


### PR DESCRIPTION
Introducing a preprocessing capability, whereby users can build and save network graph data objects for future use. Likewise, users can read and use pre-constructed network graph data objects. These capabilities are intended to reduce computationsl time spent on network graph construction tasks during operational uses. 

Network graph data objects refer broadly to the variables returned by [`nwm_network_preprocess`](https://github.com/NOAA-OWP/t-route/blob/7128442d01f3cdd1e02ab2d169e6940d82736fb4/src/nwm_routing/src/nwm_routing/preprocess.py#L14-L144) , a set of python dictionary and Pandas DataFrame variables that contain network topology  and/or channel geometry data. These data objects are bespoke to a simulations spatial domain, but not the temporal domain. For example, all of the returns from  [`nwm_network_preprocess`](https://github.com/NOAA-OWP/t-route/blob/7128442d01f3cdd1e02ab2d169e6940d82736fb4/src/nwm_routing/src/nwm_routing/preprocess.py#L14-L144) will be identical for a 3 hour CONUS AnA simulation as they are for a 10 day CONUS forecast simulation. For this reason, it makes little sense to spend computational resources re-generating these data objects for different simulation configurations on the same spatial domain.

## Preprocessing network graph data objects
In order to use preprocessed data objects, they must be generated first. This is done by setting `network_topology_parameters['preprocessing_parameters']['preprocess_only'] = True` and `network_topology_parameters['preprocessing_parameters']['preprocess_output_folder'] = 'directory/where/data/is/saved'` in the configuration (.yaml) file. See changes to `doc/v3_doc.yaml`for parameter descriptions. When a simulation is executed with these parameter settings, it will conclude immediately after building and saving network graph data objects. Critically, when `network_topology_parameters['preprocessing_parameters']['preprocess_only'] = True`, the t-route execution only builds and saves data, the actual routing simulation does not occur!

Network graph data objects are packaged into a dictionary and saved to disk as a `.npy` file, which are ideal in terms of data compression and efficient I/O.

## Jump starting simulations with preprocessed network graph data
Assuming that network graph data have already been preprocessed and saved to disk, users can jump-start simulations by reading-in these data directly, rather than creating them from scratch. This is done by setting `network_topology_parameters['preprocessing_parameters']['use_preprocessed_data'] = True` and `network_topology_parameters['preprocessing_parameters']['preprocess_output_filename'] = 'filepath/where/data/is/saved/filename.npy` in the configuration file (.yaml). Once a simulation is initiated with these configuration settings, the call to `nwm_network_preprocess` in `__main__.py` is avoided and preprocessed data are read in from disk instead.

## Proof of concept: CONUS
Below are timing statistics for a 28 hour CONUS forecast (no DA) without any preprocessing. Notice that ~41 seconds are spent creating network graph objects.
```
************ TIMING SUMMARY ************
----------------------------------------
Network graph construction: 40.72 secs, 14.34 %
Initial condition handling: 0.94 secs, 0.33 %
Forcing array construction: 1.5 secs, 0.53 %
Routing computations: 218.54 secs, 76.97 %
Output writing: 22.23 secs, 7.83 %
----------------------------------------
Total execution time: 283.93 secs
```
Below are timing statistics after running the same simulation with already-preprocessed data. We greatly reduce the network graph construction time (just the time required to open and unpack the `.npy` file), which reduces the overall execution time by ~30 seconds (10%)
```
************ TIMING SUMMARY ************
----------------------------------------
Network graph construction: 6.74 secs, 2.66 %
Initial condition handling: 1.33 secs, 0.52 %
Forcing array construction: 1.51 secs, 0.59 %
Routing computations: 218.94 secs, 86.33 %
Output writing: 25.09 secs, 9.89 %
----------------------------------------
Total execution time: 253.61 secs
```
the `.npy` file saved to disk that contain preprocessed CONUS network graph data objects is ~300Mb in size.
