### PR TITLE
Write flow at gage locations to netCDF (CHANOBS) file

### DIFF
--- a/doc/v3_doc.yaml
+++ b/doc/v3_doc.yaml
@@ -488,8 +488,22 @@ compute_parameters:
 # parameters controlling model outputs
 output_parameters:
     # ---------------
+    # chanobs writing parameters
+    # "CHANOBS" netCDF files contain timeseries of t-route simulated routed flow results
+    # at gage locations only. 
+    # optional, only needed if writing data to CHANOBS (netCDF) files
+    chanobs_output:
+        # ---------------
+        # path to directory where chanobs files will be written
+        # (!!) mandatory if writing chanobs files
+        chanobs_output_directory: 
+        # ---------------
+        # name of netCDF file where chanobs data will be written
+        # (!!) mandatory if writng chanobs files
+        chanobs_filepath:
+    # ---------------
     # csv writing parameters
-    # (!!) mandatory
+    # optional, only needed if writing data to CSV
     # TODO: remove output dependencies on csv_output field, here
     csv_output: 
         # ---------------

--- a/src/nwm_routing/src/nwm_routing/output.py
+++ b/src/nwm_routing/src/nwm_routing/output.py
@@ -217,108 +217,21 @@ def nwm_output_generator(
         
     if chano:
         
-        LOG.info("- writing t-route flow results to CHANOBS file")
+        LOG.info("- writing t-route flow results at gage locations to CHANOBS file")
+        start = time.time()
+                
+        nhd_io.write_chanobs(
+            Path(chano['chanobs_output_directory'] + chano['chanobs_filepath']), 
+            flowveldepth, 
+            link_gage_df, 
+            t0, 
+            dt, 
+            nts,
+            # TODO allow user to pass a list of segments at which they would like to print results
+            # rather than just printing at gages. 
+        )
         
-        gage_feature_id = link_gage_df.index.to_numpy(dtype = "int32")
-        gage_flow_data = flowveldepth.loc[link_gage_df.index].iloc[:,::3].to_numpy(dtype="float32") 
-        
-        gage_flow_time = [t0 + timedelta(seconds = (i+1) * dt) for i in range(nts)]
-#         gage_flow_time = np.arange(
-#             np.datetime64(t0 + timedelta(seconds = dt)),
-#             np.datetime64(t0 + timedelta(seconds = (nts+1)*dt)),
-#             np.timedelta64(dt, 's')
-#         )
-        
-        import netCDF4
-        from cftime import date2num
-        
-        with netCDF4.Dataset(
-            filename = '/glade/scratch/adamw/chanobs_dump/chanobs_test',
-            mode = 'w',
-            format = "NETCDF4"
-        ) as f:
-            
-            # =========== DIMENSIONS ===============
-            _ = f.createDimension("time", nts)
-            _ = f.createDimension("feature_id", len(gage_feature_id))
-            _ = f.createDimension("reference_time", 1)
-            
-            # =========== reference_time VARIABLE ===============
-            REF_TIME = f.createVariable(
-                varname = "reference_time",
-                datatype = 'int32',
-                dimensions = ("reference_time",),
-            )
-            REF_TIME[:] = date2num(
-                t0, 
-                units = "minutes since 1970-01-01 00:00:00 UTC",
-                calendar = "gregorian"
-            )
-            f['reference_time'].setncatts(
-                {
-                    'long_name': 'vaild output time',
-                    'standard_name': 'time',
-                    'units': 'minutes since 1970-01-01 00:00:00 UTC'
-                }
-            )
-            
-            # =========== time VARIABLE ===============
-            TIME = f.createVariable(
-                varname = "time",
-                datatype = 'int32',
-                dimensions = ("time",),
-            )
-            TIME[:] = date2num(
-                gage_flow_time, 
-                units = "minutes since 1970-01-01 00:00:00 UTC",
-                calendar = "gregorian"
-            )
-            f['time'].setncatts(
-                {
-                    'long_name': 'model initialization time',
-                    'standard_name': 'forecast_reference_time',
-                    'units': 'minutes since 1970-01-01 00:00:00 UTC'
-                }
-            )
-            
-            # =========== feature_id VARIABLE ===============
-            FEATURE_ID = f.createVariable(
-                varname = "feature_id",
-                datatype = 'int32',
-                dimensions = ("feature_id",),
-            )
-            FEATURE_ID[:] = gage_feature_id
-            f['feature_id'].setncatts(
-                {
-                    'long_name': 'Reach ID',
-                    'comment': 'NHDPlusv2 ComIDs within CONUS, arbitrary Reach IDs outside of CONUS',
-                    'cf_role:': 'timeseries_id'
-                }
-            )
-            
-            # =========== streamflow VARIABLE ===============            
-            y = f.createVariable(
-                    varname = "streamflow",
-                    datatype = "f4",
-                    dimensions = ("time", "feature_id"),
-                    fill_value = np.nan
-                )
-            y[:] = gage_flow_data
-            
-            # =========== GLOBAL ATTRIBUTES ===============  
-            f.setncatts(
-                {
-                    'model_initialization_time': t0.strftime('%Y-%m-%d_%H:%M:%S'),
-                    'model_output_valid_time': gage_flow_time[0].strftime('%Y-%m-%d_%H:%M:%S'),
-                    'model_total_valid_times': len(gage_flow_time)
-                }
-            )
-            
-        
-        import pdb; pdb.set_trace()
-        # find gage locations
-        
-        
+        LOG.debug("writing flow data to CHANOBS took %s seconds." % (time.time() - start))       
 
     # Write out LastObs as netcdf.
     # Assumed that this capability is only needed for AnA simulations


### PR DESCRIPTION
This PR proposes new output routines for writing flow results at gage locations to "CHANOBS" files. These additions are motivated by NWM3.0 calibration needs. 

## Additions

- new function: `nhd_io.write_chanobs`, which writes flow results from segments co-located with stream gages to netCDF. If the  user-specified netCDF file does not yet exist, one is created. If the user-specified file already exists, flow results are simply appended to it. 
- New output arguments in configuration .yaml file specifying the directory and name of the netCDF file that results are to be written to. 
- New conditional call to `nhd_io.write_chanobs` in  `output.nwm_output_generator` that is activated if chanobs output parameters exist in configuration file. 

## Removals

- None

## Changes

- None

## Testing

1.  Ran a 5.9 year (`nts=622000`) calibration simulation in test basin 06846500 with 1-month loop chunks. Flow results at the catchment outlet (gage location) were written to `/glade/scratch/adamw/chanobs_dump/chanobs_test`. It took about 0.15 seconds to append flows to netCDF output after each loop iteration. Below is a few lines of code I used to open and plot the data:
``` python
import xarray as xr
import pandas as pd

dat = xr.open_dataset("/glade/scratch/adamw/chanobs_dump/chanobs_test").streamflow.to_dataframe()
dat = dat.reset_index().set_index('time')
dat.loc[:,'streamflow'].plot()
```
![image](https://user-images.githubusercontent.com/66840445/145224295-486de48f-c52a-4f52-b0e5-22807bafccc5.png)

2. A parity check between current upstream master and this development branch confirmed that code additions proposed here do no affect flow, velocity, or depth results. 

## Todos

- Writing entire time-series to a single file is really convenient for analysis. Otherwise, we need to stitch together multiple CHRTOUT files or .csv files. Future work may consider allowing users to specify the segments from which flows are written to netCDF. 

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
