### PR TITLE
Alaska reservoir fix

### DIFF
--- a/src/troute-network/troute/network/reservoirs/levelpool/levelpool.pyx
+++ b/src/troute-network/troute/network/reservoirs/levelpool/levelpool.pyx
@@ -31,7 +31,7 @@ cdef class MC_Levelpool(Reach):
     MC_Reservoir is a subclass of MC_Reach_Base_Class
   """
 
-  def __init__(self, long id, int lake_number, long[::1] upstream_ids, args, wbody_type_code):
+  def __init__(self, long id, long lake_number, long[::1] upstream_ids, args, wbody_type_code):
     """
       Construct the kernel based on passed parameters,
       which only constructs the parent class

--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -551,7 +551,7 @@ def write_chanobs(
             # =========== feature_id VARIABLE ===============
             FEATURE_ID = f.createVariable(
                 varname = "feature_id",
-                datatype = 'int32',
+                datatype = 'int64',
                 dimensions = ("feature_id",),
             )
             FEATURE_ID[:] = gage_feature_id

--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -487,7 +487,7 @@ def write_chanobs(
     '''
     
     # array of segment linkIDs at gage locations. Results from these segments will be written
-    gage_feature_id = link_gage_df.index.to_numpy(dtype = "int32")
+    gage_feature_id = link_gage_df.index.to_numpy(dtype = "int64")
     
     # array of simulated flow data at gage locations
     gage_flow_data = flowveldepth.loc[link_gage_df.index].iloc[:,::3].to_numpy(dtype="float32") 


### PR DESCRIPTION
This pull request enables levelpool reservoir simulations with int64 type waterbody IDs. There are int64 waterbody IDs in the Alaska domain, where were causing the model to fail because the waterbody ID was expected to be int32 type. This fix will facilitate oCONUS calibration simulations.


