### PR TITLE
Write waterbody results to waterbody outlet segments

### DIFF
--- a/src/nwm_routing/src/nwm_routing/__main__.py
+++ b/src/nwm_routing/src/nwm_routing/__main__.py
@@ -1089,6 +1089,7 @@ def main_v03(argv):
             waterbody_types_df,
             break_network_at_waterbodies,
             waterbody_type_specified,
+            link_lake_crosswalk,
             independent_networks,
             reaches_bytw,
             rconn,
@@ -1106,6 +1107,7 @@ def main_v03(argv):
             waterbody_types_df,
             break_network_at_waterbodies,
             waterbody_type_specified,
+            link_lake_crosswalk,
             independent_networks,
             reaches_bytw,
             rconn,
@@ -1308,6 +1310,7 @@ def main_v03(argv):
             data_assimilation_parameters,
             lastobs_df,
             link_gage_df,
+            link_lake_crosswalk,
         )
         
         if showtiming:

--- a/src/nwm_routing/src/nwm_routing/output.py
+++ b/src/nwm_routing/src/nwm_routing/output.py
@@ -22,8 +22,9 @@ def nwm_output_generator(
     return_courant,
     cpu_pool,
     data_assimilation_parameters=False,
-    lastobs_df=None,
-    link_gage_df=None,
+    lastobs_df = None,
+    link_gage_df = None,
+    link_lake_crosswalk = None,
 ):
 
     dt = run.get("dt")

--- a/src/nwm_routing/src/nwm_routing/output.py
+++ b/src/nwm_routing/src/nwm_routing/output.py
@@ -95,6 +95,11 @@ def nwm_output_generator(
             copy=False,
         )
         
+        # replace waterbody lake_ids with outlet link ids
+        if link_lake_crosswalk:
+            for lake, seg in link_lake_crosswalk.items():
+                flowveldepth.rename(index={lake:seg[0]}, inplace = True)
+        
         # todo: create a unit test by saving FVD array to disk and then checking that
         # it matches FVD array from parent branch or other configurations. 
         # flowveldepth.to_pickle(output_parameters['test_output'])
@@ -110,6 +115,11 @@ def nwm_output_generator(
                 ],
                 copy=False,
             )
+            
+            # replace waterbody lake_ids with outlet link ids
+            if link_lake_crosswalk:
+                for lake, seg in link_lake_crosswalk.items():
+                    courant.rename(index={lake:seg[0]}, inplace = True)
             
         LOG.debug("Constructing the FVD DataFrame took %s seconds." % (time.time() - start))
 

--- a/src/nwm_routing/src/nwm_routing/preprocess.py
+++ b/src/nwm_routing/src/nwm_routing/preprocess.py
@@ -65,11 +65,12 @@ def nwm_network_preprocess(
         break_network_at_waterbodies = False
 
     if break_network_at_waterbodies:
-        connections = nhd_network.replace_waterbodies_connections(
+        connections, link_lake_crosswalk = nhd_network.replace_waterbodies_connections(
             connections, wbody_conn
         )
+    else:
+        link_lake_crosswalk = None
 
-    
     LOG.debug("supernetwork connections set complete in %s seconds." % (time.time() - start_time))
 
     ################################
@@ -243,6 +244,7 @@ def nwm_network_preprocess(
                  'waterbody_types_df': waterbody_types_df,
                  'break_network_at_waterbodies': break_network_at_waterbodies,
                  'waterbody_type_specified': waterbody_type_specified,
+                 'link_lake_crosswalk': link_lake_crosswalk,
                  'independent_networks': independent_networks,
                  'reaches_bytw': reaches_bytw,
                  'rconn': rconn,
@@ -281,6 +283,7 @@ def nwm_network_preprocess(
         waterbody_types_df,
         break_network_at_waterbodies,  # Could this be inferred from the wbody_conn or waterbodies_df  # Could this be inferred from the wbody_conn or waterbodies_df? Consider making this name less about the network and more about the reservoir simulation.
         waterbody_type_specified,  # Seems like this could be inferred from waterbody_types_df...
+        link_lake_crosswalk,
         independent_networks,
         reaches_bytw,
         rconn,
@@ -305,6 +308,7 @@ def unpack_nwm_preprocess_data(preprocessing_parameters):
         waterbody_types_df = inputs.get('waterbody_types_df',None)
         break_network_at_waterbodies = inputs.get('break_network_at_waterbodies',None)
         waterbody_type_specified = inputs.get('waterbody_type_specified',None)
+        link_lake_crosswalk = inputs.get('link_lake_crosswalk', None)
         independent_networks = inputs.get('independent_networks',None)
         reaches_bytw = inputs.get('reaches_bytw',None)
         rconn = inputs.get('rconn',None)
@@ -325,6 +329,7 @@ def unpack_nwm_preprocess_data(preprocessing_parameters):
         waterbody_types_df,
         break_network_at_waterbodies,
         waterbody_type_specified,
+        link_lake_crosswalk,
         independent_networks,
         reaches_bytw,
         rconn,


### PR DESCRIPTION
This Pull Request changes the final index values of waterbody nodes in a simulation domain. Specifically, I am proposing to rename the index values on waterbody nodes from lake ids to the segment link id of the waterbody outlet. Without this change, t-route returns NaN values of outflow and depth for waterbody outlet segments in CHRTOUT files, which is inconsistent with required output writing protocol. 
## Additions

- The construction of a new `link_lake` dictionary that relates waterbody lake ids to the corresponding link id of the waterbody outlet segment. This dictionary is created in `nhd_network.replace_waterbodies_connections` and passed throughout framework code as an eventual input argument to `nwm_output_generator`. This dictionary is created by first finding upstream connections of the reservoir shore (first downstream segment), and intersecting the connections set with a set of segments affiliated with that waterbody. This produces a single outlet segment per waterbody. I tested on CONUS to ensure that each waterbody has one and only one outlet segment.
- `flowveldepth` indices for waterbody nodes are renamed from lake id to link id using the newly constructed `link_lake_crosswalk` dictionary. 

## Removals

- None

## Changes

- None

## Testing

1. CONUS domain testing to ensure that all values in the `link_lake` dictionary are all lists of length 1.
2.  Neuse River with waterbodies and all DA. Neuse River with no waterbodies : `/glade/u/home/adamw/projects/t-route/test/jobs/reservoir_debug/neuse.yaml`

## Screenshots


## Notes/todos

- In order to make this happen I needed to generated the reverse connections dictionary for the entire network in `nhd_network.replace_waterbodies_connections`. This gets created again later in the workflow when network reaches are constructed. It takes some time to build this dictionary at CONUS scale, so this PR introduces a minor preprocessing inefficiency that can be addressed later. 
- WRF Hydro writes elevation information for all segments associated with a waterbody. I am not sure where this information stems from. Here, we write waterbody flow and water surface elevation to the last segment in the waterbody. 

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist
- `/glade/u/home/adamw/projects/t-route/test/jobs/reservoir_debug/neuse.yaml`
- Write results to CHRTOUT and make sure that waterbody outflow and water surface elevation are correctly written
