### PR TITLE
Changes to handle reservoir persistence

### DIFF
--- a/src/troute-routing/troute/routing/compute.py
+++ b/src/troute-routing/troute/routing/compute.py
@@ -354,7 +354,7 @@ def compute_nhd_routing_v02(
             subnetwork_list = copy.deepcopy(subnetwork_list)
 
         else:
-            subnetworks_only_ordered_jit, reaches_ordered_bysubntw_clustered = subnetwork_list
+            subnetworks_only_ordered_jit, reaches_ordered_bysubntw_clustered = copy.deepcopy(subnetwork_list)
         
         if 1 == 1:
             LOG.info("JIT Preprocessing time %s seconds." % (time.time() - start_time))
@@ -418,6 +418,11 @@ def compute_nhd_routing_v02(
                     else:
                         lake_segs = []
                         waterbodies_df_sub = pd.DataFrame()
+                    
+                    #check if any DA reservoirs are offnetwork. if so change reservoir type to
+                    #1: levelpool
+                    tmp_lake_ids = list(set(waterbody_types_df_sub.index).intersection(offnetwork_upstreams))
+                    waterbody_types_df_sub.at[tmp_lake_ids,'reservoir_type'] = 1
                     
                     param_df_sub = param_df.loc[
                         common_segs,


### PR DESCRIPTION
Added some script to allow reservoir persistence. If a reservoir is in the offnetwork_upstream list the reservoir type is set to 1=levelpool. This prevents reservoir DA from occurring twice in separate subnetworks.

## Additions

- Checks if lake id is in offnetwork_upstream list. If so the reservoir type for the given lake id in the subnetwork is changed to levelpool.
- Unrelated, but a deepcopy is made of the of the subnetwork list because for some reason it was being altered when parallel processing occurs.

## Removals

-

## Changes

-

## Testing

1. 

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
