### PR TITLE
Streamflow DA bug fix (negative values)

### DIFF
--- a/src/python_routing_v02/troute/routing/fast_reach/simple_da.pyx
+++ b/src/python_routing_v02/troute/routing/fast_reach/simple_da.pyx
@@ -1,4 +1,4 @@
-from libc.math cimport exp, isnan, NAN
+from libc.math cimport exp, isnan, NAN, fabs
 from libc.stdio cimport printf
 
 cpdef float simple_da_with_decay_py(
@@ -119,7 +119,7 @@ cdef float obs_persist_shift(
     """
 
     cdef float da_weight, da_shift, da_weighted_shift
-    da_weight = exp(minutes_since_last_valid/-decay_coeff)  # TODO: This could be pre-calculated knowing when obs finish relative to simulation time
+    da_weight = exp(fabs(minutes_since_last_valid)/-decay_coeff)  # TODO: This could be pre-calculated knowing when obs finish relative to simulation time
     # TODO: we need to be able to export these values to compute the 'Nudge'
     # One possibility would be to return only the nudge from this function...
     da_shift = last_valid_obs - model_val


### PR DESCRIPTION
Further testing of t-routes DA scheme at CONUS scale revealed some issues that were not observed at smaller development scales. In particular, there were negative and -Inf values appearing at gage locations. As it turns out, the DA-decay method had but in it. Specifically, the DA weight value is: `da_weight = exp(time_since_lastobs/ decay_coeff)`, where `time_since_lastobs` is the number of minutes since the last quality observation was taken at the gage. Per this, equation `time_since_lastobs` should not be a negative value, but the existing code was simulating as such. 

Elaborating a bit more with some context. The DA weight is weight that a simulated value is given relative to the last observation. When the last observation occurred very recently, the weight on the simulated value should be minimal because it is unlikely that actual (observed) streamflow underwent a large change in a brief amount of time. On the other hand, when it has been a while since the last quality observation, then the DA weight should be large. In either case, the DA weight value should never be greater than 1. The only way to make this happen is if the `time_since_lastobs` is always a positive value. 

Regardless of the math and logic, the implemented changes in this PR do away with negative and -Inf values appearing in the streamflow simulations at gage locations. 

## Additions

- absolute value operation on `time_since_lastobs` in `simple_da.pyx`

## Removals

- None

## Changes

- None

## Testing

1. Isolated two problematic gages (`06400875` and `09386950`) where CONUS testing was showing negative values in the simulated streamflow record. Confirmed the results observed at CONUS scale. Confirmed that the requested changed here ameliorated these issues. 
