### PR TITLE
Simulation looping with hybrid reservoir data assimilation

### DIFF
--- a/src/troute-nwm/src/nwm_routing/__main__.py
+++ b/src/troute-nwm/src/nwm_routing/__main__.py
@@ -534,6 +534,17 @@ def main_v03(argv):
                 t0 + timedelta(seconds = dt * nts),
             )
             
+            # if there are no TimeSlice files available for hybrid reservoir DA, 
+            # but there are DA parameters from the previous loop, then create a
+            # dummy observations df. This allows the reservoir persistence to continue.
+            if reservoir_usgs_df.empty and len(reservoir_usgs_param_df.index) > 0:
+                reservoir_usgs_df = pd.DataFrame(
+                    data    = np.nan, 
+                    index   = reservoir_usgs_param_df.index, 
+                    columns = [t0]
+                )
+            # repeat for USACE 
+            
             if showtiming:
                 forcing_end_time = time.time()
                 task_times['forcing_time'] += forcing_end_time - route_end_time

--- a/src/troute-nwm/src/nwm_routing/__main__.py
+++ b/src/troute-nwm/src/nwm_routing/__main__.py
@@ -63,7 +63,9 @@ def nwm_route(
     usgs_df,
     lastobs_df,
     reservoir_usgs_df,
+    reservoir_usgs_param_df,
     reservoir_usace_df,
+    reservoir_usace_param_df,
     da_parameter_dict,
     assume_short_ts,
     return_courant,
@@ -109,7 +111,9 @@ def nwm_route(
         usgs_df,
         lastobs_df,
         reservoir_usgs_df,
+        reservoir_usgs_param_df,
         reservoir_usace_df,
+        reservoir_usace_param_df,
         da_parameter_dict,
         assume_short_ts,
         return_courant,
@@ -181,6 +185,43 @@ def get_waterbody_water_elevation(waterbodies_df, q0):
     waterbodies_df.update(q0)
 
     return waterbodies_df
+
+def set_reservoir_da_prams(run_results):
+    '''
+    '''
+    
+    reservoir_usgs_param_df = pd.DataFrame(data = [], 
+                                           index = [], 
+                                           columns = [
+                                               'update_time', 'prev_persisted_outflow', 
+                                               'persistence_update_time', 'persistence_index'
+                                           ]
+                                          )
+    reservoir_usace_param_df = pd.DataFrame(data = [], 
+                                           index = [], 
+                                           columns = [
+                                               'update_time', 'prev_persisted_outflow', 
+                                               'persistence_update_time', 'persistence_index'
+                                           ]
+                                          )
+    
+    for r in run_results:
+        
+        if len(r[4][0]) > 0:
+            tmp_usgs = pd.DataFrame(data = r[4][1], index = r[4][0], columns = ['update_time'])
+            tmp_usgs['prev_persisted_outflow'] = r[4][2]
+            tmp_usgs['persistence_update_time'] = r[4][4]
+            tmp_usgs['persistence_index'] = r[4][3]
+            reservoir_usgs_param_df = pd.concat([reservoir_usgs_param_df, tmp_usgs])
+        
+        if len(r[5][0]) > 0:
+            tmp_usace = pd.DataFrame(data = r[5][1], index = r[5][0], columns = ['update_time'])
+            tmp_usace['prev_persisted_outflow'] = r[5][2]
+            tmp_usace['persistence_update_time'] = r[5][4]
+            tmp_usace['persistence_index'] = r[5][3]
+            reservoir_usace_param_df = pd.concat([reservoir_usace_param_df, tmp_usace])
+    
+    return reservoir_usgs_param_df, reservoir_usace_param_df
 
 
 def update_lookback_hours(dt, nts, waterbody_parameters):
@@ -376,7 +417,9 @@ def main_v03(argv):
         qlats, 
         usgs_df, 
         reservoir_usgs_df, 
-        reservoir_usace_df
+        reservoir_usgs_param_df,
+        reservoir_usace_df,
+        reservoir_usace_param_df
     ) = nwm_forcing_preprocess(
         run_sets[0],
         forcing_parameters,
@@ -431,7 +474,9 @@ def main_v03(argv):
             usgs_df,
             lastobs_df,
             reservoir_usgs_df,
+            reservoir_usgs_param_df,
             reservoir_usace_df,
+            reservoir_usace_param_df,
             da_parameter_dict,
             assume_short_ts,
             return_courant,
@@ -452,6 +497,9 @@ def main_v03(argv):
         q0 = new_nwm_q0(run_results)
         waterbodies_df = get_waterbody_water_elevation(waterbodies_df, q0)
         
+        # get reservoir DA initial parameters for next loop itteration
+        reservoir_usgs_param_df, reservoir_usace_param_df = set_reservoir_da_prams(run_results)
+        
         # TODO move the conditional call to write_lite_restart to nwm_output_generator.
         if "lite_restart" in output_parameters:
             nhd_io.write_lite_restart(
@@ -467,7 +515,9 @@ def main_v03(argv):
                 qlats, 
                 usgs_df, 
                 reservoir_usgs_df, 
-                reservoir_usace_df
+                _,
+                reservoir_usace_df,
+                _,
             ) = nwm_forcing_preprocess(
                 run_sets[run_set_iterator + 1],
                 forcing_parameters,

--- a/src/troute-nwm/src/nwm_routing/__main__.py
+++ b/src/troute-nwm/src/nwm_routing/__main__.py
@@ -188,6 +188,7 @@ def get_waterbody_water_elevation(waterbodies_df, q0):
 
 def set_reservoir_da_prams(run_results):
     '''
+    Update persistence reservoir DA parameters for subsequent loops
     '''
     
     reservoir_usgs_param_df = pd.DataFrame(data = [], 

--- a/src/troute-nwm/src/nwm_routing/__main__.py
+++ b/src/troute-nwm/src/nwm_routing/__main__.py
@@ -534,24 +534,35 @@ def main_v03(argv):
                 t0 + timedelta(seconds = dt * nts),
             )
             
-            # if there are no TimeSlice files available for hybrid reservoir DA, 
+            # if there are no TimeSlice files available for hybrid reservoir DA in the next loop, 
             # but there are DA parameters from the previous loop, then create a
-            # dummy observations df. This allows the reservoir persistence to continue.
-            if reservoir_usgs_df.empty and len(reservoir_usgs_param_df.index) > 0:
-                reservoir_usgs_df = pd.DataFrame(
-                    data    = np.nan, 
-                    index   = reservoir_usgs_param_df.index, 
-                    columns = [t0]
-                )
-            # repeat for USACE 
-            
+            # dummy observations df. This allows the reservoir persistence to continue across loops.
+            # USGS Reservoirs
+            if 2 in waterbody_types_df['reservoir_type'].unique():
+                if reservoir_usgs_df.empty and len(reservoir_usgs_param_df.index) > 0:
+                    reservoir_usgs_df = pd.DataFrame(
+                        data    = np.nan, 
+                        index   = reservoir_usgs_param_df.index, 
+                        columns = [t0]
+                    )
+                    
+            # USACE Reservoirs   
+            if 3 in waterbody_types_df['reservoir_type'].unique():
+                if reservoir_usace_df.empty and len(reservoir_usace_param_df.index) > 0:
+                    reservoir_usace_df = pd.DataFrame(
+                        data    = np.nan, 
+                        index   = reservoir_usgs_param_df.index, 
+                        columns = [t0]
+                    )
+                
+            # update RFC lookback hours if there are RFC-type reservoirs in the simulation domain
+            if 4 in waterbody_types_df['reservoir_type'].unique():
+                waterbody_parameters = update_lookback_hours(dt, nts, waterbody_parameters)     
+                
             if showtiming:
                 forcing_end_time = time.time()
                 task_times['forcing_time'] += forcing_end_time - route_end_time
-
-            if waterbody_type_specified:
-                waterbody_parameters = update_lookback_hours(dt, nts, waterbody_parameters)
-                
+  
             if showtiming:
                 ic_end_time = time.time()
                 task_times['initial_condition_time'] += ic_end_time - forcing_end_time

--- a/src/troute-nwm/src/nwm_routing/__main__.py
+++ b/src/troute-nwm/src/nwm_routing/__main__.py
@@ -510,7 +510,6 @@ def main_v03(argv):
                 output_parameters['lite_restart']
             )
         
-        # No forcing to prepare for the last loop
         if run_set_iterator < len(run_sets) - 1:
             (
                 qlats, 

--- a/src/troute-nwm/src/nwm_routing/preprocess.py
+++ b/src/troute-nwm/src/nwm_routing/preprocess.py
@@ -1051,6 +1051,19 @@ def nwm_forcing_preprocess(
     else:
         reservoir_usgs_df = pd.DataFrame()
         
+    # create USGS reservoir hybrid DA initial parameters dataframe    
+    if reservoir_usgs_df.empty == False:
+        reservoir_usgs_param_df = pd.DataFrame(
+            data = 0, 
+            index = reservoir_usgs_df.index ,
+            columns = ['update_time']
+        )
+        reservoir_usgs_param_df['prev_persisted_outflow'] = np.nan
+        reservoir_usgs_param_df['persistence_update_time'] = 0
+        reservoir_usgs_param_df['persistence_index'] = 0
+    else:
+        reservoir_usgs_param_df = pd.DataFrame()
+
     #---------------------------------------------
     # observations for USACE reservoir DA
     #---------------------------------------------  
@@ -1110,7 +1123,20 @@ def nwm_forcing_preprocess(
         
     else:
         reservoir_usace_df = pd.DataFrame()
-    
+        
+    # create USACE reservoir hybrid DA initial parameters dataframe    
+    if reservoir_usace_df.empty == False:
+        reservoir_usace_param_df = pd.DataFrame(
+            data = 0, 
+            index = reservoir_usace_df.index ,
+            columns = ['update_time']
+        )
+        reservoir_usace_param_df['prev_persisted_outflow'] = np.nan
+        reservoir_usace_param_df['persistence_update_time'] = 0
+        reservoir_usace_param_df['persistence_index'] = 0
+    else:
+        reservoir_usace_param_df = pd.DataFrame()
+
     #---------------------------------------------------------------------------
     # Assemble coastal coupling data [WIP]
     
@@ -1133,4 +1159,4 @@ def nwm_forcing_preprocess(
     if not usgs_df.empty:
         usgs_df = usgs_df.loc[:,t0:]
     
-    return qlats_df, usgs_df, reservoir_usgs_df, reservoir_usace_df
+    return qlats_df, usgs_df, reservoir_usgs_df, reservoir_usgs_param_df, reservoir_usace_df, reservoir_usace_param_df

--- a/src/troute-routing/troute/routing/compute.py
+++ b/src/troute-routing/troute/routing/compute.py
@@ -1159,7 +1159,9 @@ def compute_diffusive_routing(
         results_diffusive.append(
             (
                 rch_list[~x], dat_all[~x,3:], 0,
-                (np.asarray([]), np.asarray([]), np.asarray([]))
+                (np.asarray([]), np.asarray([]), np.asarray([])),
+                (np.asarray([]), np.asarray([]), np.asarray([]), np.asarray([]), np.asarray([])),
+                (np.asarray([]), np.asarray([]), np.asarray([]), np.asarray([]), np.asarray([])),
             )
         )
 

--- a/src/troute-routing/troute/routing/compute.py
+++ b/src/troute-routing/troute/routing/compute.py
@@ -144,12 +144,12 @@ def _prep_reservoir_da_dataframes(reservoir_usgs_df, reservoir_usgs_param_df, re
 
     Arguments
     ---------
-    reservoir_usgs_df      (DataFrame): gage flow observations at USGS-type reservoirs
-    reservoir_usgs_param_df
-    reservoir_usace_df     (DataFrame): gage flow observations at USACE-type reservoirs
-    reservoir_usace_param_df
-    waterbody_types_df_sub (DataFrame): type-codes for waterbodies in sub domain
-    t0                      (datetime): model initialization time
+    reservoir_usgs_df        (DataFrame): gage flow observations at USGS-type reservoirs
+    reservoir_usgs_param_df  (DataFrame): USGS reservoir DA state parameters
+    reservoir_usace_df       (DataFrame): gage flow observations at USACE-type reservoirs
+    reservoir_usace_param_df (DataFrame): USACE reservoir DA state parameters
+    waterbody_types_df_sub   (DataFrame): type-codes for waterbodies in sub domain
+    t0                        (datetime): model initialization time
 
     Returns
     -------
@@ -1159,7 +1159,9 @@ def compute_diffusive_routing(
         results_diffusive.append(
             (
                 rch_list[~x], dat_all[~x,3:], 0,
+                # place-holder for streamflow DA parameters
                 (np.asarray([]), np.asarray([]), np.asarray([])),
+                # place-holder for reservoir DA paramters
                 (np.asarray([]), np.asarray([]), np.asarray([]), np.asarray([]), np.asarray([])),
                 (np.asarray([]), np.asarray([]), np.asarray([]), np.asarray([]), np.asarray([])),
             )

--- a/src/troute-routing/troute/routing/compute.py
+++ b/src/troute-routing/troute/routing/compute.py
@@ -434,13 +434,23 @@ def compute_nhd_routing_v02(
 
                     # prepare reservoir DA data
                     (reservoir_usgs_df_sub, 
-                     reservoir_usgs_df_time, 
+                     reservoir_usgs_df_time,
+                     reservoir_usgs_update_time,
+                     reservoir_usgs_prev_persisted_flow,
+                     reservoir_usgs_persistence_update_time,
+                     reservoir_usgs_persistence_index,
                      reservoir_usace_df_sub, 
                      reservoir_usace_df_time,
+                     reservoir_usace_update_time,
+                     reservoir_usace_prev_persisted_flow,
+                     reservoir_usace_persistence_update_time,
+                     reservoir_usace_persistence_index,
                      waterbody_types_df_sub,
                      ) = _prep_reservoir_da_dataframes(
-                        reservoir_usgs_df, 
+                        reservoir_usgs_df,
+                        reservoir_usgs_param_df,
                         reservoir_usace_df, 
+                        reservoir_usace_param_df,
                         waterbody_types_df_sub, 
                         t0
                     )
@@ -479,12 +489,22 @@ def compute_nhd_routing_v02(
                                 pd.Series(index=lastobs_df_sub.index, name="Null"),
                             ).values.astype("float32"),
                             da_decay_coefficient,
+                            # USGS Hybrid Reservoir DA data
                             reservoir_usgs_df_sub.values.astype("float32"),
                             reservoir_usgs_df_sub.index.values.astype("int32"),
                             reservoir_usgs_df_time.astype('float32'),
+                            reservoir_usgs_update_time.astype('float32'),
+                            reservoir_usgs_prev_persisted_flow.astype('float32'),
+                            reservoir_usgs_persistence_update_time.astype('float32'),
+                            reservoir_usgs_persistence_index.astype('float32'),
+                            # USACE Hybrid Reservoir DA data
                             reservoir_usace_df_sub.values.astype("float32"),
                             reservoir_usace_df_sub.index.values.astype("int32"),
                             reservoir_usace_df_time.astype('float32'),
+                            reservoir_usace_update_time.astype("float32"),
+                            reservoir_usace_prev_persisted_flow.astype("float32"),
+                            reservoir_usace_persistence_update_time.astype("float32"),
+                            reservoir_usace_persistence_index.astype("float32"),
                             {
                                 us: fvd
                                 for us, fvd in flowveldepth_interorder.items()
@@ -669,13 +689,23 @@ def compute_nhd_routing_v02(
                     
                     # prepare reservoir DA data
                     (reservoir_usgs_df_sub, 
-                     reservoir_usgs_df_time, 
+                     reservoir_usgs_df_time,
+                     reservoir_usgs_update_time,
+                     reservoir_usgs_prev_persisted_flow,
+                     reservoir_usgs_persistence_update_time,
+                     reservoir_usgs_persistence_index,
                      reservoir_usace_df_sub, 
                      reservoir_usace_df_time,
+                     reservoir_usace_update_time,
+                     reservoir_usace_prev_persisted_flow,
+                     reservoir_usace_persistence_update_time,
+                     reservoir_usace_persistence_index,
                      waterbody_types_df_sub,
                      ) = _prep_reservoir_da_dataframes(
-                        reservoir_usgs_df, 
+                        reservoir_usgs_df,
+                        reservoir_usgs_param_df,
                         reservoir_usace_df, 
+                        reservoir_usace_param_df,
                         waterbody_types_df_sub, 
                         t0
                     )
@@ -712,12 +742,22 @@ def compute_nhd_routing_v02(
                                 pd.Series(index=lastobs_df_sub.index, name="Null"),
                             ).values.astype("float32"),
                             da_decay_coefficient,
+                            # USGS Hybrid Reservoir DA data
                             reservoir_usgs_df_sub.values.astype("float32"),
                             reservoir_usgs_df_sub.index.values.astype("int32"),
                             reservoir_usgs_df_time.astype('float32'),
+                            reservoir_usgs_update_time.astype('float32'),
+                            reservoir_usgs_prev_persisted_flow.astype('float32'),
+                            reservoir_usgs_persistence_update_time.astype('float32'),
+                            reservoir_usgs_persistence_index.astype('float32'),
+                            # USACE Hybrid Reservoir DA data
                             reservoir_usace_df_sub.values.astype("float32"),
                             reservoir_usace_df_sub.index.values.astype("int32"),
                             reservoir_usace_df_time.astype('float32'),
+                            reservoir_usace_update_time.astype("float32"),
+                            reservoir_usace_prev_persisted_flow.astype("float32"),
+                            reservoir_usace_persistence_update_time.astype("float32"),
+                            reservoir_usace_persistence_index.astype("float32"),
                             {
                                 us: fvd
                                 for us, fvd in flowveldepth_interorder.items()
@@ -829,13 +869,23 @@ def compute_nhd_routing_v02(
                 
                 # prepare reservoir DA data
                 (reservoir_usgs_df_sub, 
-                 reservoir_usgs_df_time, 
+                 reservoir_usgs_df_time,
+                 reservoir_usgs_update_time,
+                 reservoir_usgs_prev_persisted_flow,
+                 reservoir_usgs_persistence_update_time,
+                 reservoir_usgs_persistence_index,
                  reservoir_usace_df_sub, 
                  reservoir_usace_df_time,
+                 reservoir_usace_update_time,
+                 reservoir_usace_prev_persisted_flow,
+                 reservoir_usace_persistence_update_time,
+                 reservoir_usace_persistence_index,
                  waterbody_types_df_sub,
                  ) = _prep_reservoir_da_dataframes(
-                    reservoir_usgs_df, 
+                    reservoir_usgs_df,
+                    reservoir_usgs_param_df,
                     reservoir_usace_df, 
+                    reservoir_usace_param_df,
                     waterbody_types_df_sub, 
                     t0
                 )
@@ -865,12 +915,22 @@ def compute_nhd_routing_v02(
                         lastobs_df_sub.get("lastobs_discharge", pd.Series(index=lastobs_df_sub.index, name="Null")).values.astype("float32"),
                         lastobs_df_sub.get("time_since_lastobs", pd.Series(index=lastobs_df_sub.index, name="Null")).values.astype("float32"),
                         da_decay_coefficient,
+                        # USGS Hybrid Reservoir DA data
                         reservoir_usgs_df_sub.values.astype("float32"),
                         reservoir_usgs_df_sub.index.values.astype("int32"),
                         reservoir_usgs_df_time.astype('float32'),
+                        reservoir_usgs_update_time.astype('float32'),
+                        reservoir_usgs_prev_persisted_flow.astype('float32'),
+                        reservoir_usgs_persistence_update_time.astype('float32'),
+                        reservoir_usgs_persistence_index.astype('float32'),
+                        # USACE Hybrid Reservoir DA data
                         reservoir_usace_df_sub.values.astype("float32"),
                         reservoir_usace_df_sub.index.values.astype("int32"),
                         reservoir_usace_df_time.astype('float32'),
+                        reservoir_usace_update_time.astype("float32"),
+                        reservoir_usace_prev_persisted_flow.astype("float32"),
+                        reservoir_usace_persistence_update_time.astype("float32"),
+                        reservoir_usace_persistence_index.astype("float32"),
                         {},
                         assume_short_ts,
                         return_courant,

--- a/src/troute-routing/troute/routing/compute.py
+++ b/src/troute-routing/troute/routing/compute.py
@@ -153,10 +153,19 @@ def _prep_reservoir_da_dataframes(reservoir_usgs_df, reservoir_usgs_param_df, re
 
     Returns
     -------
-    reservoir_usgs_df_sub  (DataFrame): gage flow observations for USGS-type reservoirs in sub domain
-    reservoir_usgs_df_time   (ndarray): time in seconds from model initialization time
-    reservoir_usace_df_sub (DataFrame): gage flow observations for USACE-type reservoirs in sub domain
-    reservoir_usace_df_time  (ndarray): time in seconds from model initialization time
+    * there are many returns, because we are passing explicit arrays to mc_reach cython code
+    reservoir_usgs_df_sub                 (DataFrame): gage flow observations for USGS-type reservoirs in sub domain
+    reservoir_usgs_df_time                  (ndarray): time in seconds from model initialization time
+    reservoir_usgs_update_time              (ndarray): update time (sec) to search for new observation at USGS reservoirs
+    reservoir_usgs_prev_persisted_flow      (ndarray): previously persisted outflow rates at USGS reservoirs
+    reservoir_usgs_persistence_update_time  (ndarray): update time (sec) of persisted value at USGS reservoirs
+    reservoir_usgs_persistence_index        (ndarray): index denoting elapsed persistence epochs at USGS reservoirs
+    reservoir_usace_df_sub                (DataFrame): gage flow observations for USACE-type reservoirs in sub domain
+    reservoir_usace_df_time                 (ndarray): time in seconds from model initialization time
+    reservoir_usace_update_time             (ndarray): update time (sec) to search for new observation at USACE reservoirs
+    reservoir_usace_prev_persisted_flow     (ndarray): previously persisted outflow rates at USACE reservoirs
+    reservoir_usace_persistence_update_time (ndarray): update time (sec) of persisted value at USACE reservoirs
+    reservoir_usace_persistence_index       (ndarray): index denoting elapsed persistence epochs at USACE reservoirs
 
     '''
     if not reservoir_usgs_df.empty:

--- a/src/troute-routing/troute/routing/fast_reach/mc_reach.pyx
+++ b/src/troute-routing/troute/routing/fast_reach/mc_reach.pyx
@@ -186,9 +186,17 @@ cpdef object compute_network_structured(
     const float[:,:] reservoir_usgs_obs,
     const int[:] reservoir_usgs_wbody_idx,
     const float[:] reservoir_usgs_time,
+    const float[:] reservoir_usgs_update_time,
+    const float[:] reservoir_usgs_prev_persisted_flow,
+    const float[:] reservoir_usgs_persistence_update_time,
+    const float[:] reservoir_usgs_persistence_index,
     const float[:,:] reservoir_usace_obs,
     const int[:] reservoir_usace_wbody_idx,
     const float[:] reservoir_usace_time,
+    const float[:] reservoir_usace_update_time,
+    const float[:] reservoir_usace_prev_persisted_flow,
+    const float[:] reservoir_usace_persistence_update_time,
+    const float[:] reservoir_usace_persistence_index,
     dict upstream_results={},
     bint assume_short_ts=False,
     bint return_courant=False,
@@ -373,20 +381,20 @@ cpdef object compute_network_structured(
     cdef np.ndarray[int, ndim=1] usace_idx = np.asarray(reservoir_usace_wbody_idx)
     
     # reservoir update time arrays
-    cdef np.ndarray[float, ndim=1] usgs_update_time  = np.zeros(np.shape(usgs_idx), dtype='float32')
-    cdef np.ndarray[float, ndim=1] usace_update_time = np.zeros(np.shape(usace_idx), dtype='float32')  
+    cdef np.ndarray[float, ndim=1] usgs_update_time  = np.asarray(reservoir_usgs_update_time)
+    cdef np.ndarray[float, ndim=1] usace_update_time = np.asarray(reservoir_usace_update_time)
     
     # reservoir persisted outflow arrays
-    cdef np.ndarray[float, ndim=1] usgs_prev_persisted_ouflow  = np.full(len(usgs_idx), np.nan, dtype='float32')
-    cdef np.ndarray[float, ndim=1] usace_prev_persisted_ouflow = np.full(len(usace_idx), np.nan, dtype='float32')  
+    cdef np.ndarray[float, ndim=1] usgs_prev_persisted_ouflow  = np.asarray(reservoir_usgs_prev_persisted_flow)
+    cdef np.ndarray[float, ndim=1] usace_prev_persisted_ouflow = np.asarray(reservoir_usace_prev_persisted_flow)  
     
     # reservoir persistence index update time arrays
-    cdef np.ndarray[float, ndim=1] usgs_persistence_update_time  = np.zeros(np.shape(usgs_idx), dtype='float32')
-    cdef np.ndarray[float, ndim=1] usace_persistence_update_time = np.zeros(np.shape(usace_idx), dtype='float32')  
+    cdef np.ndarray[float, ndim=1] usgs_persistence_update_time  = np.asarray(reservoir_usgs_persistence_update_time)
+    cdef np.ndarray[float, ndim=1] usace_persistence_update_time = np.asarray(reservoir_usace_persistence_update_time)
     
     # reservoir persisted outflow period index
-    cdef np.ndarray[float, ndim=1] usgs_prev_persistence_index  = np.zeros(np.shape(usgs_idx), dtype='float32')
-    cdef np.ndarray[float, ndim=1] usace_prev_persistence_index = np.zeros(np.shape(usace_idx), dtype='float32')  
+    cdef np.ndarray[float, ndim=1] usgs_prev_persistence_index  = np.asarray(reservoir_usgs_persistence_index)
+    cdef np.ndarray[float, ndim=1] usace_prev_persistence_index = np.asarray(reservoir_usace_persistence_index)
 
     #---------------------------------------------------------------------------------------------
     #---------------------------------------------------------------------------------------------
@@ -638,4 +646,4 @@ cpdef object compute_network_structured(
     #slice off the initial condition timestep and return
     output = np.asarray(flowveldepth[:,1:,:], dtype='float32')
     #return np.asarray(data_idx, dtype=np.intp), np.asarray(flowveldepth.base.reshape(flowveldepth.shape[0], -1), dtype='float32')
-    return np.asarray(data_idx, dtype=np.intp)[fill_index_mask], output.reshape(output.shape[0], -1)[fill_index_mask], 0, (np.asarray([data_idx[usgs_position_i] for usgs_position_i in usgs_positions]), np.asarray(lastobs_times), np.asarray(lastobs_values))
+    return np.asarray(data_idx, dtype=np.intp)[fill_index_mask], output.reshape(output.shape[0], -1)[fill_index_mask], 0, (np.asarray([data_idx[usgs_position_i] for usgs_position_i in usgs_positions]), np.asarray(lastobs_times), np.asarray(lastobs_values)), (usgs_idx, usgs_update_time-((timestep-1)*dt), usgs_prev_persisted_ouflow, usgs_prev_persistence_index, usgs_persistence_update_time-((timestep-1)*dt)), (usace_idx, usace_update_time-((timestep-1)*dt), usace_prev_persisted_ouflow, usace_prev_persistence_index, usace_persistence_update_time-((timestep-1)*dt))


### PR DESCRIPTION
There are several state parameters that need to passed over between reservoir DA simulation loops:
- **update time** - model time (seconds since simulation start) at which new observations are sought for assimilation
- **previously persisted outflow** - value of the persisted outflow from the previous timestep
- **persistence update time** - model time (seconds since simulation start) at which the persisted reservoir outflow is reconsidered.
- **persistence index** - the number of elapsed persistence update intervals
These parameters are updated for each reservoir at each timestep. When we run a simulation looped over temporal chunks, the parameter information must be passed from one loop to the next. Else, the parameters will reset to default values. If the parameter information is not passed from one loop the next, then issues may arise. Such as a situation in which an observation has been persisted for nearly the maximum allowable duration at the end of the first loop. If the parameter information is not passed, then the same observation may be persisted further onward in time beyond the acceptable limits. 

The proposed solution involves creating and passing new data objects that contain reservoir DA parameter values. Initially, data frames are created that contain initial values for all parameters, indexed by lake_id. These data frames are passed to compute.py, where they are broken into distinct 1-d arrays that are passed to mc_reach.compute_network_structured(). These arrays are used to initialize arrays within mc_reach.compute_network_structured() that are updated after each timestep to track parameter states. Once the network computation is complete, parameter arrays are returned from mc_reach.compute_network_structured(). The data within the returned arrays is re-cast into data frames for the subsequent simulation. 

## Testing

Testing is done with a 28-hour analysis and assimilation dataset from previous NWM 2.1 operations. This dataset contains forcings and results for a CONUS simulation with all data assimilation capabilities turned ON, including hybrid reservoir DA. The testing dataset is ideal because streamflow results compute by NWM 2.1 provide a target for t-route.

The CONUS domain is subset to the Neuse River watershed in North Carolina, which contains 9 total waterbodies, two of which are USGS hybrid reservoirs.

Testing data and simulation configuration files are on Cheyenne - file directory available upon request. 

## TODO
- [x] Check that looped simulation produces the same results as non-looped simulation
- [x] Check that looped simulations very nearly match NWM 2.1 simulated reservoir outflow (perfect match is not expected)
- [x] Implement solution in other parallel schemes - currently only implemented for serial computations
- [x] Test with strictly open-loop setting
- [x] Test with streamflow DA, no reservoir DA
- [x] Test with reservoir DA, no streamflow DA
- [x] Test with USGS hybrid DA, no USACE hybrid DA
- [x] Test with USACE hybrid DA, no USGS hybrid DA
- [x]  Update docstrings
- [x] Review code for parsimony and formatting
- [x] Repeat testing in other basins of the CONUS domain
