### PR TITLE
speeding up the renaming of flowveldepth indices: lakeid <> segid

### DIFF
--- a/src/python_framework_v02/troute/nhd_network.py
+++ b/src/python_framework_v02/troute/nhd_network.py
@@ -523,7 +523,7 @@ def replace_waterbodies_connections(connections, waterbodies):
             outgoing = reservoir_shore(connections, wbody_nodes)
             new_conn[wbody_code] = outgoing
             
-            link_lake[wbody_code] = list(set(rconn[outgoing[0]]).intersection(set(wbody_nodes)))
+            link_lake[wbody_code] = list(set(rconn[outgoing[0]]).intersection(set(wbody_nodes)))[0]
 
         elif reservoir_boundary(connections, waterbodies, n):
             # one of the children of n is a member of a waterbody


### PR DESCRIPTION
Turns out that the solutions in #516 did not scale nicely to CONUS. This is because pandas `rename()` is slow on very large dataframes, such as the `flowveldepth` dataframe produced for CONUS results. Here, I am rewriting the process of renaming `flowveldepth` index values using numpy, which turns out to be many orders of magnitude faster. 

