### PR TITLE
hotfix: reservoir DA data-prep logic

### DIFF
--- a/src/troute-routing/troute/routing/compute.py
+++ b/src/troute-routing/troute/routing/compute.py
@@ -166,7 +166,8 @@ def _prep_reservoir_da_dataframes(reservoir_usgs_df, reservoir_usace_df, waterbo
     else:
         reservoir_usgs_df_sub = pd.DataFrame()
         reservoir_usgs_df_time = pd.DataFrame().to_numpy().reshape(0,)
-        waterbody_types_df_sub.loc[waterbody_types_df_sub['reservoir_type'] == 2] = 1
+        if not waterbody_types_df_sub.empty:
+            waterbody_types_df_sub.loc[waterbody_types_df_sub['reservoir_type'] == 2] = 1
 
     # select USACE reservoir DA data waterbodies in sub-domain
     if not reservoir_usace_df.empty:
@@ -178,7 +179,8 @@ def _prep_reservoir_da_dataframes(reservoir_usgs_df, reservoir_usace_df, waterbo
     else: 
         reservoir_usace_df_sub = pd.DataFrame()
         reservoir_usace_df_time = pd.DataFrame().to_numpy().reshape(0,)
-        waterbody_types_df_sub.loc[waterbody_types_df_sub['reservoir_type'] == 3] = 1
+        if not waterbody_types_df_sub.empty:
+            waterbody_types_df_sub.loc[waterbody_types_df_sub['reservoir_type'] == 3] = 1
         
     return reservoir_usgs_df_sub, reservoir_usgs_df_time, reservoir_usace_df_sub, reservoir_usace_df_time, waterbody_types_df_sub
 


### PR DESCRIPTION
A recent pull request disrupted the ability to run open loop simulations without any reservoirs. Here, we provide a fix for that disruption 

## Additions

- revised logic in `compute._prep_reservoir_da_dataframes` that allows `waterbody_types_df_sub` to be empty. 
