### PR TITLE
bug fix: empty reservoir_types_df causes failure when looping

### DIFF
--- a/src/troute-nwm/src/nwm_routing/__main__.py
+++ b/src/troute-nwm/src/nwm_routing/__main__.py
@@ -538,27 +538,28 @@ def main_v03(argv):
             # but there are DA parameters from the previous loop, then create a
             # dummy observations df. This allows the reservoir persistence to continue across loops.
             # USGS Reservoirs
-            if 2 in waterbody_types_df['reservoir_type'].unique():
-                if reservoir_usgs_df.empty and len(reservoir_usgs_param_df.index) > 0:
-                    reservoir_usgs_df = pd.DataFrame(
-                        data    = np.nan, 
-                        index   = reservoir_usgs_param_df.index, 
-                        columns = [t0]
-                    )
-                    
-            # USACE Reservoirs   
-            if 3 in waterbody_types_df['reservoir_type'].unique():
-                if reservoir_usace_df.empty and len(reservoir_usace_param_df.index) > 0:
-                    reservoir_usace_df = pd.DataFrame(
-                        data    = np.nan, 
-                        index   = reservoir_usgs_param_df.index, 
-                        columns = [t0]
-                    )
-                
-            # update RFC lookback hours if there are RFC-type reservoirs in the simulation domain
-            if 4 in waterbody_types_df['reservoir_type'].unique():
-                waterbody_parameters = update_lookback_hours(dt, nts, waterbody_parameters)     
-                
+            if not waterbody_types_df.empty:
+                if 2 in waterbody_types_df['reservoir_type'].unique():
+                    if reservoir_usgs_df.empty and len(reservoir_usgs_param_df.index) > 0:
+                        reservoir_usgs_df = pd.DataFrame(
+                            data    = np.nan, 
+                            index   = reservoir_usgs_param_df.index, 
+                            columns = [t0]
+                        )
+
+                # USACE Reservoirs   
+                if 3 in waterbody_types_df['reservoir_type'].unique():
+                    if reservoir_usace_df.empty and len(reservoir_usace_param_df.index) > 0:
+                        reservoir_usace_df = pd.DataFrame(
+                            data    = np.nan, 
+                            index   = reservoir_usgs_param_df.index, 
+                            columns = [t0]
+                        )
+
+                # update RFC lookback hours if there are RFC-type reservoirs in the simulation domain
+                if 4 in waterbody_types_df['reservoir_type'].unique():
+                    waterbody_parameters = update_lookback_hours(dt, nts, waterbody_parameters)     
+
             if showtiming:
                 forcing_end_time = time.time()
                 task_times['forcing_time'] += forcing_end_time - route_end_time


### PR DESCRIPTION
Code fails for situations when the `reservoir_types_df` is empty, which can occur if the user opts not to simulate waterbodies or there are no waterbodies in the domain, and there are more than one loops for a simulation. This is fixed by adding an if-statement in `__main__.py`, that avoids referencing `reservoir_types_df` columns if the dataframe is empty.

The new code (lines 542 - 562 in `__main__.py`) appear below. You can see that the outermost if-statement guards against referencing the `waterbody_types_df` dataframe if it is empty. 
``` python
            if not waterbody_types_df.empty:
                if 2 in waterbody_types_df['reservoir_type'].unique():
                    if reservoir_usgs_df.empty and len(reservoir_usgs_param_df.index) > 0:
                        reservoir_usgs_df = pd.DataFrame(
                            data    = np.nan, 
                            index   = reservoir_usgs_param_df.index, 
                            columns = [t0]
                        )

                # USACE Reservoirs   
                if 3 in waterbody_types_df['reservoir_type'].unique():
                    if reservoir_usace_df.empty and len(reservoir_usace_param_df.index) > 0:
                        reservoir_usace_df = pd.DataFrame(
                            data    = np.nan, 
                            index   = reservoir_usgs_param_df.index, 
                            columns = [t0]
                        )

                # update RFC lookback hours if there are RFC-type reservoirs in the simulation domain
                if 4 in waterbody_types_df['reservoir_type'].unique():
                    waterbody_parameters = update_lookback_hours(dt, nts, waterbody_parameters)  
```
