### PR TITLE
Break network at gages for streamflow DA

### DIFF
--- a/doc/v3_doc.yaml
+++ b/doc/v3_doc.yaml
@@ -86,11 +86,6 @@ network_topology_parameters:
         # optional, default to zero
         mask_key: 
         # ---------------
-        # logical, if True gaged segments occupy a reach of their own
-        # defaults to False
-        # (!!) mandatory for DA simulations
-        break_network_at_gages: 
-        # ---------------
         # attribute names in channel geometry file (Route_Link.nc)
         # optional, defaults to attribute names in WRF RouteLink.nc
         # This section is only needed if, for whatever reason, the channel
@@ -385,11 +380,11 @@ compute_parameters:
     # simulations is desired.
     hybrid_parameters:
         # ---------------
-        # boolean paramete whether or not hybrid routing is actived.
+        # boolean parameter whether or not hybrid routing is actived.
         # If it is set to True, the hybrid routing is activated. If false, 
         # MC is solely used for channel flow routing.
         # (!!) mandatory for hybrid simulations
-        run_hybrid_domain:
+        run_hybrid_routing:
         # ---------------
         # filepath to diffusive domain dictionary file. 
         # This file can be either JSON or yaml and contain a dictionary

--- a/src/troute-network/troute/nhd_network.py
+++ b/src/troute-network/troute/nhd_network.py
@@ -289,6 +289,48 @@ def split_at_junction(network, path, node):
     '''
     return len(network[node]) == 1
 
+def split_at_gages_waterbodies_and_junctions(gage_nodes, waterbody_nodes, network, path, node):
+    '''
+    
+    Arguments:
+    ----------
+    gage_nodes
+    waterbody_nodes
+    network
+    path
+    node
+    
+    Returns:
+    --------
+    (bool): False if segment is a network break point, True otherwise
+    
+    ''' 
+    if (path[-1] in gage_nodes) | (node in gage_nodes):
+        return False  # force a path split if coming from or going to a gage node
+    if (path[-1] in waterbody_nodes) ^ (node in waterbody_nodes):
+        return False  # force a path split if entering or exiting a waterbody
+    else:
+        return len(network[node]) == 1
+
+def split_at_gages_and_junctions(gage_nodes, network, path, node):
+    '''
+    
+    Arguments:
+    ----------
+    gage_nodes
+    network
+    path
+    node
+    
+    Returns:
+    --------
+    (bool): False if segment is a network break point, True otherwise
+    
+    '''
+    if (path[-1] in gage_nodes) | (node in gage_nodes):
+        return False  # force a path split if entering or exiting a waterbody
+    else:
+        return len(network[node]) == 1
 
 def split_at_waterbodies_and_junctions(waterbody_nodes, network, path, node):
     '''

--- a/src/troute-network/troute/nhd_network_utilities_v02.py
+++ b/src/troute-network/troute/nhd_network_utilities_v02.py
@@ -130,7 +130,7 @@ def build_connections(supernetwork_parameters):
 
     return connections, param_df, wbodies, gages
 
-def organize_independent_networks(connections, break_nodes=None):
+def organize_independent_networks(connections, wbody_break_segments, gage_break_segments):
     '''
     Build reverse network connections, independent drainage networks, and network reaches.
     Reaches are defined as linearly connected segments between two junctions or break points.

--- a/src/troute-network/troute/nhd_network_utilities_v02.py
+++ b/src/troute-network/troute/nhd_network_utilities_v02.py
@@ -138,7 +138,8 @@ def organize_independent_networks(connections, wbody_break_segments, gage_break_
     Arguments:
     ----------
     connections (dict, int: [int]): downstream network connections
-    break_nodes              (set): segment ids where network reaches are broken
+    wbody_break_segments     (set): waterbody segments to break reaches at inlets/outlets
+    gage_break_segments      (set): gage ids to break reaches at gages
     
     Returns:
     --------

--- a/src/troute-network/troute/nhd_network_utilities_v02.py
+++ b/src/troute-network/troute/nhd_network_utilities_v02.py
@@ -159,12 +159,36 @@ def organize_independent_networks(connections, wbody_break_segments, gage_break_
     # construct network reaches
     reaches_bytw = {}
     for tw, net in independent_networks.items():
-        if break_nodes:
+        
+        # break reaches at waterbody inlets/outlets, gages and junctions
+        if wbody_break_segments and gage_break_segments:
             
-            # reaches will be broken between junctions and specified break nodes
             path_func = partial(
-                nhd_network.split_at_waterbodies_and_junctions, set(break_nodes), net
+                nhd_network.split_at_gages_waterbodies_and_junctions, 
+                gage_break_segments, 
+                wbody_break_segments, 
+                net
             )
+            
+        # break reaches at gages and junctions
+        elif gage_break_segments and not wbody_break_segments:
+            
+            path_func = partial(
+                nhd_network.split_at_gages_and_junctions, 
+                gage_break_segments, 
+                net
+            )
+        
+        # break network at waterbody inlets/outlets and junctions
+        elif wbody_break_segments and not gage_break_segments:
+            
+            path_func = partial(
+                nhd_network.split_at_waterbodies_and_junctions, 
+                wbody_break_segments, 
+                net
+            )
+            
+        # break reaches at junctions
         else:
             
             # reaches will be broken between junctions

--- a/src/troute-nwm/src/nwm_routing/preprocess.py
+++ b/src/troute-nwm/src/nwm_routing/preprocess.py
@@ -122,9 +122,12 @@ def nwm_network_preprocess(
     break_network_at_waterbodies = waterbody_parameters.get(
         "break_network_at_waterbodies", False
     )
-    break_network_at_gages = supernetwork_parameters.get(
-        "break_network_at_gages", False
-    )
+    
+    # if streamflow DA, then break network at gages
+    break_network_at_gages = False
+    streamflow_da = data_assimilation_parameters.get('streamflow_da', False)
+    if streamflow_da:
+        break_network_at_gages = streamflow_da.get('streamflow_nudging', False)
 
     if not wbody_conn: 
         # Turn off any further reservoir processing if the network contains no 

--- a/src/troute-nwm/src/nwm_routing/preprocess.py
+++ b/src/troute-nwm/src/nwm_routing/preprocess.py
@@ -134,7 +134,7 @@ def nwm_network_preprocess(
         # waterbodies
         break_network_at_waterbodies = False
 
-    # if waterbodies are being simulated, udjust the connections graph so that 
+    # if waterbodies are being simulated, adjust the connections graph so that 
     # waterbodies are collapsed to single nodes. Also, build a mapping between 
     # waterbody outlet segments and lake ids
     if break_network_at_waterbodies:

--- a/src/troute-nwm/src/nwm_routing/preprocess.py
+++ b/src/troute-nwm/src/nwm_routing/preprocess.py
@@ -280,15 +280,18 @@ def nwm_network_preprocess(
     LOG.info("organizing connections into reaches ...")
     start_time = time.time()
     
-    network_break_segments = set()
+    gage_break_segments = set()
+    wbody_break_segments = set()
     if break_network_at_waterbodies:
-        network_break_segments = network_break_segments.union(wbody_conn.values())
+        wbody_break_segments = wbody_break_segments.union(wbody_conn.values())
+        
     if break_network_at_gages:
-        network_break_segments = network_break_segments.union(gages['gages'].keys())
+        gage_break_segments = gage_break_segments.union(gages['gages'].keys())
         
     independent_networks, reaches_bytw, rconn = nnu.organize_independent_networks(
         connections,
-        network_break_segments,
+        wbody_break_segments,
+        gage_break_segments,
     )
     
     LOG.debug("reach organization complete in %s seconds." % (time.time() - start_time))

--- a/src/troute-routing/troute/routing/compute.py
+++ b/src/troute-routing/troute/routing/compute.py
@@ -234,14 +234,32 @@ def compute_nhd_routing_v02(
             for subn_tw, subnet in ordered_subn_dict.items():
                 conn_subn = {k: connections[k] for k in subnet if k in connections}
                 rconn_subn = {k: rconn[k] for k in subnet if k in rconn}
-                if waterbodies_df.empty:
-                    path_func = partial(nhd_network.split_at_junction, rconn_subn)
-                else:
+                
+                if not waterbodies_df.empty and not usgs_df.empty:
+                    path_func = partial(
+                        nhd_network.split_at_gages_waterbodies_and_junctions,
+                        set(usgs_df.index.values),
+                        set(waterbodies_df.index.values),
+                        rconn_subn
+                        )
+                
+                elif waterbodies_df.empty and not usgs_df.empty:
+                    path_func = partial(
+                        nhd_network.split_at_gages_and_junctions,
+                        set(usgs_df.index.values),
+                        rconn_subn
+                        )
+                
+                elif not waterbodies_df.empty and usgs_df.empty:
                     path_func = partial(
                         nhd_network.split_at_waterbodies_and_junctions,
                         set(waterbodies_df.index.values),
                         rconn_subn
                         )
+                
+                else:
+                    path_func = partial(nhd_network.split_at_junction, rconn_subn)
+                
                 reaches_ordered_bysubntw[order][
                     subn_tw
                 ] = nhd_network.dfs_decomposition(rconn_subn, path_func)
@@ -498,14 +516,30 @@ def compute_nhd_routing_v02(
             for subn_tw, subnet in ordered_subn_dict.items():
                 conn_subn = {k: connections[k] for k in subnet if k in connections}
                 rconn_subn = {k: rconn[k] for k in subnet if k in rconn}
-                if waterbodies_df.empty:
-                    path_func = partial(nhd_network.split_at_junction, rconn_subn)
-                else:
+                if not waterbodies_df.empty and not usgs_df.empty:
+                    path_func = partial(
+                        nhd_network.split_at_gages_waterbodies_and_junctions,
+                        set(usgs_df.index.values),
+                        set(waterbodies_df.index.values),
+                        rconn_subn
+                        )
+                
+                elif waterbodies_df.empty and not usgs_df.empty:
+                    path_func = partial(
+                        nhd_network.split_at_gages_and_junctions,
+                        set(usgs_df.index.values),
+                        rconn_subn
+                        )
+                
+                elif not waterbodies_df.empty and usgs_df.empty:
                     path_func = partial(
                         nhd_network.split_at_waterbodies_and_junctions,
                         set(waterbodies_df.index.values),
                         rconn_subn
                         )
+                
+                else:
+                    path_func = partial(nhd_network.split_at_junction, rconn_subn)
                 reaches_ordered_bysubntw[order][
                     subn_tw
                 ] = nhd_network.dfs_decomposition(rconn_subn, path_func)


### PR DESCRIPTION
This pull request proposes changes to properly construct reaches between gages. For streamflow DA, gage nodes should always be the terminal nodes in a reach. This way, the assimilated data can be routed downstream to the adjacent node. As describe in issue #528, the existing reach construction process failed to construct reaches around immediately adjacent gage nodes. 

## Additions

- New splitting functions `nhd_network.split_at_gages_waterbodies_and_junctions`,  `nhd_network.split_at_gages_and_junctions`, that force breaks at gages,  waterbody inlets/outlets, & junctions and gages & junctions, respectively . These splitting functions are used by `dfs_decomposition` to identify where one reach ends and another begins. 

## Changes

- The parameter `break_network_at_gages` is no longer necessary in the yaml configuration file. Instead, if the user turns on streamflow data assimilation (i.e. `streamflow_nudging == True`), then reaches are automatically broken at gage nodes. 
- Subnetwork reach creation that occurs in `compute.py` for `by-subnetwork-jit` and `by-subnetwork-jit-clustered` parallel options was not acknowledging gage break points. I have updated the code in `compute.py` to fix this. 

## Testing

I have isolated to small simulations to demonstrate both the problem and solution:
- `/glade/u/home/adamw/projects/t-route/test/jobs/cypress_creek.yaml`
- `/glade/u/home/adamw/projects/t-route/test/jobs/kinnickinnic.yaml`

Both simulations launched by these configuration files are for small domains, 500 timesteps, with streamflow DA turned ON. Outputs are written to "chanobs" files, which only store routed flow results at gage nodes.

To understand the initial problem do the following:
1. Checkout out the current t-route master
2. Copy the yaml configuration files from my directory to a directory of your own. 
3. Edit the 'chanobs_output_directory:` parameter in the configuration file so that the chanobs file is written to a destination in your file space. 
4. Run the simulations (e.g. `python -m nwm_routing -f kinnickinnic.yaml`)
5. Use a Jupyter notebook to plot flow results at segment `12164326` in the Kinnickinnic domain and segment `21478146` in the Cypress Creek domain. You should observe that data assimilation does NOT occur at these segments, even though they are gage nodes and data assimilation should happen. 
6. Checkout the development branch I am PR-ing from, here. No need to recompile because all changes are in Python. 
7. Delete the chanobs files created by the previous simulation (e.g. `rm /my/directory/where/kinnickinnic`).
8. Re-run the simulations.
9. Re-plot the results and you should see that DA is happening as expected. 

## Screenshots
Kinnickinnic domain, segment `12164326` before the proposed fix - no DA happening:
![image](https://user-images.githubusercontent.com/66840445/155576547-58fdee8d-45e0-408c-9e37-a6b5caa6e24c.png)

Kinnickinnic domain, segment `12164326` after the proposed fix - DA happening as expected:
![image](https://user-images.githubusercontent.com/66840445/155575368-68f9890e-cd04-46a4-ac93-a78d4b686597.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:


