### PR TITLE
Light restart

### DIFF
--- a/doc/v3_doc.yaml
+++ b/doc/v3_doc.yaml
@@ -285,6 +285,18 @@ compute_parameters:
     # optional, defaults to a cold-start
     restart_parameters:
         # ---------------
+        # filepath to a 'lite' channel restart file create by a previous t-route simulation
+        # if a file is specified, then it will be given preference over WRF restart files 
+        # for a simulation restart.
+        # optional, defauls to None and channels are cold-started from zero flow and depth
+        lite_channel_restart_file: 
+        # ---------------
+        # filepath to a 'lite' waterbody restart file create by a previous t-route simulation
+        # if a file is specified, then it will be given preference over WRF restart files 
+        # for a simulation restart.
+        # optional, defauls to None and channels are cold-started from zero flow and depth
+        lite_waterbody_restart_file: 
+        # ---------------
         # filepath to WRF Hydro HYDRO_RST file
         # optional, defauls to None and channels are cold-started from zero flow and depth
         wrf_hydro_channel_restart_file: 
@@ -499,6 +511,14 @@ output_parameters:
         # CHRTOUT files used are the ones we'd want to write results to.
         # (!!) mandatory if writing results to CHRTOUT. Default is to None and results will not be written.
         wrf_hydro_channel_output_source_folder: 
+    # ---------------
+    # parameters controlling the writing of lite restart files
+    # optional, default is None and no lite restart data are created
+    lite_restart:
+        # ---------------
+        # path to directory where channel and waterbody lite restart files will be written to
+        # (!!) mandatory if writing restart data lite files. Default is to None and results will not be written.
+        lite_restart_output_directory:
     # ---------------
     # parameters controlling the writing of restart data to HYDRO_RST netcdf files
     # optional, defauls is None and results restart data is not written

--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -1189,6 +1189,17 @@ def main_v03(argv):
             route_end_time = time.time()
             task_times['route_time'] += route_end_time - route_start_time
 
+        # create initial conditions for next loop itteration
+        q0 = new_nwm_q0(run_results)
+        waterbodies_df = get_waterbody_water_elevation(waterbodies_df, q0)
+        if "lite_restart" in output_parameters:
+            nhd_io.write_lite_restart(
+                q0, 
+                waterbodies_df, 
+                t0 + timedelta(seconds = dt * nts), 
+                output_parameters['lite_restart']
+            )
+        
         # No forcing to prepare for the last loop
         if run_set_iterator < len(run_sets) - 1:
             qlats, usgs_df = nwm_forcing_preprocess(
@@ -1206,11 +1217,6 @@ def main_v03(argv):
             if showtiming:
                 forcing_end_time = time.time()
                 task_times['forcing_time'] += forcing_end_time - route_end_time
-
-            q0 = new_nwm_q0(run_results)
-
-            # TODO: Confirm this works with Waterbodies turned off
-            waterbodies_df = get_waterbody_water_elevation(waterbodies_df, q0)
 
             if waterbody_type_specified:
                 waterbody_parameters = update_lookback_hours(dt, nts, waterbody_parameters)

--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -1192,6 +1192,8 @@ def main_v03(argv):
         # create initial conditions for next loop itteration
         q0 = new_nwm_q0(run_results)
         waterbodies_df = get_waterbody_water_elevation(waterbodies_df, q0)
+        
+        # TODO move the conditional call to write_lite_restart to nwm_output_generator.
         if "lite_restart" in output_parameters:
             nhd_io.write_lite_restart(
                 q0, 

--- a/src/nwm_routing/src/nwm_routing/output.py
+++ b/src/nwm_routing/src/nwm_routing/output.py
@@ -80,7 +80,7 @@ def nwm_output_generator(
         csv_output_segments = csv_output.get("csv_output_segments", None)
 
     
-    if csv_output_folder or rsrto or chrto or True:
+    if csv_output_folder or rsrto or chrto:
         
         start = time.time()
         qvd_columns = pd.MultiIndex.from_product(
@@ -91,7 +91,10 @@ def nwm_output_generator(
             [pd.DataFrame(r[1], index=r[0], columns=qvd_columns) for r in results],
             copy=False,
         )
-        flowveldepth.to_pickle('/glade/scratch/adamw/dev_test')
+        
+        # todo: create a unit test by saving FVD array to disk and then checking that
+        # it matches FVD array from parent branch or other configurations. 
+        # flowveldepth.to_pickle(output_parameters['test_output'])
 
         if return_courant:
             courant_columns = pd.MultiIndex.from_product(

--- a/src/nwm_routing/src/nwm_routing/output.py
+++ b/src/nwm_routing/src/nwm_routing/output.py
@@ -80,7 +80,7 @@ def nwm_output_generator(
         csv_output_segments = csv_output.get("csv_output_segments", None)
 
     
-    if csv_output_folder or rsrto or chrto:
+    if csv_output_folder or rsrto or chrto or True:
         
         start = time.time()
         qvd_columns = pd.MultiIndex.from_product(
@@ -91,6 +91,7 @@ def nwm_output_generator(
             [pd.DataFrame(r[1], index=r[0], columns=qvd_columns) for r in results],
             copy=False,
         )
+        flowveldepth.to_pickle('/glade/scratch/adamw/dev_test')
 
         if return_courant:
             courant_columns = pd.MultiIndex.from_product(

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -1034,6 +1034,75 @@ def get_channel_restart_from_wrf_hydro(
     return q_initial_states
 
 
+def read_lite_restart(
+    file
+):
+    '''
+    Open lite restart pickle files. Can open either waterbody_restart or channel_restart
+    
+    Arguments
+    -----------
+        file (string): File path to lite restart file
+        
+    Returns
+    ----------
+        df (DataFrame): restart states
+        t0 (datetime): restart datetime
+    '''
+    
+    # open pickle file to pandas DataFrame
+    df = pd.read_pickle(pathlib.Path(file))
+    
+    # extract restart time as datetime object
+    t0 = df['time'].iloc[0].to_pydatetime()
+    
+    return df.drop(columns = 'time') , t0
+    
+
+def write_lite_restart(
+    q0, 
+    waterbodies_df, 
+    t0, 
+    restart_parameters
+):
+    '''
+    Save initial conditions dataframes as pickle files
+    
+    Arguments
+    -----------
+        q0 (DataFrame):
+        waterbodies_df (DataFrame):
+        t0 (datetime.datetime):
+        restart_parameters (string):
+        
+    Returns
+    -----------
+        
+    '''
+    
+    output_directory = restart_parameters.get('lite_restart_output_directory', None)
+    if output_directory:
+        
+        # create pathlib object for output directory
+        output_path = pathlib.Path(output_directory)
+        
+        # create restart filenames
+        t0_str = t0.strftime("%Y%m%d%H%M")
+        channel_restart_filename = 'channel_restart_'+t0_str
+        waterbody_restart_filename = 'waterbody_restart_'+t0_str
+        
+        q0_out = q0.copy()
+        q0_out['time'] = t0
+        q0_out.to_pickle(pathlib.Path.joinpath(output_path, channel_restart_filename))
+
+        wbody_initial_states = waterbodies_df.loc[:,['qd0','h0']]
+        wbody_initial_states['time'] = t0
+        wbody_initial_states.to_pickle(pathlib.Path.joinpath(output_path, waterbody_restart_filename))
+        
+    else:
+        LOG.error("Not writing lite restart files. No lite_restart_output_directory variable was not specified in configuration file.")
+    
+
 def write_hydro_rst(
     data,
     restart_files,

--- a/src/python_framework_v02/troute/nhd_io.py
+++ b/src/python_framework_v02/troute/nhd_io.py
@@ -1094,10 +1094,15 @@ def write_lite_restart(
         q0_out = q0.copy()
         q0_out['time'] = t0
         q0_out.to_pickle(pathlib.Path.joinpath(output_path, channel_restart_filename))
+        LOG.debug('Dropped lite channel restart file %s' % pathlib.Path.joinpath(output_path, channel_restart_filename))
 
-        wbody_initial_states = waterbodies_df.loc[:,['qd0','h0']]
-        wbody_initial_states['time'] = t0
-        wbody_initial_states.to_pickle(pathlib.Path.joinpath(output_path, waterbody_restart_filename))
+        if not waterbodies_df.empty:
+            wbody_initial_states = waterbodies_df.loc[:,['qd0','h0']]
+            wbody_initial_states['time'] = t0
+            wbody_initial_states.to_pickle(pathlib.Path.joinpath(output_path, waterbody_restart_filename))
+            LOG.debug('Dropped lite waterbody restart file %s' % pathlib.Path.joinpath(output_path, channel_restart_filename))
+        else:
+            LOG.debug('No lite waterbody restart file dropped becuase waterbodies are either turned off or do not exist in this domain.')
         
     else:
         LOG.error("Not writing lite restart files. No lite_restart_output_directory variable was not specified in configuration file.")


### PR DESCRIPTION
This pull request proposes a light restart capability, whereby final channel and waterbody states are saved to disk as pickle files after each computational loop. In the event that a long term simulation crashes, these restart files can be used to warm start the simulation from a point in time closer to where the simulation failed than the starting initial condition. 

## Testing
- Ensured that my development branch generates the same exact flow, velocity and depth results as the upstream master. In other words, writing-out restart files along the way has no bearing on the physics solution.
- Also ensured that a simulation on the development branch that is warm started from a lite restart file produces the same result as a simulation warm started at an earlier time with a HYDRO_RST file. 
- Ensured that restart writing and reading was successful for simulations in domains with and without waterbodies. 