### PR TITLE
change feature_id variable type for CHANOBS files

### DIFF
--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -551,7 +551,7 @@ def write_chanobs(
             # =========== feature_id VARIABLE ===============
             FEATURE_ID = f.createVariable(
                 varname = "feature_id",
-                datatype = 'int32',
+                datatype = 'int64',
                 dimensions = ("feature_id",),
             )
             FEATURE_ID[:] = gage_feature_id


### PR DESCRIPTION
hot fix for calibration. Allows data from Alaska domain to be properly indexed in CHANOBS output files. 
