### PR TITLE
Expedite time slice interpolation routine

### DIFF
--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -1015,8 +1015,21 @@ def _read_timeslice_file(f):
     
     return timeslice_observations, observation_quality
 
+def _interpolate_one(df, interpolation_limit, frequency):
+    
+    interp_out = (df.resample('min').
+                        interpolate(
+                            limit = interpolation_limit, 
+                            limit_direction = 'both'
+                        ).
+                        resample(frequency).
+                        asfreq().
+                        to_numpy()
+                       )
+    return interp_out
+
 def get_obs_from_timeslices(
-    crosswalk_file,
+    crosswalk_df,
     crosswalk_gage_field,
     crosswalk_dest_field,
     timeslice_files,
@@ -1024,21 +1037,18 @@ def get_obs_from_timeslices(
     interpolation_limit,
     frequency_secs,
     t0,
-    cpu_pool
+    cpu_pool, 
 ):
     """
     Read observations from TimeSlice files, interpolate available observations
     and organize into a Pandas DataFrame
     
     Aguments
-    --------
-    - crosswalk_file               (str): full directory path to channel segment 
-                                          cross walk file (RouteLink.nc)
-                                          
-    - crosswalk_gage_field         (str): fieldname of gage ID data in crosswalk file
+    --------                                          
+    - crosswalk_gage_field         (str): fieldname of gage ID data in crosswalk dataframe
     
-    - crosswalk_dest_field         (str): fieldname of destination data in crosswalk 
-                                          file. For streamflow DA, this is the field
+    - crosswalk_dest_field         (str): fieldname of destination data in link_gage_df. 
+                                          For streamflow DA, this is the field
                                           containing segment IDs. For reservoir DA, 
                                           this is the field containing waterbody IDs.
                                           
@@ -1055,7 +1065,7 @@ def get_obs_from_timeslices(
     - t0                       (datetime): Initialization time of simulation set
     
     - cpu_pool                      (int): Number of CPUs used for parallel 
-                                           TimeSlice reading
+                                           TimeSlice reading and interolation
     
     Returns
     -------
@@ -1092,51 +1102,20 @@ def get_obs_from_timeslices(
     # concatenate dataframes
     timeslice_obs_df  = pd.concat(timeslice_obs_frames, axis = 1)
     timeslice_qual_df = pd.concat(timeslice_qual_frames, axis = 1)   
-        
-    # Open the cross walk file and build a dataframe of gages and their corresponding
-    # linkID locations. This dataframe will be joined to the `timeslice_obs_df`, so 
-    # that gage observations are indexed by linkID, rather than gageID. 
-    #
-    # TODO: Re-write this section to allow the crosswalk file to be flexile. For 
-    # reservoir DA, we would use a differenct cross walk (gage<>waterbody) than 
-    # we would for streamflow DA. 
-    #
-    with xr.open_dataset(crosswalk_file) as ds:
-        
-        # assemble list of gage IDs as bytestrings, this list includes
-        # the entire gages variable from the crosswalk file, most of which
-        # are empty because most segments are not co-loacated with gages
-        gage_list = list(map(bytes.strip, ds[crosswalk_gage_field].values))
-
-        # create mask for populated (alphanumeric) gage IDs
-        gage_mask = list(map(bytes.isalnum, gage_list))
-        
-        # apply mask to gage_list, isolating only populated gage IDs
-        gage_da   = list(map(bytes.strip, ds[crosswalk_gage_field][gage_mask].values))
-        
-        # convert gage IDs to unicode strings
-        gage_da   = np.asarray(gage_da).astype('<U15')
-
-        # package crosswalk data into a dictionary
-        data_var_dict = {
-            crosswalk_gage_field: gage_da,
-            crosswalk_dest_field: ds[crosswalk_dest_field].values[gage_mask]
-            }
-        
-        # construct crosswalk dataframe, set gage ID field as index
-        df = (pd.DataFrame(data = data_var_dict).
-              set_index(crosswalk_gage_field))
-        
+      
+    # Link <> gage crosswalk data
+    df = crosswalk_df.reset_index()
+    df[crosswalk_gage_field] = np.asarray(df[crosswalk_gage_field]).astype('<U15')
+    df = df.set_index(crosswalk_gage_field)
+    
     # join crosswalk data with timeslice data, indexed on crosswalk destination field
     observation_df = (df.join(timeslice_obs_df).
                reset_index().
-               rename(columns={"index": crosswalk_gage_field}).
                set_index(crosswalk_dest_field).
                drop([crosswalk_gage_field], axis=1))
 
     observation_qual_df = (df.join(timeslice_qual_df).
                reset_index().
-               rename(columns={"index": crosswalk_gage_field}).
                set_index(crosswalk_dest_field).
                drop([crosswalk_gage_field], axis=1))
 
@@ -1163,14 +1142,31 @@ def get_obs_from_timeslices(
     frequency = str(int(frequency_secs/60))+"min"    
     
     # interpolate and resample frequency
-    observation_df_T = (observation_df_T.resample('min').
-                        interpolate(
-                            limit = interpolation_limit, 
-                            limit_direction = 'both'
-                        ).
-                        resample(frequency).
-                        asfreq()
-                       )
+    buffer_df = observation_df_T.resample(frequency).asfreq()
+    with Parallel(n_jobs=cpu_pool) as parallel:
+        
+        jobs = []
+        interp_chunks = ()
+        step = 200
+        for a, i in enumerate(range(0, len(observation_df_T.columns), step)):
+            
+            start = i
+            if (i+step-1) < buffer_df.shape[1]:
+                stop = i+(step)
+            else:
+                stop = buffer_df.shape[1]
+                
+            jobs.append(
+                delayed(_interpolate_one)(observation_df_T.iloc[:,start:stop], interpolation_limit, frequency)
+            )
+            
+        interp_chunks = parallel(jobs)
+
+    observation_df_T = pd.DataFrame(
+        data = np.concatenate(interp_chunks, axis = 1), 
+        columns = buffer_df.columns, 
+        index = buffer_df.index
+    )
     
     # re-transpose, making link the index
     observation_df_new = observation_df_T.transpose()

--- a/src/troute-nwm/src/nwm_routing/__main__.py
+++ b/src/troute-nwm/src/nwm_routing/__main__.py
@@ -311,6 +311,8 @@ def main_v03(argv):
             reaches_bytw,
             rconn,
             link_gage_df,
+            usgs_lake_gage_crosswalk, 
+            usace_lake_gage_crosswalk,
             diffusive_network_data,
             topobathy_data,
         ) = nwm_network_preprocess(
@@ -381,11 +383,14 @@ def main_v03(argv):
         break_network_at_waterbodies,
         segment_index,
         link_gage_df,
+        usgs_lake_gage_crosswalk, 
+        usace_lake_gage_crosswalk,
         link_lake_crosswalk,
         lastobs_df.index,
         cpu_pool,
         t0,
     )
+    
         
     if showtiming:
         forcing_end_time = time.time()
@@ -469,6 +474,8 @@ def main_v03(argv):
                 break_network_at_waterbodies,
                 segment_index,
                 link_gage_df,
+                usgs_lake_gage_crosswalk, 
+                usace_lake_gage_crosswalk,
                 link_lake_crosswalk,
                 lastobs_df.index,
                 cpu_pool,

--- a/src/troute-nwm/src/nwm_routing/__main__.py
+++ b/src/troute-nwm/src/nwm_routing/__main__.py
@@ -290,6 +290,8 @@ def main_v03(argv):
             reaches_bytw,
             rconn,
             link_gage_df,
+            usgs_lake_gage_crosswalk, 
+            usace_lake_gage_crosswalk,
             diffusive_network_data,
             topobathy_data,
         ) = unpack_nwm_preprocess_data(

--- a/src/troute-nwm/src/nwm_routing/preprocess.py
+++ b/src/troute-nwm/src/nwm_routing/preprocess.py
@@ -403,7 +403,9 @@ def nwm_network_preprocess(
         independent_networks,
         reaches_bytw,
         rconn,
-        pd.DataFrame.from_dict(gages),
+        link_gage_df,
+        usgs_lake_gage_crosswalk, 
+        usace_lake_gage_crosswalk,
         diffusive_network_data,
         topobathy_data,
     )
@@ -673,6 +675,8 @@ def nwm_forcing_preprocess(
     break_network_at_waterbodies,
     segment_index,
     link_gage_df,
+    usgs_lake_gage_crosswalk, 
+    usace_lake_gage_crosswalk,
     link_lake_crosswalk,
     lastobs_index,
     cpu_pool,
@@ -1010,7 +1014,7 @@ def nwm_forcing_preprocess(
         if usgs_files:
             
             reservoir_usgs_df = nhd_io.get_obs_from_timeslices(
-                crosswalk_file,
+                usgs_lake_gage_crosswalk,
                 crosswalk_gage_field,
                 crosswalk_lakeID_field,
                 usgs_files,
@@ -1071,7 +1075,7 @@ def nwm_forcing_preprocess(
                 
         if usace_files:
             reservoir_usace_df = nhd_io.get_obs_from_timeslices(
-                crosswalk_file,
+                usace_lake_gage_crosswalk,
                 crosswalk_gage_field,
                 crosswalk_lakeID_field,
                 usace_files,

--- a/src/troute-nwm/src/nwm_routing/preprocess.py
+++ b/src/troute-nwm/src/nwm_routing/preprocess.py
@@ -157,6 +157,9 @@ def nwm_network_preprocess(
         supernetwork_parameters,
     )
     
+    link_gage_df = pd.DataFrame.from_dict(gages)
+    link_gage_df.index.name = 'link'
+    
     break_network_at_waterbodies = waterbody_parameters.get(
         "break_network_at_waterbodies", False
     )

--- a/src/troute-nwm/src/nwm_routing/preprocess.py
+++ b/src/troute-nwm/src/nwm_routing/preprocess.py
@@ -449,6 +449,8 @@ def unpack_nwm_preprocess_data(preprocessing_parameters):
         reaches_bytw = inputs.get('reaches_bytw',None)
         rconn = inputs.get('rconn',None)
         gages = inputs.get('link_gage_df',None)
+        usgs_lake_gage_crosswalk = inputs.get('usgs_lake_gage_crosswalk',None)
+        usace_lake_gage_crosswalk = inputs.get('usace_lake_gage_crosswalk',None)
         diffusive_network_data = inputs.get('diffusive_network_data',None)
         topobathy_data = inputs.get('topobathy_data',None)
                 
@@ -469,6 +471,8 @@ def unpack_nwm_preprocess_data(preprocessing_parameters):
         reaches_bytw,
         rconn,
         gages,
+        usgs_lake_gage_crosswalk, 
+        usace_lake_gage_crosswalk,
         diffusive_network_data,
         topobathy_data,
     )

--- a/src/troute-nwm/src/nwm_routing/preprocess.py
+++ b/src/troute-nwm/src/nwm_routing/preprocess.py
@@ -866,7 +866,7 @@ def nwm_forcing_preprocess(
         if usgs_files:
             usgs_df = (
                 nhd_io.get_obs_from_timeslices(
-                    crosswalk_file,
+                    link_gage_df,
                     crosswalk_gage_field,
                     crosswalk_segID_field,
                     usgs_files,

--- a/src/troute-nwm/src/nwm_routing/preprocess.py
+++ b/src/troute-nwm/src/nwm_routing/preprocess.py
@@ -379,6 +379,8 @@ def nwm_network_preprocess(
                  'reaches_bytw': reaches_bytw,
                  'rconn': rconn,
                  'link_gage_df': link_gage_df,
+                 'usgs_lake_gage_crosswalk': usgs_lake_gage_crosswalk, 
+                 'usace_lake_gage_crosswalk': usace_lake_gage_crosswalk,
                  'diffusive_network_data': diffusive_network_data,
                  'topobathy_data': topobathy_data,
                 }

--- a/src/troute-nwm/src/nwm_routing/preprocess.py
+++ b/src/troute-nwm/src/nwm_routing/preprocess.py
@@ -247,22 +247,34 @@ def nwm_network_preprocess(
 
         if param_file and reservoir_da:
             waterbody_type_specified = True
-            waterbody_types_df = nhd_io.read_reservoir_parameter_file(
+            (
+                waterbody_types_df, 
+                usgs_lake_gage_crosswalk, 
+                usace_lake_gage_crosswalk
+            ) = nhd_io.read_reservoir_parameter_file(
                 param_file,
                 usgs_hybrid,
                 usace_hybrid,
                 rfc_forecast,
                 level_pool_params.get("level_pool_waterbody_id", 'lake_id'),
+                reservoir_da.get('crosswalk_usgs_gage_field', 'usgs_gage_id'),
+                reservoir_da.get('crosswalk_usgs_lakeID_field', 'usgs_lake_id'),
+                reservoir_da.get('crosswalk_usace_gage_field', 'usace_gage_id'),
+                reservoir_da.get('crosswalk_usace_lakeID_field', 'usace_lake_id'),
                 wbody_conn.values(),
             )
         else:
             waterbody_type_specified = True
             waterbody_types_df = pd.DataFrame(data = 1, index = waterbodies_df.index, columns = ['reservoir_type'])
+            usgs_lake_gage_crosswalk = None
+            usace_lake_gage_crosswalk = None
 
     else:
         # Declare empty dataframes
         waterbody_types_df = pd.DataFrame()
         waterbodies_df = pd.DataFrame()
+        usgs_lake_gage_crosswalk = None
+        usace_lake_gage_crosswalk = None
 
     #============================================================================
     # build diffusive domain data and edit MC domain data for hybrid simulation

--- a/src/troute-nwm/src/nwm_routing/preprocess.py
+++ b/src/troute-nwm/src/nwm_routing/preprocess.py
@@ -378,7 +378,7 @@ def nwm_network_preprocess(
                  'independent_networks': independent_networks,
                  'reaches_bytw': reaches_bytw,
                  'rconn': rconn,
-                 'link_gage_df': pd.DataFrame.from_dict(gages),
+                 'link_gage_df': link_gage_df,
                  'diffusive_network_data': diffusive_network_data,
                  'topobathy_data': topobathy_data,
                 }

--- a/src/troute-nwm/src/nwm_routing/preprocess.py
+++ b/src/troute-nwm/src/nwm_routing/preprocess.py
@@ -955,12 +955,13 @@ def nwm_forcing_preprocess(
             "Creating a DataFrame of USGS gage observations for Reservoir DA ..."
         )
         
+        
         # build dataframe that crosswalks segmentIDs to lakeIDs
         link_lake_df = (
             gage_lake_df.
             join(gage_link_df, how = 'inner').
-            reset_index().set_index('index').
-            drop(['level_0'], axis = 1)
+            reset_index().set_index('link').
+            drop(['index'], axis = 1)
         )
         
         # resample `usgs_df` to 15 minute intervals

--- a/src/troute-nwm/src/nwm_routing/preprocess.py
+++ b/src/troute-nwm/src/nwm_routing/preprocess.py
@@ -926,18 +926,11 @@ def nwm_forcing_preprocess(
     # create crosswalking dataframes and identify USGS lakeIDs in the model domain
     if usgs_persistence:
         
-        crosswalk_file = reservoir_da_parameters["gage_lakeID_crosswalk_file"]
-        crosswalk_file = pathlib.Path(crosswalk_file)
-        
-        with xr.open_dataset(crosswalk_file) as ds:
-            gage_lake_dict = {
-                'gage': ds.usgs_gage_id.values,
-                'usgs_lake_id': ds.usgs_lake_id.values
-            }
-            gage_lake_df = (
-                pd.DataFrame(data = gage_lake_dict).
-                set_index('gage')
-            )
+        gage_lake_df = (
+            usgs_lake_gage_crosswalk.
+            reset_index().
+            set_index(['usgs_gage_id']) # <- TODO use input parameter for this
+        )
         
         # build dataframe that crosswalks gageIDs to segmentIDs
         gage_link_df = (

--- a/src/troute-routing/troute/routing/compute.py
+++ b/src/troute-routing/troute/routing/compute.py
@@ -166,6 +166,7 @@ def _prep_reservoir_da_dataframes(reservoir_usgs_df, reservoir_usace_df, waterbo
     else:
         reservoir_usgs_df_sub = pd.DataFrame()
         reservoir_usgs_df_time = pd.DataFrame().to_numpy().reshape(0,)
+        waterbody_types_df_sub.loc[waterbody_types_df_sub['reservoir_type'] == 2] = 1
 
     # select USACE reservoir DA data waterbodies in sub-domain
     if not reservoir_usace_df.empty:
@@ -177,8 +178,9 @@ def _prep_reservoir_da_dataframes(reservoir_usgs_df, reservoir_usace_df, waterbo
     else: 
         reservoir_usace_df_sub = pd.DataFrame()
         reservoir_usace_df_time = pd.DataFrame().to_numpy().reshape(0,)
+        waterbody_types_df_sub.loc[waterbody_types_df_sub['reservoir_type'] == 3] = 1
         
-    return reservoir_usgs_df_sub, reservoir_usgs_df_time, reservoir_usace_df_sub, reservoir_usace_df_time
+    return reservoir_usgs_df_sub, reservoir_usgs_df_time, reservoir_usace_df_sub, reservoir_usace_df_time, waterbody_types_df_sub
 
 def compute_nhd_routing_v02(
     connections,
@@ -411,7 +413,8 @@ def compute_nhd_routing_v02(
                     (reservoir_usgs_df_sub, 
                      reservoir_usgs_df_time, 
                      reservoir_usace_df_sub, 
-                     reservoir_usace_df_time
+                     reservoir_usace_df_time,
+                     waterbody_types_df_sub,
                      ) = _prep_reservoir_da_dataframes(
                         reservoir_usgs_df, 
                         reservoir_usace_df, 
@@ -645,7 +648,8 @@ def compute_nhd_routing_v02(
                     (reservoir_usgs_df_sub, 
                      reservoir_usgs_df_time, 
                      reservoir_usace_df_sub, 
-                     reservoir_usace_df_time
+                     reservoir_usace_df_time,
+                     waterbody_types_df_sub,
                      ) = _prep_reservoir_da_dataframes(
                         reservoir_usgs_df, 
                         reservoir_usace_df, 
@@ -804,7 +808,8 @@ def compute_nhd_routing_v02(
                 (reservoir_usgs_df_sub, 
                  reservoir_usgs_df_time, 
                  reservoir_usace_df_sub, 
-                 reservoir_usace_df_time
+                 reservoir_usace_df_time,
+                 waterbody_types_df_sub,
                  ) = _prep_reservoir_da_dataframes(
                     reservoir_usgs_df, 
                     reservoir_usace_df, 
@@ -927,7 +932,8 @@ def compute_nhd_routing_v02(
             (reservoir_usgs_df_sub, 
              reservoir_usgs_df_time, 
              reservoir_usace_df_sub, 
-             reservoir_usace_df_time
+             reservoir_usace_df_time,
+             waterbody_types_df_sub,
              ) = _prep_reservoir_da_dataframes(
                 reservoir_usgs_df, 
                 reservoir_usace_df, 


### PR DESCRIPTION
The purpose of this Pull Request is to speed up workflows related to the handling of TimeSlice data for streamflow and reservoir data assimilation. The changes here were initially prompted by the sluggish performance of the existing method for nan-filling TimeSlice data by interpolation using pandas `DataFrame.interpolate()`, which fills interpolates through nan gaps on a row-by-row basis. At CONUS scale, with over 7k gages, interpolation can take ~3 - 4 seconds, and this happens at every loop iteration, which is cumulatively costly for long-term simulations. Here, I went ahead and parallelized the implementation of `DataFrame.interpolate()`, by farming-out small chunks of gages to separate CPUs so that we can simultaneously interpolate many gages at the same time. Overall, this change reduces the interpolation time by an order of magnitude. 

Along the way, I also realized that we are frequenctly opening and closing files, such as RouteLink or the reservoir parameter file, simply to extract crosswalk data (e.g. relating gage ids with link ids). To reduce the frequency of file I/O, I decided to create crosswalk DataFrames early in the workflow and put the to use whenever a crosswalk is needed, rather than opening a file and reading information from it. There are three principal crosswalk DataFrames that are put to use here: 1) link<>gage, 2) usgs lake_id <> gage and 3) usace lake_id <> gage.  

## Testing
I tested the development of this with a 28-hour AnA CONUS-scale case. First, I made sure that the gap filled DataFrame returned by `nhd_io.get_obs_from_timeslices` was identical to that created by the current t-route/master workflow. Then I checked for the performance difference. The change in the PR are showing a 57% improvement in performance related to the handling of USGS TimeSlice data. 

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist


