### PR TITLE
lake<>segment indexing fix and qlateral preference change

### DIFF
--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -287,8 +287,11 @@ def get_ql_from_chrtout(
 ):
     '''
     Return an array of qlateral data from a single CHRTOUT netCDF4 file.
-    If the lateral inflow variable is not present in the file, then calculate
-    lateral inflow as the sum of qbucket and surface runoff.
+    Lateral inflows to any segment are calculated as the sum of qBucket
+    and qSfcLatRunoff variables. In the event that one or both of these
+    variables are not available, then the q_lateral variable is used. In
+    the event that none of these variables are available an error will be
+    thrown and the simulation will stop. 
     
     Arguments
     ---------
@@ -307,12 +310,11 @@ def get_ql_from_chrtout(
     ) as ds:
         
         all_variables = list(ds.variables.keys())
-        if qlateral_varname in all_variables:
-            dat = ds.variables[qlateral_varname][:].filled(fill_value = 0.0)
-        
-        else:
+        if qbucket_varname in all_variables and runoff_varname in all_variables:
             dat = ds.variables[qbucket_varname][:].filled(fill_value = 0.0) + \
                 ds.variables[runoff_varname][:].filled(fill_value = 0.0)
+        else:
+            dat = ds.variables[qlateral_varname][:].filled(fill_value = 0.0)
         
     return dat
 

--- a/src/troute-network/troute/nhd_network_utilities_v02.py
+++ b/src/troute-network/troute/nhd_network_utilities_v02.py
@@ -728,7 +728,10 @@ def build_qlateral_array(
 
             jobs = []
             for f in qlat_files:
-                jobs.append(delayed(nhd_io.get_ql_from_chrtout)(f))
+                jobs.append(
+                    delayed(nhd_io.get_ql_from_chrtout)
+                    (f, qlat_file_value_col, gw_bucket_col, terrain_ro_col)
+                )
             ql_list = parallel(jobs)
 
         # get feature_id from a single CHRTOUT file

--- a/src/troute-nwm/src/nwm_routing/output.py
+++ b/src/troute-nwm/src/nwm_routing/output.py
@@ -106,7 +106,7 @@ def nwm_output_generator(
             
             # replace lake IDs with segment IDs in the flowveldepth index array
             segids = np.fromiter(link_lake_crosswalk.values(), dtype = int)
-            fvdidxs[lake_index_intersect[1]] = segids
+            fvdidxs[lake_index_intersect[1]] = segids[lake_index_intersect[2]]
             
             # (re) set the flowveldepth index
             flowveldepth.set_index(fvdidxs, inplace = True)


### PR DESCRIPTION
This Pull Request proposes a bug fix and a change.

- A bug was found in PR #520, whereby waterbody outflow (and water elevation) values were being written to the wrong waterbodies. Here, we fix the indexing such that we are writing results to the correct waterbody outlet segments.
- We explicitly change the preferred source of lateral inflow data in CHRTOUT files. Instead of preferring to get lateral inflow data from the `q_lateral` variable, we no prefer to get lateral inflow from the sum of `qBucket` and `qScfLatRunff` terms. The reason for this change is to conform with WRF-Hydro's routing model.