### PR TITLE
Hack to accommodate Alaska glacially dammed lakes (GDLs)

### DIFF
--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -1254,6 +1254,12 @@ def get_channel_restart_from_wrf_hydro(
         inplace=True,
     )
     qdf2[channel_ID_column] = xdf
+    
+    # handle GDL sythetic waterbody segmetns
+    gdl_idx = qdf2[qdf2['link'] < 10].index
+    if not gdl_idx.empty:
+        qdf2.loc[gdl_idx,"link"] = (qdf2.loc[gdl_idx,"link"] + 9999).astype("int64")
+    
     qdf2 = qdf2.reset_index().set_index([channel_ID_column])
 
     q_initial_states = qdf2

--- a/src/troute-network/troute/nhd_network_utilities_v02.py
+++ b/src/troute-network/troute/nhd_network_utilities_v02.py
@@ -68,6 +68,12 @@ def build_connections(supernetwork_parameters):
     # rename dataframe columns to keys in the cols dict variable
     param_df = param_df.rename(columns=nhd_network.reverse_dict(cols))
     
+
+    # handle GDL sythetic waterbody segmetns
+    gdl_idx = param_df[param_df['key'] < 10].index
+    if not gdl_idx.empty:
+        param_df.loc[gdl_idx,"key"] = (param_df.loc[gdl_idx,"key"] + 9999).astype("int64")
+    
     # handle synthetic waterbody segments
     synthetic_wb_segments = supernetwork_parameters.get("synthetic_wb_segments", None)
     synthetic_wb_id_offset = supernetwork_parameters.get("synthetic_wb_id_offset", 9.99e11)


### PR DESCRIPTION
# The Issue
The Alaska domain contains six glacially dammed lakes. These waterbodies are unique in that they have zero area, their `lake_id` values are single digit integers, and the "synthetic" stream segments underlying the waterbodies have link ids that are the same as the `lake_id`. 
```
         LkArea     LkMxE  WeirC  WeirL  OrificeC  OrificeA  OrificeE        lat         lon       time     WeirE  ascendingIndex  ifd  Dam_Length crs
lake_id                                                                                                                                               
1           0.0  140.0000    0.0    0.0       0.0       0.0  140.0000  60.291977 -149.340302 2000-01-01  140.0000             168  1.0        10.0    
2           0.0   56.0000    0.0    0.0       0.0       0.0   56.0000  60.461060 -150.561066 2000-01-01   56.0000              31  1.0        10.0    
3           0.0    4.1238    0.0    0.0       0.0       0.0    4.1238  61.442162 -142.945206 2000-01-01    4.1238              32  1.0        10.0    
4           0.0    0.3910    0.0    0.0       0.0       0.0    0.3910  60.671307 -144.755157 2000-01-01    0.3910              33  1.0        10.0    
5           0.0    0.6549    0.0    0.0       0.0       0.0    0.6549  61.149956 -146.168121 2000-01-01    0.6549             158  1.0        10.0    
6           0.0    3.4860    0.0    0.0       0.0       0.0    3.4860  62.058807 -145.452637 2000-01-01    3.4860              45  1.0        10.0   
```
Because there are matching `lake_id` and `key` values between the `waterbodies_df` and `param_df` for GDLs, the `q0` data frame returned by `__main__.new_nwm_q0` contains duplicate indices for each GDL. Which causes downstream issues. The root of this problem is a line in `compute.py`, which inserts `lake_ids` into the list of segments (this line is repeated for all parallel options):
```python
            param_df_sub = param_df_sub.reindex(
                param_df_sub.index.tolist() + lake_segs
            ).sort_index()
```
Here, the `lake_segs` of GDLs are numbered the same as the synthetic stream segments underlying the GDL, which causes duplicate indices. 
As it turns out, t-route assumes that `lake_ids` are globally unique integers across all other waterbodies AND stream segment link ids. However, this is NOT assumed by the designers of the model hydrofabric. 

# Hacky solution
The solution proposed in this pull request is to re-number the synthetic stream segment IDs underlying GDLs such that they are globally unique. This re-numbering needs to occur in two places: directly after reading-in the RouteLink file during the creation of `param_df` and again after reading-in the RouteLink file when creating the `q0` dataframe, in cases where initial conditions are read from a WRF restart file. 

