### PR TITLE
write waterbody results to LAKEOUT files

### DIFF
--- a/doc/v3_doc.yaml
+++ b/doc/v3_doc.yaml
@@ -708,3 +708,9 @@ output_parameters:
             - validation_files:
                 - validation_file3
                 - validation_file4
+    # ---------------
+    # parameters controlling the writing of results to LAKEOUT netcdf files
+    # optional, default is None and results are not written to lakeout.
+    # path to directory where un-edited LAKEOUT files are located.
+    # (!!) mandatory if writing results to lakeout. Default is to None and results will not be written.
+    lakeout_output:

--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -1559,3 +1559,275 @@ def lastobs_df_output(
     # write-out LastObs file as netcdf
     output_path = pathlib.Path(lastobs_output_folder + "/nudgingLastObs." + modelTimeAtOutput_str + ".nc").resolve()
     ds.to_netcdf(str(output_path))
+
+def write_waterbody_netcdf(
+    wbdy_filepath, 
+    wbdy_df, 
+    waterbodies_df, 
+    t0, 
+    dt, 
+    nts,
+    time_index
+):
+    
+    '''
+    Write results of waterbodies to netcdf. 
+    Written as one file per time step.
+    
+    Arguments
+    -------------
+        wbdy_filepath (Path or string) - directory where files will be created
+        wbdy_df (DataFrame) - t-route waterbody inflow, outflow, and depth results
+        waterbodies_df (DataFrame) - linkIDs of waterbodies in network
+        t0 (datetime) - initial time
+        dt (int) - timestep duration (seconds)
+        nts (int) - number of timesteps in simulation
+        time_index (ind) - specific timestep for this file
+        
+    Returns
+    -------------
+    
+    '''
+    
+    # array of segment linkIDs at gage locations. Results from these segments will be written
+    waterbodies_df = waterbodies_df.reset_index().rename(columns = {'lake_id': 'ID'})[['ID','lat','lon','crs']]
+    wbdy_feature_id = waterbodies_df.ID.to_numpy(dtype = "int64")
+
+    # dataframe of waterbody types
+    wbdy_type = wbdy_df.loc[:,['ID','reservoir_type']].drop_duplicates().reservoir_type.to_numpy(dtype = 'int32')
+    
+    # array of simulated flow data at gage locations
+    wbdy_data = wbdy_df.drop(columns='reservoir_type').pivot(index=['ID','time'],columns='variable',values='value')
+    
+    # array of simulation time
+    wbdy_time = [t0 + timedelta(seconds = (time_index+1) * dt)]
+    
+    # Merge waterbodies_df with wbdy_data
+    full_wbdy_data = pd.merge(waterbodies_df,wbdy_data,on = 'ID')
+    
+    if wbdy_filepath:
+        
+        # open netCDF4 Dataset in write mode
+        with netCDF4.Dataset(
+            filename = wbdy_filepath + str(wbdy_time[0].strftime('%Y%m%d%H%M')) + '.LAKEOUT.nc',
+            mode = 'w',
+            format = "NETCDF4"
+        ) as f:
+
+            # =========== DIMENSIONS ===============
+            _ = f.createDimension("time", 1)
+            _ = f.createDimension("feature_id", len(wbdy_feature_id))
+            _ = f.createDimension("reference_time", 1)
+            _ = f.createDimension("latitude", len(wbdy_feature_id))
+            _ = f.createDimension("longitude", len(wbdy_feature_id))
+
+            # =========== time VARIABLE ===============
+            TIME = f.createVariable(
+                varname = "time",
+                datatype = 'int32',
+                dimensions = ("time",),
+            )
+            TIME[:] = date2num(
+                wbdy_time, 
+                units = "minutes since 1970-01-01 00:00:00 UTC",
+                calendar = "gregorian"
+            )
+            f['time'].setncatts(
+                {
+                    'long_name': 'valid output time',
+                    'standard_name': 'time',
+                    'valid_min': date2num(
+                        t0, 
+                        units = "minutes since 1970-01-01 00:00:00 UTC",
+                        calendar = "gregorian"
+                    ),
+                    'valid_max': date2num(
+                        wbdy_time[0], 
+                        units = "minutes since 1970-01-01 00:00:00 UTC",
+                        calendar = "gregorian"
+                    ),
+                    'units': 'minutes since 1970-01-01T00:00:00+00:00',
+                    'calendar': 'proleptic_gregorian'
+                }
+            )
+
+            # =========== reference_time VARIABLE ===============
+            REF_TIME = f.createVariable(
+                varname = "reference_time",
+                datatype = 'int32',
+                dimensions = ("reference_time",),
+            )
+            REF_TIME[:] = date2num(
+                t0, 
+                units = "minutes since 1970-01-01 00:00:00 UTC",
+                calendar = "gregorian"
+            )
+            f['reference_time'].setncatts(
+                {
+                    'long_name': 'model initialization time',
+                    'standard_name': 'forecast_reference_time',
+                    'units': 'minutes since 1970-01-01T00:00:00+00:00',
+                    'calendar': 'proleptic_gregorian'
+                }
+            )
+
+            # =========== feature_id VARIABLE ===============
+            FEATURE_ID = f.createVariable(
+                varname = "feature_id",
+                datatype = 'int64',
+                dimensions = ("feature_id",),
+            )
+            FEATURE_ID[:] = wbdy_feature_id
+            f['feature_id'].setncatts(
+                {
+                    'long_name': 'Lake ComID',
+                    'comment': '',
+                    'cf_role:': 'timeseries_id'
+                }
+            )
+
+            # =========== latitude VARIABLE ===============
+            LATITUDE = f.createVariable(
+                varname = "latitude",
+                datatype = 'f4',
+                dimensions = ("feature_id",),
+                fill_value = np.nan
+            )
+            LATITUDE[:] = full_wbdy_data.lat.tolist()
+            f['latitude'].setncatts(
+                {
+                    'long_name': 'Lake latitude',
+                    'standard_name': 'latitude',
+                    'units': 'degrees_north'
+                }
+            )
+            
+            # =========== longitude VARIABLE ===============
+            LONGITUDE = f.createVariable(
+                varname = "longitude",
+                datatype = 'f4',
+                dimensions = ("feature_id",),
+                fill_value = np.nan
+            )
+            LONGITUDE[:] = full_wbdy_data.lon.tolist()
+            f['longitude'].setncatts(
+                {
+                    'long_name': 'Lake longitude',
+                    'standard_name': 'longitude',
+                    'units': 'degrees_east'
+                }
+            )
+            
+            # =========== reservoir type VARIABLE ===============            
+            res_type = f.createVariable(
+                    varname = "reservoir_type",
+                    datatype = "i4",
+                    dimensions = ("feature_id")
+                )
+            res_type[:] = wbdy_type
+            f['reservoir_type'].setncatts(
+                {
+                    'coordinates': 'latitude longitude',
+                    'long_name': 'reservoir_type',
+                    'flag_values': [1, 2, 3, 4],
+                    'flag_meanings': 'Level_pool USGS-persistence USACE-persistence RFC-forecasts'
+                }
+            )
+            
+            # =========== crs VARIABLE ===============            
+            crs = f.createVariable(
+                    varname = "crs",
+                    datatype = "S1",
+                    dimensions = ()
+                )
+            crs[:] = np.array(waterbodies_df.loc[0,'crs'],dtype = '|S1')
+            f['crs'].setncatts(
+                {
+                    'transform_name': 'latitude longitude',
+                    'grid_mapping_name': 'latitude longitude',
+                    'esri_pe_string': 'GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137.0,298.257223563]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]];-400 -400 1000000000;-100000 10000;-100000 10000;8.98315284119521E-09;0.001;0.001;IsHighPrecision',
+                    'spatial_ref': 'GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137.0,298.257223563]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]];-400 -400 1000000000;-100000 10000;-100000 10000;8.98315284119521E-09;0.001;0.001;IsHighPrecision',
+                    'long_name': 'CRS definition',
+                    'longitude_of_prime_meridian': 0.0,
+                    '_CoordinateAxes': 'latitude longitude',
+                    'semi_major_axis': 6378137.0,
+                    'semi_minor_axis': 6356752.5,
+                    'inverse_flattening': 298.25723
+                }
+            )
+            
+            # =========== inflow VARIABLE ===============            
+            inflow = f.createVariable(
+                    varname = "inflow",
+                    datatype = "f4",
+                    dimensions = ("feature_id"),
+                    fill_value = -999900
+                )
+            inflow[:] = full_wbdy_data.i.tolist()
+            f['inflow'].setncatts(
+                {
+                    'long_name': 'Lake Inflow',
+                    'units': 'm3 s-1',
+                    'grid_mapping': 'crs',
+                    'valid_range': [-1000000,1000000],
+                    'coordinates': 'latitude longitude',
+                    'add_offset': 0.0,
+                    'scale_factor': 0.01,
+                    'missing_value': -999900
+                }
+            )
+
+            # =========== outflow VARIABLE ===============            
+            outflow = f.createVariable(
+                    varname = "outflow",
+                    datatype = "f4",
+                    dimensions = ("feature_id"),
+                    fill_value = np.nan
+                )
+            outflow[:] = full_wbdy_data.q.tolist()
+            f['outflow'].setncatts(
+                {
+                    'long_name': 'Lake Outflow',
+                    'units': 'm3 s-1',
+                    'grid_mapping': 'crs',
+                    'valid_range': [-1000000,1000000],
+                    'coordinates': 'latitude longitude',
+                    'add_offset': 0.0,
+                    'scale_factor': 0.01,
+                    'missing_value': -999900
+                }
+            )
+
+            # =========== depth VARIABLE ===============            
+            depth = f.createVariable(
+                    varname = "water_sfc_elev",
+                    datatype = "f4",
+                    dimensions = ("feature_id"),
+                    fill_value = np.nan
+                )
+            depth[:] = full_wbdy_data.d.tolist()
+            f['water_sfc_elev'].setncatts(
+                {
+                    'long_name': 'Water Surface Elevation',
+                    'units': 'm',
+                    'comment': 'If reservoir_type = 4, water_sfc_elev is invalid because this value corresponds only to level pool',
+                    'coordinates': 'latitude longitude'
+                }
+            )
+
+            # =========== GLOBAL ATTRIBUTES ===============  
+            f.setncatts(
+                {
+                    'TITLE': 'OUTPUT FROM T-ROUTE',
+                    'featureType': 'timeSeries',
+                    'proj4': '+proj=lcc +units=m +a=6370000.0 +b=6370000.0 +lat_1=30.0 +lat_2=60.0 +lat_0=40.0 +lon_0=-97.0 +x_0=0 +y_0=0 +k_0=1.0 +nadgrids=@',
+                    'model_initialization_time': t0.strftime('%Y-%m-%d_%H:%M:%S'),
+                    'station_dimension': 'lake_id',
+                    'model_output_valid_time': wbdy_time[0].strftime('%Y-%m-%d_%H:%M:%S'),
+                    'model_total_valid_times': nts,
+                    'Conventions': 'CF-1.6',
+                    'code_version': '',
+                    'model_output_type': 'reservoir',
+                    'model_configuration': ''
+                }
+            )

--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -1566,8 +1566,7 @@ def write_waterbody_netcdf(
     waterbodies_df, 
     t0, 
     dt, 
-    nts,
-    time_index
+    nts
 ):
     
     '''
@@ -1600,7 +1599,7 @@ def write_waterbody_netcdf(
     wbdy_data = wbdy_df.drop(columns='reservoir_type').pivot(index=['ID','time'],columns='variable',values='value')
     
     # array of simulation time
-    wbdy_time = [t0 + timedelta(seconds = (time_index+1) * dt)]
+    wbdy_time = [t0 + timedelta(seconds = (wbdy_df.time.unique()[0] + 1).tolist() * dt)]
     
     # Merge waterbodies_df with wbdy_data
     full_wbdy_data = pd.merge(waterbodies_df,wbdy_data,on = 'ID')

--- a/src/troute-nwm/src/nwm_routing/__main__.py
+++ b/src/troute-nwm/src/nwm_routing/__main__.py
@@ -580,7 +580,7 @@ def main_v03(argv):
         if showtiming:
             ic_end_time = time.time()
             task_times['initial_condition_time'] += ic_end_time - ic_start_time
-                
+        
         nwm_output_generator(
             run,
             run_results,
@@ -592,6 +592,8 @@ def main_v03(argv):
             qts_subdivisions,
             compute_parameters.get("return_courant", False),
             cpu_pool,
+            waterbodies_df,
+            waterbody_types_df,
             data_assimilation_parameters,
             lastobs_df,
             link_gage_df,

--- a/src/troute-nwm/src/nwm_routing/output.py
+++ b/src/troute-nwm/src/nwm_routing/output.py
@@ -337,36 +337,31 @@ def nwm_output_generator(
         
         LOG.debug("writing flow data to CHANOBS took %s seconds." % (time.time() - start))       
 
-    # Write out LastObs as netcdf.
-    # Assumed that this capability is only needed for AnA simulations
-    # i.e. when timeslice files are provided to support DA
-    streamflow_da = data_assimilation_parameters.get('streamflow_da', None)
-    if streamflow_da:
-        lastobs_output_folder = streamflow_da.get(
-            "lastobs_output_folder", None
-            )
-    
-    data_assimilation_folder = data_assimilation_parameters.get(
-    "usgs_timeslices_folder", None
-    )
+        # Write out LastObs as netcdf.
+        # This is only needed if 1) streamflow nudging is ON and 2) a lastobs output
+        # folder is provided by the user.
+        streamflow_da = data_assimilation_parameters.get('streamflow_da', None)
+        nudging_true = streamflow_da.get('streamflow_nudging', None)
+        if streamflow_da:
+            lastobs_output_folder = streamflow_da.get(
+                "lastobs_output_folder", None
+                )
 
-    # if lastobs_output_folder:
-    #     warnings.warn("No LastObs output folder directory specified in input file - not writing out LastObs data")
-    if data_assimilation_folder and lastobs_output_folder:
-        
-        LOG.info("- writing lastobs files")
-        start = time.time()
-        
-        nhd_io.lastobs_df_output(
-            lastobs_df,
-            dt,
-            nts,
-            t0,
-            link_gage_df['gages'],
-            lastobs_output_folder,
-        )
-        
-        LOG.debug("writing lastobs files took %s seconds." % (time.time() - start))
+        if nudging_true and lastobs_output_folder:
+
+            LOG.info("- writing lastobs files")
+            start = time.time()
+
+            nhd_io.lastobs_df_output(
+                lastobs_df,
+                dt,
+                nts,
+                t0,
+                link_gage_df['gages'],
+                lastobs_output_folder,
+            )
+
+            LOG.debug("writing lastobs files took %s seconds." % (time.time() - start))
 
     if 'flowveldepth' in locals():
         LOG.debug(flowveldepth)

--- a/src/troute-nwm/src/nwm_routing/output.py
+++ b/src/troute-nwm/src/nwm_routing/output.py
@@ -160,6 +160,10 @@ def nwm_output_generator(
             wbdy_df = pd.merge(pd.concat([i_df,q_df,d_df]),
                                waterbody_types_df.reset_index().rename(columns = {'lake_id': 'ID'}),
                                on = 'ID')
+            
+            #filter only timesteps at dt*qts_subdivisions intervals
+            timestep_index = np.where(((wbdy_df.time.unique() + 1) * dt) % (dt * qts_subdivisions) == 0)
+            wbdy_df = wbdy_df[wbdy_df.time.isin(timestep_index[0])]
         
         # replace waterbody lake_ids with outlet link ids
         if link_lake_crosswalk:
@@ -197,7 +201,7 @@ def nwm_output_generator(
         LOG.info("- writing t-route flow results to LAKEOUT files")
         start = time.time()
         
-        for time_index, i in enumerate(wbdy_df.time.unique()):
+        for i in wbdy_df.time.unique():
             
             nhd_io.write_waterbody_netcdf(
                 wbdyo, 
@@ -206,7 +210,6 @@ def nwm_output_generator(
                 t0, 
                 dt, 
                 nts,
-                time_index,
             )
         
         

--- a/src/troute-nwm/src/nwm_routing/output.py
+++ b/src/troute-nwm/src/nwm_routing/output.py
@@ -113,7 +113,7 @@ def nwm_output_generator(
     chrto = output_parameters.get("chrtout_output", None)
     test = output_parameters.get("test_output", None)
     chano = output_parameters.get("chanobs_output", None)
-    wbdyo = output_parameters.get("wbdy_output", None)
+    wbdyo = output_parameters.get("lakeout_output", None)
 
     if csv_output:
         csv_output_folder = output_parameters["csv_output"].get(
@@ -142,7 +142,7 @@ def nwm_output_generator(
             ).to_flat_index()
 
             wbdy = pd.concat(
-                [pd.DataFrame(r[4], index=r[0], columns=i_columns) for r in results],
+                [pd.DataFrame(r[6], index=r[0], columns=i_columns) for r in results],
                 copy=False,
             ).reset_index().rename(columns = {'index': 'ID'})
 

--- a/src/troute-nwm/src/nwm_routing/output.py
+++ b/src/troute-nwm/src/nwm_routing/output.py
@@ -190,6 +190,26 @@ def nwm_output_generator(
     if test:
         flowveldepth.to_pickle(Path(test))
     
+    if wbdyo:
+        
+        LOG.info("- writing t-route flow results to LAKEOUT files")
+        start = time.time()
+        
+        for time_index, i in enumerate(wbdy_df.time.unique()):
+            
+            nhd_io.write_waterbody_netcdf(
+                wbdyo, 
+                wbdy_df[wbdy_df.time==i], 
+                waterbodies_df, 
+                t0, 
+                dt, 
+                nts,
+                time_index,
+            )
+        
+        
+        LOG.debug("writing LAKEOUT files took a total time of %s seconds." % (time.time() - start))
+    
     if rsrto:
 
         LOG.info("- writing restart files")

--- a/src/troute-routing/troute/routing/compute.py
+++ b/src/troute-routing/troute/routing/compute.py
@@ -1173,6 +1173,7 @@ def compute_diffusive_routing(
                 # place-holder for reservoir DA paramters
                 (np.asarray([]), np.asarray([]), np.asarray([]), np.asarray([]), np.asarray([])),
                 (np.asarray([]), np.asarray([]), np.asarray([]), np.asarray([]), np.asarray([])),
+                np.asarray([])
             )
         )
 

--- a/src/troute-routing/troute/routing/compute.py
+++ b/src/troute-routing/troute/routing/compute.py
@@ -1173,7 +1173,8 @@ def compute_diffusive_routing(
                 # place-holder for reservoir DA paramters
                 (np.asarray([]), np.asarray([]), np.asarray([]), np.asarray([]), np.asarray([])),
                 (np.asarray([]), np.asarray([]), np.asarray([]), np.asarray([]), np.asarray([])),
-                np.asarray([])
+                # place holder for reservoir inflows
+                np.zeros(dat_all[~x,3::3].shape)
             )
         )
 

--- a/src/troute-routing/troute/routing/fast_reach/mc_reach.pyx
+++ b/src/troute-routing/troute/routing/fast_reach/mc_reach.pyx
@@ -435,6 +435,7 @@ cpdef object compute_network_structured(
     cdef _Reach* r
     #create a memory view of the ndarray
     cdef float[:,:,::1] flowveldepth = flowveldepth_nd
+    cdef np.ndarray[float, ndim=3] upstream_array = np.zeros((data_idx.shape[0], nsteps+1, 1), dtype='float32')
     cdef float reservoir_outflow, reservoir_water_elevation
     cdef int id = 0
     
@@ -549,12 +550,14 @@ cpdef object compute_network_structured(
                 flowveldepth[r.id, timestep, 0] = reservoir_outflow
                 flowveldepth[r.id, timestep, 1] = 0.0
                 flowveldepth[r.id, timestep, 2] = reservoir_water_elevation
+                upstream_array[r.id, timestep, 0] = upstream_flows
 
             elif r.type == compute_type.RESERVOIR_RFC:
                 run_rfc_c(r, upstream_flows, 0.0, routing_period, &reservoir_outflow, &reservoir_water_elevation)
                 flowveldepth[r.id, timestep, 0] = reservoir_outflow
                 flowveldepth[r.id, timestep, 1] = 0.0
                 flowveldepth[r.id, timestep, 2] = reservoir_water_elevation
+                upstream_array[r.id, timestep, 0] = upstream_flows
             
             else:
                 #Create compute reach kernel input buffer
@@ -645,5 +648,7 @@ cpdef object compute_network_structured(
     free(reach_structs)
     #slice off the initial condition timestep and return
     output = np.asarray(flowveldepth[:,1:,:], dtype='float32')
+    #do the same for the upstream_array
+    output_upstream = np.asarray(upstream_array[:,1:,:], dtype='float32')
     #return np.asarray(data_idx, dtype=np.intp), np.asarray(flowveldepth.base.reshape(flowveldepth.shape[0], -1), dtype='float32')
-    return np.asarray(data_idx, dtype=np.intp)[fill_index_mask], output.reshape(output.shape[0], -1)[fill_index_mask], 0, (np.asarray([data_idx[usgs_position_i] for usgs_position_i in usgs_positions]), np.asarray(lastobs_times), np.asarray(lastobs_values)), (usgs_idx, usgs_update_time-((timestep-1)*dt), usgs_prev_persisted_ouflow, usgs_prev_persistence_index, usgs_persistence_update_time-((timestep-1)*dt)), (usace_idx, usace_update_time-((timestep-1)*dt), usace_prev_persisted_ouflow, usace_prev_persistence_index, usace_persistence_update_time-((timestep-1)*dt))
+    return np.asarray(data_idx, dtype=np.intp)[fill_index_mask], output.reshape(output.shape[0], -1)[fill_index_mask], 0, (np.asarray([data_idx[usgs_position_i] for usgs_position_i in usgs_positions]), np.asarray(lastobs_times), np.asarray(lastobs_values)), (usgs_idx, usgs_update_time-((timestep-1)*dt), usgs_prev_persisted_ouflow, usgs_prev_persistence_index, usgs_persistence_update_time-((timestep-1)*dt)), (usace_idx, usace_update_time-((timestep-1)*dt), usace_prev_persisted_ouflow, usace_prev_persistence_index, usace_persistence_update_time-((timestep-1)*dt)), output_upstream.reshape(output.shape[0], -1)[fill_index_mask]

--- a/src/troute-routing/troute/routing/fast_reach/mc_reach.pyx
+++ b/src/troute-routing/troute/routing/fast_reach/mc_reach.pyx
@@ -435,7 +435,7 @@ cpdef object compute_network_structured(
     cdef _Reach* r
     #create a memory view of the ndarray
     cdef float[:,:,::1] flowveldepth = flowveldepth_nd
-    cdef np.ndarray[float, ndim=3] upstream_array = np.zeros((data_idx.shape[0], nsteps+1, 1), dtype='float32')
+    cdef np.ndarray[float, ndim=3] upstream_array = np.empty((data_idx.shape[0], nsteps+1, 1), dtype='float32')
     cdef float reservoir_outflow, reservoir_water_elevation
     cdef int id = 0
     

--- a/test/LowerColorado_TX/test_AnA.yaml
+++ b/test/LowerColorado_TX/test_AnA.yaml
@@ -83,7 +83,5 @@ output_parameters:
         #----------
         chanobs_output_directory: output/
         chanobs_filepath        : LowerColorado_chanobs.nc
-    lakebody_output:
-        #----------
-        lakeout_output_directory: lakeout/
+    lakeout_output: lakeout/
     

--- a/test/LowerColorado_TX/test_AnA.yaml
+++ b/test/LowerColorado_TX/test_AnA.yaml
@@ -83,4 +83,7 @@ output_parameters:
         #----------
         chanobs_output_directory: output/
         chanobs_filepath        : LowerColorado_chanobs.nc
+    lakebody_output:
+        #----------
+        lakeout_output_directory: lakeout/
     


### PR DESCRIPTION
Added the capability to write LAKEOUT netcdf files containing inflow, outflow, and depth of waterbodies. One file is created per time step of the run.

## Additions

- lakeout_output parameter to output parameters in yaml file (documentation also added to v3_doc.yaml)
- added lakeout directory in test directory where LAKEOUT netcdf files will be saved.
- write_waterbody_netcdf function to nhd_io.py file. This function writes one netcdf file per time step containing information for all waterbodies
- waterbodies_df and waterbody_types_df added as input parameters to nwm_output_generator function in __main__.py
- waterbodies_df and waterbody_types_df added as input parameters to nwm_output_generator function in output.py
- added wbdyo from lakeout_ouput parameter in nwm_output_generator function
- added creation of wbdy_df containing waterbody parameters. Added conditionals to only perform these calculations if waterbodies are being used.
- added upstream_array in mc_reach.pyx which is an empty array that is populated with the inflow for waterbodies. returned as 6th index

## Removals

-

## Changes

-

## Testing

1. Verified that netcdf files print to correct directory
2. Verified that no files are created if data assimilation is turned off, or if reaches are not separated by waterbodies
3. Verified that netcdf files created by write_waterbody_netcdf function contain all necessary components/metadata

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
