### PR TITLE
hotfix for diffusive wave independent networks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ __pycache__/
 *.py[cod]
 .env
 .python-version
+.ipynb_checkpoints/
 
 # pyenv #
 #########

--- a/src/troute-nwm/src/nwm_routing/preprocess.py
+++ b/src/troute-nwm/src/nwm_routing/preprocess.py
@@ -293,6 +293,7 @@ def nwm_network_preprocess(
             _, reaches, rconn_diff = nnu.organize_independent_networks(
                 diffusive_network_data[tw]['connections'],
                 set(trib_segs),
+                set(),
             )
             diffusive_network_data[tw]['rconn'] = rconn_diff
             diffusive_network_data[tw]['reaches'] = reaches[tw]


### PR DESCRIPTION
hotfix to `preprocessing.py` to fix missing gage segment set argument in organize_independent_networks.

## Additions

- adding .ipynb_checkpoints/ to .gitignore to reduce unwanted commits


## Changes

- adding empty set arg to organize_independent_networks when building build diffusive domain data

## Testing

- no errors when running `test_AnA.yaml` using both True and False for `run_hybrid_domain`
