### PR TITLE
Expedite file reading and writing processes

### DIFF
--- a/doc/v3_doc.yaml
+++ b/doc/v3_doc.yaml
@@ -499,17 +499,6 @@ output_parameters:
         # CHRTOUT files used are the ones we'd want to write results to.
         # (!!) mandatory if writing results to CHRTOUT. Default is to None and results will not be written.
         wrf_hydro_channel_output_source_folder: 
-        # ---------------
-        # path to the directory where edited CHRTOUT files will be written to
-        # optional, defaults to wrf_hydro_channel_output_source_folder
-        wrf_hydro_channel_final_output_folder: 
-        # ---------------
-        # tag appended to CHRTOUT filenames after t-route results have been written
-        # For example, if wrf_hydro_channel_output_new_extension = TROUTE and the
-        # CHRTOUT file being edited is named 777777.CHRTOUT_DOMAIN1, then the edited file
-        # name will be 777777.CHRTOUT_DOMAIN1.TROUTE
-        # optional, defaults to "TRTE"
-        wrf_hydro_channel_output_new_extension:
     # ---------------
     # parameters controlling the writing of restart data to HYDRO_RST netcdf files
     # optional, defauls is None and results restart data is not written
@@ -519,17 +508,8 @@ output_parameters:
         # (!!) mandatory if writing restart data to HYDRO_RST Default is to None and results will not be written.
         wrf_hydro_restart_dir:
         # ---------------
-        # path to the directory where edited HYDRO_RST files will be written to
-        # optional, defaults to wrf_hydro_restart_dir
-        wrf_hydro_restart_write_dir:
-        # ---------------
-        # tag appended to HYDRO_RST filenames after t-route results have been written
-        # optional, defaults to "TRTE"
-        wrf_hydro_channel_restart_new_extension:
-        # ---------------
-        # !!!!!! DEPRICATED
-        # TODO: this parameter is completely unnecessary in a V3 execution and should
-        # be taken out of consideration with a forthcoming PR
+        # string. Unique file pattern of restart files (e.g. HYDRO_RST.*)
+        # optional, defaults to 'HYDRO_RST*'
         wrf_hydro_channel_restart_pattern_filter:
     # ---------------
     # paramters controlling a single-segment parity assessment between t-route and WRF-hydro

--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -1313,6 +1313,7 @@ async def main_v03_async(argv):
     args = _handle_args_v03(argv)  # async shares input framework with non-async
     (
         log_parameters,
+        preprocessing_parameters,
         supernetwork_parameters,
         waterbody_parameters,
         compute_parameters,
@@ -1329,22 +1330,40 @@ async def main_v03_async(argv):
     
     main_start_time = time.time()
 
-    (
-        connections,
-        param_df,
-        wbody_conn,
-        waterbodies_df,
-        waterbody_types_df,
-        break_network_at_waterbodies,
-        waterbody_type_specified,
-        independent_networks,
-        reaches_bytw,
-        rconn,
-        link_gage_df,
-    ) = nwm_network_preprocess(
-        supernetwork_parameters,
-        waterbody_parameters,
-    )
+    if preprocessing_parameters.get('use_preprocessed_data', False): 
+        (
+            connections,
+            param_df,
+            wbody_conn,
+            waterbodies_df,
+            waterbody_types_df,
+            break_network_at_waterbodies,
+            waterbody_type_specified,
+            independent_networks,
+            reaches_bytw,
+            rconn,
+            link_gage_df,
+        ) = unpack_nwm_preprocess_data(
+            preprocessing_parameters
+        )
+    else:
+        (
+            connections,
+            param_df,
+            wbody_conn,
+            waterbodies_df,
+            waterbody_types_df,
+            break_network_at_waterbodies,
+            waterbody_type_specified,
+            independent_networks,
+            reaches_bytw,
+            rconn,
+            link_gage_df,
+        ) = nwm_network_preprocess(
+            supernetwork_parameters,
+            waterbody_parameters,
+            preprocessing_parameters,
+        )
 
     # TODO: This function modifies one of its arguments (waterbodies_df), which is somewhat poor practice given its otherwise functional nature. Consider refactoring
     waterbodies_df, q0, t0, lastobs_df, da_parameter_dict = nwm_initial_warmstate_preprocess(

--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -1199,6 +1199,7 @@ def main_v03(argv):
                 break_network_at_waterbodies,
                 param_df.index,
                 lastobs_df.index,
+                cpu_pool,
                 t0 + timedelta(seconds = dt * nts),
             )
             

--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -1428,13 +1428,12 @@ async def main_v03_async(argv):
 
     run_set_iterator = 0
     for run_set_iterator, run in enumerate(run_sets[:-1]):
-
-        t0 = run.get("t0")
-        dt = run.get("dt")
+                    
+        dt = forcing_parameters.get("dt", None)
         nts = run.get("nts")
-
+        
         qlats, usgs_df = await forcings_task
-
+        
         # TODO: confirm utility of visual parity check in async execution
         if parity_sets:
             parity_sets[run_set_iterator]["dt"] = dt
@@ -1519,8 +1518,7 @@ async def main_v03_async(argv):
     run_set_iterator += 1
     run = run_sets[run_set_iterator]
 
-    t0 = run.get("t0")
-    dt = run.get("dt")
+    dt = forcing_parameters.get("dt", None)
     nts = run.get("nts")
 
     qlats, usgs_df = await forcings_task

--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -1136,6 +1136,7 @@ def main_v03(argv):
         break_network_at_waterbodies,
         param_df.index,
         lastobs_df.index,
+        cpu_pool,
         t0,
     )
     
@@ -1237,6 +1238,7 @@ def main_v03(argv):
             parity_sets[run_set_iterator] if parity_parameters else {},
             qts_subdivisions,
             compute_parameters.get("return_courant", False),
+            cpu_pool,
             data_assimilation_parameters,
             lastobs_df,
             link_gage_df,

--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -1402,6 +1402,7 @@ async def main_v03_async(argv):
         break_network_at_waterbodies,
         param_df.index,
         lastobs_df.index,
+        IO_cpu_pool,
         t0,
     )
 
@@ -1459,6 +1460,7 @@ async def main_v03_async(argv):
             break_network_at_waterbodies,
             param_df.index,
             lastobs_df.index,
+            IO_cpu_pool,
             t0 + timedelta(seconds = dt * nts),
         )
 
@@ -1487,6 +1489,7 @@ async def main_v03_async(argv):
             parity_sets[run_set_iterator] if parity_parameters else {},
             qts_subdivisions,
             compute_parameters.get("return_courant", False),
+            IO_cpu_pool,
             data_assimilation_parameters,
             lastobs_df,
             link_gage_df,
@@ -1564,6 +1567,7 @@ async def main_v03_async(argv):
         parity_sets[run_set_iterator] if parity_parameters else {},
         qts_subdivisions,
         compute_parameters.get("return_courant", False),
+        IO_cpu_pool,
         data_assimilation_parameters,
         lastobs_df,
         link_gage_df,

--- a/src/nwm_routing/src/nwm_routing/output.py
+++ b/src/nwm_routing/src/nwm_routing/output.py
@@ -20,6 +20,7 @@ def nwm_output_generator(
     parity_set,
     qts_subdivisions,
     return_courant,
+    cpu_pool,
     data_assimilation_parameters=False,
     lastobs_df=None,
     link_gage_df=None,
@@ -164,6 +165,7 @@ def nwm_output_generator(
                 flowveldepth,
                 chrtout_files,
                 qts_subdivisions,
+                cpu_pool,
             )
         
         LOG.debug("writing CHRTOUT files took a total time of %s seconds." % (time.time() - start))

--- a/src/nwm_routing/src/nwm_routing/output.py
+++ b/src/nwm_routing/src/nwm_routing/output.py
@@ -171,7 +171,7 @@ def nwm_output_generator(
                 Path(chrtout_read_folder) / f for f in run["qlat_files"]
             )
 
-            nhd_io.write_q_to_wrf_hydro(
+            nhd_io.write_chrtout(
                 flowveldepth,
                 chrtout_files,
                 Path(chrtout_write_folder),

--- a/src/nwm_routing/src/nwm_routing/output.py
+++ b/src/nwm_routing/src/nwm_routing/output.py
@@ -103,7 +103,7 @@ def nwm_output_generator(
                 copy=False,
             )
             
-    LOG.debug("Constructing the FVD DataFrame took %s seconds." % (time.time() - start))
+        LOG.debug("Constructing the FVD DataFrame took %s seconds." % (time.time() - start))
 
     if rsrto:
 

--- a/src/nwm_routing/src/nwm_routing/output.py
+++ b/src/nwm_routing/src/nwm_routing/output.py
@@ -138,10 +138,11 @@ def nwm_output_generator(
                     ),
                 )
             else:
-                # print error and/or raise exception
-                str = "WRF Hydro restart files not found - Aborting restart write sequence"
-                raise AssertionError(str)
+                LOG.info('Did not find any restart files in wrf_hydro_channel_restart_source_directory. Aborting restart write sequence.')
                 
+        else:
+            LOG.info('wrf_hydro_channel_restart_source_directory not specified in configuration file. Aborting restart write sequence.')
+            
         LOG.debug("writing restart files took %s seconds." % (time.time() - start))
 
     if chrto:

--- a/src/nwm_routing/src/nwm_routing/output.py
+++ b/src/nwm_routing/src/nwm_routing/output.py
@@ -78,14 +78,13 @@ def nwm_output_generator(
         )
         csv_output_segments = csv_output.get("csv_output_segments", None)
 
-    start = time.time()
+    
     if csv_output_folder or rsrto or chrto:
-
+        
+        start = time.time()
         qvd_columns = pd.MultiIndex.from_product(
             [range(nts), ["q", "v", "d"]]
         ).to_flat_index()
-
-        import pdb; pdb.set_trace()
 
         flowveldepth = pd.concat(
             [pd.DataFrame(r[1], index=r[0], columns=qvd_columns) for r in results],
@@ -103,14 +102,14 @@ def nwm_output_generator(
                 ],
                 copy=False,
             )
-
-    LOG.debug("building FVD array took %s seconds." % (time.time() - start))
+            
+    LOG.debug("Constructing the FVD DataFrame took %s seconds." % (time.time() - start))
 
     if rsrto:
 
         LOG.info("- writing restart files")
         start = time.time()
-
+        
         wrf_hydro_restart_dir = rsrto.get(
             "wrf_hydro_channel_restart_source_directory", None
         )
@@ -148,8 +147,9 @@ def nwm_output_generator(
 
     if chrto:
         
-        LOG.info("- writing results to CHRTOUT")
+        LOG.info("- writing t-route flow results to CHRTOUT files")
         start = time.time()
+        
         chrtout_read_folder = chrto.get(
             "wrf_hydro_channel_output_source_folder", None
         )
@@ -166,11 +166,12 @@ def nwm_output_generator(
                 qts_subdivisions,
             )
         
-        LOG.debug("writing CHRTOUT files took %s seconds." % (time.time() - start))
+        LOG.debug("writing CHRTOUT files took a total time of %s seconds." % (time.time() - start))
 
     if csv_output_folder: 
     
         LOG.info("- writing flow, velocity, and depth results to .csv")
+        start = time.time()
 
         # create filenames
         # TO DO: create more descriptive filenames
@@ -199,6 +200,7 @@ def nwm_output_generator(
             courant = courant.sort_index()
             courant.loc[csv_output_segments].to_csv(output_path.joinpath(filename_courant))
 
+        LOG.debug("writing CSV file took %s seconds." % (time.time() - start))
         # usgs_df_filtered = usgs_df[usgs_df.index.isin(csv_output_segments)]
         # usgs_df_filtered.to_csv(output_path.joinpath("usgs_df.csv"))
 
@@ -214,6 +216,10 @@ def nwm_output_generator(
     # if lastobs_output_folder:
     #     warnings.warn("No LastObs output folder directory specified in input file - not writing out LastObs data")
     if data_assimilation_folder and lastobs_output_folder:
+        
+        LOG.info("- writing lastobs files")
+        start = time.time()
+        
         nhd_io.lastobs_df_output(
             lastobs_df,
             dt,
@@ -222,6 +228,8 @@ def nwm_output_generator(
             link_gage_df['gages'],
             lastobs_output_folder,
         )
+        
+        LOG.debug("writing lastobs files took %s seconds." % (time.time() - start))
 
     if 'flowveldepth' in locals():
         LOG.debug(flowveldepth)

--- a/src/nwm_routing/src/nwm_routing/output.py
+++ b/src/nwm_routing/src/nwm_routing/output.py
@@ -159,13 +159,8 @@ def nwm_output_generator(
         chrtout_read_folder = chrto.get(
             "wrf_hydro_channel_output_source_folder", None
         )
-        chrtout_write_folder = chrto.get(
-            "wrf_hydro_channel_final_output_folder", chrtout_read_folder
-        )
+
         if chrtout_read_folder:
-            wrf_hydro_channel_output_new_extension = chrto.get(
-                "wrf_hydro_channel_output_new_extension", "TRTE"
-            )
 
             chrtout_files = sorted(
                 Path(chrtout_read_folder) / f for f in run["qlat_files"]
@@ -174,9 +169,7 @@ def nwm_output_generator(
             nhd_io.write_chrtout(
                 flowveldepth,
                 chrtout_files,
-                Path(chrtout_write_folder),
                 qts_subdivisions,
-                wrf_hydro_channel_output_new_extension,
             )
 
     if csv_output_folder: 

--- a/src/nwm_routing/src/nwm_routing/output.py
+++ b/src/nwm_routing/src/nwm_routing/output.py
@@ -78,11 +78,14 @@ def nwm_output_generator(
         )
         csv_output_segments = csv_output.get("csv_output_segments", None)
 
+    start = time.time()
     if csv_output_folder or rsrto or chrto:
 
         qvd_columns = pd.MultiIndex.from_product(
             [range(nts), ["q", "v", "d"]]
         ).to_flat_index()
+
+        import pdb; pdb.set_trace()
 
         flowveldepth = pd.concat(
             [pd.DataFrame(r[1], index=r[0], columns=qvd_columns) for r in results],
@@ -101,9 +104,12 @@ def nwm_output_generator(
                 copy=False,
             )
 
+    LOG.debug("building FVD array took %s seconds." % (time.time() - start))
+
     if rsrto:
 
         LOG.info("- writing restart files")
+        start = time.time()
 
         wrf_hydro_restart_dir = rsrto.get(
             "wrf_hydro_channel_restart_source_directory", None
@@ -137,11 +143,13 @@ def nwm_output_generator(
                 # print error and/or raise exception
                 str = "WRF Hydro restart files not found - Aborting restart write sequence"
                 raise AssertionError(str)
+                
+        LOG.debug("writing restart files took %s seconds." % (time.time() - start))
 
     if chrto:
         
         LOG.info("- writing results to CHRTOUT")
-        
+        start = time.time()
         chrtout_read_folder = chrto.get(
             "wrf_hydro_channel_output_source_folder", None
         )
@@ -157,6 +165,8 @@ def nwm_output_generator(
                 chrtout_files,
                 qts_subdivisions,
             )
+        
+        LOG.debug("writing CHRTOUT files took %s seconds." % (time.time() - start))
 
     if csv_output_folder: 
     

--- a/src/nwm_routing/src/nwm_routing/output.py
+++ b/src/nwm_routing/src/nwm_routing/output.py
@@ -138,10 +138,10 @@ def nwm_output_generator(
                     ),
                 )
             else:
-                LOG.info('Did not find any restart files in wrf_hydro_channel_restart_source_directory. Aborting restart write sequence.')
+                LOG.critical('Did not find any restart files in wrf_hydro_channel_restart_source_directory. Aborting restart write sequence.')
                 
         else:
-            LOG.info('wrf_hydro_channel_restart_source_directory not specified in configuration file. Aborting restart write sequence.')
+            LOG.critical('wrf_hydro_channel_restart_source_directory not specified in configuration file. Aborting restart write sequence.')
             
         LOG.debug("writing restart files took %s seconds." % (time.time() - start))
 

--- a/src/nwm_routing/src/nwm_routing/output.py
+++ b/src/nwm_routing/src/nwm_routing/output.py
@@ -116,8 +116,7 @@ def nwm_output_generator(
 
         if wrf_hydro_restart_dir:
 
-            restart_pattern_filter = rsrto.get("wrf_hydro_channel_restart_pattern_filter", "HYRDO_RST*")
-            
+            restart_pattern_filter = rsrto.get("wrf_hydro_channel_restart_pattern_filter", "HYDRO_RST.*")
             # list of WRF Hydro restart files
             wrf_hydro_restart_files = sorted(
                 Path(wrf_hydro_restart_dir).glob(

--- a/src/nwm_routing/src/nwm_routing/output.py
+++ b/src/nwm_routing/src/nwm_routing/output.py
@@ -108,35 +108,22 @@ def nwm_output_generator(
         wrf_hydro_restart_dir = rsrto.get(
             "wrf_hydro_channel_restart_source_directory", None
         )
-        wrf_hydro_restart_write_dir = rsrto.get(
-            "wrf_hydro_channel_restart_output_directory", wrf_hydro_restart_dir
-        )
+
         if wrf_hydro_restart_dir:
 
-            wrf_hydro_channel_restart_new_extension = rsrto.get(
-                "wrf_hydro_channel_restart_new_extension", "TRTE"
+            restart_pattern_filter = rsrto.get("wrf_hydro_channel_restart_pattern_filter", "HYRDO_RST*")
+            
+            # list of WRF Hydro restart files
+            wrf_hydro_restart_files = sorted(
+                Path(wrf_hydro_restart_dir).glob(
+                    restart_pattern_filter
+                )
             )
 
-            if rsrto.get("wrf_hydro_channel_restart_pattern_filter", None):
-                # list of WRF Hydro restart files
-                wrf_hydro_restart_files = sorted(
-                    Path(wrf_hydro_restart_dir).glob(
-                        rsrto["wrf_hydro_channel_restart_pattern_filter"]
-                        + "[!"
-                        + wrf_hydro_channel_restart_new_extension
-                        + "]"
-                    )
-                )
-            else:
-                wrf_hydro_restart_files = sorted(
-                    Path(wrf_hydro_restart_dir) / f for f in run["qlat_files"]
-                )
-
             if len(wrf_hydro_restart_files) > 0:
-                nhd_io.write_channel_restart_to_wrf_hydro(
+                nhd_io.write_hydro_rst(
                     flowveldepth,
                     wrf_hydro_restart_files,
-                    Path(wrf_hydro_restart_write_dir),
                     restart_parameters.get("wrf_hydro_channel_restart_file"),
                     dt,
                     nts,
@@ -145,7 +132,6 @@ def nwm_output_generator(
                     restart_parameters.get(
                         "wrf_hydro_channel_ID_crosswalk_file_field_name"
                     ),
-                    wrf_hydro_channel_restart_new_extension,
                 )
             else:
                 # print error and/or raise exception

--- a/src/nwm_routing/src/nwm_routing/preprocess.py
+++ b/src/nwm_routing/src/nwm_routing/preprocess.py
@@ -342,6 +342,7 @@ def nwm_forcing_preprocess(
     break_network_at_waterbodies,
     segment_index,
     lastobs_index,
+    cpu_pool,
     warmstate_t0 = None,
 ):
 
@@ -396,6 +397,7 @@ def nwm_forcing_preprocess(
 
     qlats_df = nnu.build_qlateral_array(
         run,
+        cpu_pool,
         segment_index,
     )
 

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -373,9 +373,7 @@ def write_to_netcdf(filename, variables, datatype = 'f4'):
 def write_chrtout(    
     flowveldepth,
     chrtout_files,
-    output_folder,
     qts_subdivisions,
-    new_extension="TRTE"
 ):
     
     # count the number of simulated timesteps

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -266,16 +266,14 @@ def get_ql_from_wrf_hydro_mf(
 
     with xr.open_mfdataset(
         qlat_files,
-        # combine="by_coords",
         combine="nested",
         concat_dim="time",
-        # data_vars="minimal",
-        # coords="minimal",
-        # compat="override",
-        preprocess=drop_all_coords,
+        data_vars=["q_lateral","qBucket","qSfcLatRunoff"],
+        coords="minimal",
+        compat="override",
         # parallel=True,
     ) as ds:
-
+        
         # if forcing file contains a variable with the specified value_col name, 
         # then use it, otherwise compute q_lateral as the sum of qBucket and qSfcLatRunoff
         try:

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -219,6 +219,42 @@ def read_qlat(path):
     """
     return get_ql_from_csv(path)
 
+def get_ql_from_chrtout(
+    f,
+    qlateral_varname = "q_lateral",
+    qbucket_varname="qBucket",
+    runoff_varname = "qSfcLatRunoff",
+):
+    '''
+    Return an array of qlateral data from a single CHRTOUT netCDF4 file.
+    If the lateral inflow variable is not present in the file, then calculate
+    lateral inflow as the sum of qbucket and surface runoff.
+    
+    Arguments
+    ---------
+    f (Path): 
+    qlateral_varname (string): lateral inflow variable name
+    qbucket_varname (string): Groundwater bucket flux variable name
+    runoff_varname (string): surface runoff variable name
+    
+    NOTES:
+    - This is very bespoke to WRF-Hydro
+    '''
+    with netCDF4.Dataset(
+        filename = f,
+        mode = 'r',
+        format = "NETCDF4"
+    ) as ds:
+        
+        all_variables = list(ds.variables.keys())
+        if qlateral_varname in all_variables:
+            dat = ds.variables[qlateral_varname][:].filled()
+        
+        else:
+            dat = ds.variables[qbucket_varname][:].filled() + \
+                ds.variables[runoff_varname][:].filled()
+        
+    return dat
 
 # TODO: Generalize this name -- perhaps `read_wrf_hydro_chrt_mf()`
 def get_ql_from_wrf_hydro_mf(

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -377,38 +377,38 @@ def write_to_netcdf(filename, variables, datatype = 'f4'):
             
             # check that dimension exists
             if dim not in list(ds.dimensions.keys()):
-                print("ERROR & abort file writing sequence")
-
-            # size of variable dimensions
-            dim_size = ds.dimensions[dim].size
+                LOG.error("The dimensions %s could not be found in file %s" % (dim, filename))
+                LOG.error("Aborting writing process for %s. No data were written to this file" % filename)
+                return        
             
             # check that dimension size and variable data size agree
+            dim_size = ds.dimensions[dim].size
             if vardata.size != dim_size:
-                print("HEY!: You the array you are trying to write to netCDF is the wrong size!")
-                print("ERROR & abort the file writing sequence")
+                LOG.error("Cannot write data of size %d to variable with dimension size of %d" % (vardata.size, dim_size))
+                LOG.error("Aborting writing process for %s. No data were written to this file" % filename)
+                return
             
             # check that varname doesn't already exist
             # if it does, then overwrite it
             if varname in list(ds.variables.keys()):
 
-                # here, we are overwiting the already existing variable, 'new'. 
-                # again, making sure that the data we write to it is of the same size.
                 ds[varname][:] = vardata
 
             # if variable does not exist, create new one
-            else: #!!!! something is wrong here! 
+            else:
 
-                # create a new variable called 'new'
+                # create a new variable
                 y = ds.createVariable(
                     varname = varname,
                     datatype = datatype,
-                    dimensions = (dim,)
+                    dimensions = (dim,),
+                    fill_value = np.nan
                 )
-                # populate variable with an numpy empty array for now. 
-                # Of course, we want to insert actual t-route data from the simulation results, here.
-                y = vardata
 
-                # we will also need to add the appropriate variable attributes
+                # write data to new variable
+                y[:] = vardata
+
+                # include variable attributes
                 ds[varname].setncatts(attrs)
                 
 def write_chrtout(    

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -392,7 +392,7 @@ def write_chrtout(
         
         flowveldepth_reindex = flowveldepth.reindex(newindex)
 
-        # unpack, subset, and transpose t-route flow data
+        # unpack and subset t-route flow data
         qtrt = flowveldepth_reindex.loc[:, ::3].to_numpy().astype("float32")
         qtrt = qtrt[:, qts_subdivisions-1::qts_subdivisions]
         

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -11,6 +11,7 @@ import sys
 import math
 from datetime import *
 import pathlib
+import netCDF4
 
 from troute.nhd_network import reverse_dict
 

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -405,86 +405,13 @@ def write_chrtout(
             'grid_mapping': 'crs',
             'valid_range': np.array([0,50000], dtype = 'float32'),
         }
+        # TODO: Include parallel write option on this loop
         for i, f in enumerate(chrtout_files[:nfiles_to_write]):
             
             variables = {
                 varname: (qtrt[:,i], dim, attrs)
             }
             write_to_netcdf(f, variables)
-            
-def write_q_to_wrf_hydro(
-    flowveldepth,
-    chrtout_files,
-    output_folder,
-    qts_subdivisions,
-    new_extension="TRTE"
-):
-    """
-    Write t-route simulated flows to WRF-Hydro CHRTOUT files.
-
-    Arguments:
-        flowveldepth (pandas Data Frame): t-route simulated flow, velocity and depth
-        chrtout_files (list): chrtout filepaths
-        output_folder (pathlib.Path): folder where updated chrtout files will be written
-        qts_subdivisions (int): number of t-route timesteps per WRF-hydro timesteps
-    """
-    
-    # count the number of simulated timesteps
-    nsteps = len(flowveldepth.loc[:,::3].columns)
-    
-    # determine how many files to write results out to
-    nfiles_to_write = int(np.floor(nsteps / qts_subdivisions))
-    
-    if nfiles_to_write > 1:
-    
-        # open all CHRTOUT files as a single xarray dataset
-        with xr.open_mfdataset(
-            chrtout_files[:nfiles_to_write], 
-            combine="nested",
-            concat_dim="time",
-        ) as chrtout:
-
-            # !!NOTE: If break_at_waterbodies == True, segment feature_ids coincident with water bodies do
-            # not show up in the flowveldepth dataframe. Re-indexing inserts these missing feature_ids and
-            # populates columns with NaN values.
-            flowveldepth_reindex = flowveldepth.reindex(chrtout.feature_id.values)
-
-            # unpack, subset, and transpose t-route flow data
-            qtrt = flowveldepth_reindex.loc[:, ::3].to_numpy().astype("float32")
-            qtrt = qtrt[:, qts_subdivisions-1::qts_subdivisions]
-            qtrt = np.transpose(qtrt)
-
-            # construct DataArray for t-route flows, dims, coords, and attrs consistent with CHRTOUT
-            qtrt_DataArray = xr.DataArray(
-                data=da.from_array(qtrt),
-                dims=["time", "feature_id"],
-                coords=dict(time=chrtout.time.values, feature_id=chrtout.feature_id.values),
-                attrs=dict(description="River Flow, t-route", units="m3 s-1",),
-            )
-
-            # add t-route DataArray to CHRTOUT dataset
-            chrtout["streamflow_troute"] = qtrt_DataArray
-
-            # group by time
-            grp_object = chrtout.groupby("time")
-
-        # build a list of datasets, one for each timestep
-        dataset_list = []
-        for grp, vals in iter(grp_object):
-            dataset_list.append(vals)
-
-        # save a new set of chrtout files to disk that contail t-route simulated flow
-        chrtout_files_new = [
-            output_folder / (s.name + "." + new_extension) for s in chrtout_files
-        ]
-
-        # mfdataset solution - can theoretically be parallelised via dask.distributed
-        xr.save_mfdataset(dataset_list, paths=chrtout_files_new)
-
-#     # pure serial solution - saving for timing tests against mfdataset
-#     for i, dat in enumerate(dataset_list):
-#         dat.to_netcdf(chrtout_files_new[i])
-
 
 def get_ql_from_wrf_hydro(qlat_files, index_col="station_id", value_col="q_lateral"):
     """

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -396,7 +396,7 @@ def write_to_netcdf(filename, variables, datatype = 'f4'):
                 ds[varname][:] = vardata
 
             # if variable does not exist, create new one
-            else: 
+            else: #!!!! something is wrong here! 
 
                 # create a new variable called 'new'
                 y = ds.createVariable(

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -345,7 +345,7 @@ def get_ql_from_wrf_hydro_mf(
 def drop_all_coords(ds):
     return ds.reset_coords(drop=True)
 
-def write_to_netcdf(filename, variables, datatype = 'f4'):
+def write_to_netcdf(f, variables, datatype = 'f4'):
     
     '''
     Quickly append or overwrite variable data in NetCDF files by leveraging the netCDF4 library. 
@@ -353,7 +353,7 @@ def write_to_netcdf(filename, variables, datatype = 'f4'):
     
     Arguments:
     ----------
-    filename (Path): Name of netCDF file to hold dataset. Can also be a python 3 pathlib instance
+    f (Path): Name of netCDF file to hold dataset. Can also be a python 3 pathlib instance
     variables (dict): dictionary keys are variable names (strings), dictionary values are tuples:
                            (
                                variable data (numpy array - 1D must be same size as variable dimension), 
@@ -370,7 +370,7 @@ def write_to_netcdf(filename, variables, datatype = 'f4'):
     '''
     
     with netCDF4.Dataset(
-        filename = filename,
+        filename = f,
         mode = 'r+',
         format = "NETCDF4"
     ) as ds:
@@ -379,15 +379,15 @@ def write_to_netcdf(filename, variables, datatype = 'f4'):
             
             # check that dimension exists
             if dim not in list(ds.dimensions.keys()):
-                LOG.error("The dimensions %s could not be found in file %s" % (dim, filename))
-                LOG.error("Aborting writing process for %s. No data were written to this file" % filename)
+                LOG.error("The dimensions %s could not be found in file %s" % (dim, f))
+                LOG.error("Aborting writing process for %s. No data were written to this file" % f)
                 return        
             
             # check that dimension size and variable data size agree
             dim_size = ds.dimensions[dim].size
             if vardata.size != dim_size:
                 LOG.error("Cannot write data of size %d to variable with dimension size of %d" % (vardata.size, dim_size))
-                LOG.error("Aborting writing process for %s. No data were written to this file" % filename)
+                LOG.error("Aborting writing process for %s. No data were written to this file" % f)
                 return
             
             # check that varname doesn't already exist

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -250,11 +250,11 @@ def get_ql_from_chrtout(
         
         all_variables = list(ds.variables.keys())
         if qlateral_varname in all_variables:
-            dat = ds.variables[qlateral_varname][:].filled()
+            dat = ds.variables[qlateral_varname][:].filled(fill_value = 0.0)
         
         else:
-            dat = ds.variables[qbucket_varname][:].filled() + \
-                ds.variables[runoff_varname][:].filled()
+            dat = ds.variables[qbucket_varname][:].filled(fill_value = 0.0) + \
+                ds.variables[runoff_varname][:].filled(fill_value = 0.0)
         
     return dat
 

--- a/src/python_framework_v02/troute/nhd_network_utilities_v02.py
+++ b/src/python_framework_v02/troute/nhd_network_utilities_v02.py
@@ -675,6 +675,7 @@ def build_forcing_sets(
 
 def build_qlateral_array(
     forcing_parameters,
+    cpu_pool,
     segment_index=pd.Index([]),
     ts_iterator=None,
     file_run_size=None,
@@ -704,7 +705,7 @@ def build_qlateral_array(
         terrain_ro_col = forcing_parameters.get("qlat_file_terrain_runoff_col","qSfcLatRunoff")
         
         # Parallel reading of qlateral data from CHRTOUT
-        with Parallel(n_jobs=36) as parallel:
+        with Parallel(n_jobs=cpu_pool) as parallel:
 
             jobs = []
             for f in qlat_files:
@@ -722,24 +723,6 @@ def build_qlateral_array(
             columns = range(len(qlat_files))
         )    
         qlat_df = qlat_df[qlat_df.index.isin(segment_index)]
-
-#         qlat_df = nhd_io.get_ql_from_wrf_hydro_mf(
-#             qlat_files=qlat_files,
-#             #ts_iterator=ts_iterator,
-#             #file_run_size=file_run_size,
-#             index_col=qlat_file_index_col,
-#             value_col=qlat_file_value_col,
-#             gw_col = gw_bucket_col,
-#             runoff_col = terrain_ro_col,
-#         )
-
-#         qlat_df = qlat_df[qlat_df.index.isin(segment_index)]
-
-    # TODO: These four lines seem extraneous
-    #    df_length = len(qlat_df.columns)
-    #    for x in range(df_length, 144):
-    #        qlat_df[str(x)] = 0
-    #        qlat_df = qlat_df.astype("float32")
 
     elif qlat_input_file:
         qlat_df = nhd_io.get_ql_from_csv(qlat_input_file)

--- a/src/python_routing_v02/troute/routing/compute.py
+++ b/src/python_routing_v02/troute/routing/compute.py
@@ -254,7 +254,7 @@ def compute_nhd_routing_v02(
 
         start_para_time = time.time()
         # if 1 == 1:
-        with Parallel(n_jobs=cpu_pool, backend="threading") as parallel:
+        with Parallel(n_jobs=cpu_pool, backend="loky") as parallel:
             results_subn = defaultdict(list)
             flowveldepth_interorder = {}
 
@@ -468,7 +468,7 @@ def compute_nhd_routing_v02(
             LOG.info("starting Parallel JIT calculation")
 
         start_para_time = time.time()
-        with Parallel(n_jobs=cpu_pool, backend="threading") as parallel:
+        with Parallel(n_jobs=cpu_pool, backend="loky") as parallel:
             results_subn = defaultdict(list)
             flowveldepth_interorder = {}
 
@@ -652,7 +652,7 @@ def compute_nhd_routing_v02(
             LOG.info("starting Parallel JIT calculation")
 
         start_para_time = time.time()
-        with Parallel(n_jobs=cpu_pool, backend="threading") as parallel:
+        with Parallel(n_jobs=cpu_pool, backend="loky") as parallel:
             results_subn = defaultdict(list)
             flowveldepth_interorder = {}
 
@@ -835,7 +835,7 @@ def compute_nhd_routing_v02(
             LOG.info("PARALLEL TIME %s seconds." % (time.time() - start_para_time))
 
     elif parallel_compute_method == "by-network":
-        with Parallel(n_jobs=cpu_pool, backend="threading") as parallel:
+        with Parallel(n_jobs=cpu_pool, backend="loky") as parallel:
             jobs = []
             for twi, (tw, reach_list) in enumerate(reaches_bytw.items(), 1):
                 # The X_sub lines use SEGS...


### PR DESCRIPTION
This pull request proposes an overhaul of the current workflows used to read forcings from CHRTOUT and write t-route results to CHRTOUT and HYDRO_RST files. I've developed new functions in `nhd_io` that no longer rely on xarray.open_mfdataset or xarray.save_mfdataset. Instead, reading and writing is done with the netCDF4 library. Additionally, calls to read and write data are placed in joblib Parallel loops.

The most important change in the results writing process is that new carbon copies of CHRTOUT and HYDRO_RST files are no longer created. Rather, new variables are simply appended to the same CHRTOUT and HYDRO_RST files used to force and start the t-route simulation.

Much more logging throughout the output process is included, here. 

## New features
- CHRTOUT and HYDRO_RST writing is done with netCDF4 instead of xarray.
- New copies of CHRTOUT and HYDRO_RST files are no longer created, rather data are directly appended.
- Reading forcings from CHRTOUT and writing results to CHRTOUT is parallelized
- Parallel backend in compute.py switched from "threading" to "loky"
- Ported updates to async pathway, getting it back up to speed
