### PR TITLE
update initial value of  water elevation for preventing any numerical…

### DIFF
--- a/src/kernel/diffusive/diffusive.f90
+++ b/src/kernel/diffusive/diffusive.f90
@@ -489,6 +489,13 @@ contains
       end if              
      
       ! compute newY(i, j) for i=1, ncomp-1 with the given newY(ncomp, j)
+      ! ** At intial time, oldY(i,j) values at i < ncomp, used in subroutine rtsafe, are not defined.
+      ! ** So, let's assume the values are all equal to flow at the bottom node.
+      do i = 1, ncomp -1
+        oldY(i,j) = newY(ncomp, j)
+      end do
+          
+      ! compute newY(i, j) for i=1, ncomp-1 with the given newY(ncomp, j)
       call mesh_diffusive_backward(dtini_given, t0, t, tfin, saveInterval, j)
 
       do i = 1,ncomp      


### PR DESCRIPTION
… error caused by initial elevation condition

[Short description explaining the high-level reason for the pull request]

## Additions

- Initial condition of water elevation was updated in diffusive.f90 for preventing any numerical errors caused by setting an unreasonable initial condition.

## Removals

-

## Changes

-

## Testing

1.  Diffusive run with NCAR provided simulation time period 
Using forcing data in inland_config_hybrid_old.yaml, diffusive wave routing was run for 28hrs from 2021-09-01 on Lower Colorado River starting just below Austin up to its outlet in the Gulf of Mexico at the Martagorda Bay.   The figure shows the results from this run.

![Recording 2022-04-18 at 16 37 17 (1)](https://user-images.githubusercontent.com/54687070/164044699-c634b734-fd01-4558-960f-d04f3762311b.gif)


## Screenshots




## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
