### PR TITLE
edits to only calculate subnetworks on first iteration of for loops

### DIFF
--- a/src/troute-nwm/src/nwm_routing/__main__.py
+++ b/src/troute-nwm/src/nwm_routing/__main__.py
@@ -76,6 +76,7 @@ def nwm_route(
     diffusive_parameters,
     diffusive_network_data,
     topobathy_data,
+    subnetwork_list,
 ):
 
     ################### Main Execution Loop across ordered networks
@@ -121,7 +122,12 @@ def nwm_route(
         waterbody_parameters,
         waterbody_types_df,
         waterbody_type_specified,
+        subnetwork_list,
     )
+    
+    # returns list, first item is run result, second item is subnetwork items
+    subnetwork_list = results[1]
+    results = results[0]
     
     if diffusive_network_data: # run diffusive side of a hybrid simulation
         
@@ -151,7 +157,7 @@ def nwm_route(
 
     LOG.debug("ordered reach computation complete in %s seconds." % (time.time() - start_time))
 
-    return results
+    return results, subnetwork_list
 
 
 def new_nwm_q0(run_results):
@@ -442,6 +448,11 @@ def main_v03(argv):
         forcing_end_time = time.time()
         task_times['forcing_time'] += forcing_end_time - ic_end_time
 
+    # Pass empty subnetwork list to nwm_route. These objects will be calculated/populated
+    # on first iteration of for loop only. For additional loops this will be passed
+    # to function from inital loop. 
+    subnetwork_list = [None, None, None]
+        
     for run_set_iterator, run in enumerate(run_sets):
 
         t0 = run.get("t0")
@@ -488,7 +499,12 @@ def main_v03(argv):
             diffusive_parameters,
             diffusive_network_data,
             topobathy_data,
+            subnetwork_list,
         )
+        
+        # returns list, first item is run result, second item is subnetwork items
+        subnetwork_list = run_results[1]
+        run_results = run_results[0]
         
         if showtiming:
             route_end_time = time.time()


### PR DESCRIPTION
Changes made to only calculate subnetworks on first iteration of for loops. Subnetwork objects needed in compute.py are stored in a new list, subnetwork_list, which is passed to and returned from functions nwm_route and compute_nhd_routing_v02.

## Additions

- New object, subnetwork_list, stores either two (for "by-subnetwork-jit-clustered") or three (for "by-subnetwork-jit") subnetwork objects.
- subnetwork_list is passed to and returned from two functions,  nwm_route and compute_nhd_routing_v02, as second item in list. The first item is the original returns from these functions.
- Original returns and subnetwork list are extracted as individual objects upon completion of functions nwm_route and compute_nhd_routing_v02 so as to not interfere with ensuing operations to results.

## Removals

-

## Changes

-

## Testing

1. Tested that code completes with loops for all parallel compute methods

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
