### PR TITLE
Bug fix allowing looped diffusive hybrid simulations

### DIFF
--- a/src/troute-routing/troute/routing/diffusive_utils.py
+++ b/src/troute-routing/troute/routing/diffusive_utils.py
@@ -192,7 +192,7 @@ def fp_chgeo_map(
                     segID = seg_list[seg]
                 
                 bo_ar_g[seg, frj] = param_df.loc[segID, 'bw']
-                traps_ar_g[seg, frj] = param_df.loc[segID, 'cs']
+                traps_ar_g[seg, frj] = 1/param_df.loc[segID, 'cs']
                 tw_ar_g[seg, frj] = param_df.loc[segID, 'tw']
                 twcc_ar_g[seg, frj] = param_df.loc[segID, 'twcc']
                 mann_ar_g[seg, frj] = param_df.loc[segID, 'n']
@@ -683,9 +683,6 @@ def diffusive_input_data_v02(
             
         # for channel altitude adjustment
         z_all.update({seg: {"adj.alt": np.zeros(1)} for seg in rch})
-    
-    # take the reciprical of cs - this seems out of place, where should this be located?
-    param_df.loc[:,'cs'] = 1/param_df.loc[:,'cs']
     
     # --------------------------------------------------------------------------------------
     #                                 Step 0-3


### PR DESCRIPTION
This is a quick bug fix that allows the diffusive hybrid model to work with looped simulations (addressing #535). The diffusive wave input argument `traps_ar_g` is the reciprocal of the trapezoidal channel side slope. Previously, there was a line of code that was taking the reciprocal of channel side slope in `diffusive_utils`:
```python
param_df.loc[:,'cs'] = 1/param_df.loc[:,'cs']
```
The issue with the line of code above is that it alters the entire input dataframe column and that alteration is retained for the next loop. So on the second loop iteration, we end up taking the reciprocal of the reciprocal!  The problem was easily fixed by moving the reciprocal operation lower down and not performing it on the entire dataframe column. 
