### PR TITLE
Quick fixes related to calibration

### DIFF
--- a/src/troute-nwm/src/nwm_routing/output.py
+++ b/src/troute-nwm/src/nwm_routing/output.py
@@ -340,12 +340,14 @@ def nwm_output_generator(
         # Write out LastObs as netcdf.
         # This is only needed if 1) streamflow nudging is ON and 2) a lastobs output
         # folder is provided by the user.
+        lastobs_output_folder = None
+        nudging_true = None
         streamflow_da = data_assimilation_parameters.get('streamflow_da', None)
-        nudging_true = streamflow_da.get('streamflow_nudging', None)
         if streamflow_da:
             lastobs_output_folder = streamflow_da.get(
                 "lastobs_output_folder", None
                 )
+            nudging_true = streamflow_da.get('streamflow_nudging', None)
 
         if nudging_true and lastobs_output_folder:
 

--- a/src/troute-nwm/src/nwm_routing/preprocess.py
+++ b/src/troute-nwm/src/nwm_routing/preprocess.py
@@ -607,6 +607,7 @@ def nwm_initial_warmstate_preprocess(
         q0, t0 = nhd_io.read_lite_restart(
             restart_parameters['lite_channel_restart_file']
         )
+        t0_str = None
     
     # build initial states from user-provided restart parameters
     else:


### PR DESCRIPTION
Two bugs:

- Initial time read-in from lite restart was causing error
- When data assimilation parameters are not provided, errors arise in output.py

