### PR TITLE
solve roredered_reaches issue when two independent diffusive mainstem domains are applied

### DIFF
--- a/src/troute-network/troute/nhd_network_utilities_v02.py
+++ b/src/troute-network/troute/nhd_network_utilities_v02.py
@@ -844,17 +844,8 @@ def build_refac_connections(diff_network_parameters):
     param_df = param_df.rename(columns=nhd_network.reverse_dict(cols))
 
     # set parameter dataframe index as segment id number, sort
-    param_df = param_df.set_index("key").sort_index()
-
-    # get and apply domain mask
-    if "mask_file_path" in diff_network_parameters:
-        data_mask = nhd_io.read_mask(
-            pathlib.Path(diff_network_parameters["mask_file_path"]),
-            layer_string=diff_network_parameters.get("mask_layer_string", None),
-        )
-        data_mask = data_mask.set_index(data_mask.columns[0])
-        param_df = param_df.filter(data_mask.index, axis=0)
-    
+    param_df = param_df.set_index("key").sort_index()  
+   
     # There can be an externally determined terminal code -- that's this first value
     terminal_codes = set()
     terminal_codes.update(terminal_code)

--- a/src/troute-nwm/src/nwm_routing/preprocess.py
+++ b/src/troute-nwm/src/nwm_routing/preprocess.py
@@ -138,6 +138,10 @@ def nwm_network_preprocess(
                 # ... dataframe returned from read_netcdf, then the code would break here.
                 topobathy_data = (nhd_io.read_netcdf(topobathy_file).set_index('link'))
                 
+                # TODO: Request GID make comID variable an integer in their product, so
+                # we do not need to change variable types, here.
+                topobathy_data.index = topobathy_data.index.astype(int)
+                
             else:
                 topobathy_data = pd.DataFrame()
                 LOG.debug('No natural cross section topobathy data provided. Hybrid simualtion will run on compound trapezoidal geometry.')
@@ -204,7 +208,6 @@ def nwm_network_preprocess(
 
     link_gage_df = pd.DataFrame.from_dict(gages)
     link_gage_df.index.name = 'link'
-    
     break_network_at_waterbodies = waterbody_parameters.get(
         "break_network_at_waterbodies", False
     )
@@ -348,10 +351,8 @@ def nwm_network_preprocess(
                         trib_segs.append(u)            
             
             diffusive_network_data[tw]['tributary_segments'] = trib_segs
-
             # diffusive domain connections object
-            diffusive_network_data[tw]['connections'] = {k: connections[k] for k in (mainstem_segs + trib_segs)}
-            
+            diffusive_network_data[tw]['connections'] = {k: connections[k] for k in (mainstem_segs + trib_segs)}       
             # diffusive domain reaches and upstream connections. 
             # break network at tributary segments
             _, reaches, rconn_diff = nnu.organize_independent_networks(
@@ -374,11 +375,11 @@ def nwm_network_preprocess(
                 refac_tw = refactored_diffusive_domain[tw]['refac_tw']
                 refactored_diffusive_network_data[refac_tw] = {}                
                 refactored_diffusive_network_data[refac_tw]['tributary_segments'] = trib_segs
-                
+
                 # Build connections with rlink mainstem and link tributaries
                 refactored_diffusive_network_data[refac_tw]['connections'] = refactored_connections                
                 refactored_diffusive_network_data[refac_tw]['connections'].update({k: [refactored_diffusive_domain[tw]['incoming_tribs'][k]] for k in (trib_segs)})
-  
+               
                 # diffusive domain reaches and upstream connections. 
                 # break network at tributary segments
                 _, refactored_reaches_batch, refactored_conn_diff = nnu.organize_independent_networks(

--- a/src/troute-nwm/src/nwm_routing/preprocess.py
+++ b/src/troute-nwm/src/nwm_routing/preprocess.py
@@ -138,10 +138,6 @@ def nwm_network_preprocess(
                 # ... dataframe returned from read_netcdf, then the code would break here.
                 topobathy_data = (nhd_io.read_netcdf(topobathy_file).set_index('link'))
                 
-                # TODO: Request GID make comID variable an integer in their product, so
-                # we do not need to change variable types, here.
-                topobathy_data.index = topobathy_data.index.astype(int)
-                
             else:
                 topobathy_data = pd.DataFrame()
                 LOG.debug('No natural cross section topobathy data provided. Hybrid simualtion will run on compound trapezoidal geometry.')

--- a/src/troute-nwm/src/nwm_routing/preprocess.py
+++ b/src/troute-nwm/src/nwm_routing/preprocess.py
@@ -329,7 +329,7 @@ def nwm_network_preprocess(
     if diffusive_domain:
         
         rconn = nhd_network.reverse_network(connections)
-
+        refactored_reaches={}
         for tw in diffusive_domain:
             
             mainstem_segs = diffusive_domain[tw]['links']           
@@ -378,15 +378,18 @@ def nwm_network_preprocess(
                 # Build connections with rlink mainstem and link tributaries
                 refactored_diffusive_network_data[refac_tw]['connections'] = refactored_connections                
                 refactored_diffusive_network_data[refac_tw]['connections'].update({k: [refactored_diffusive_domain[tw]['incoming_tribs'][k]] for k in (trib_segs)})
-                
+  
                 # diffusive domain reaches and upstream connections. 
                 # break network at tributary segments
-                _, refactored_reaches, refactored_conn_diff = nnu.organize_independent_networks(
+                _, refactored_reaches_batch, refactored_conn_diff = nnu.organize_independent_networks(
                                                             refactored_diffusive_network_data[refac_tw]['connections'],
                                                             set(trib_segs),
                                                             set(),
                                                             )
+
+                refactored_reaches[refac_tw] = refactored_reaches_batch[refac_tw]
                 refactored_diffusive_network_data[refac_tw]['mainstem_segs'] = refactored_diffusive_domain[tw]['rlinks']
+                             
             else:
                 refactored_reaches={}
            
@@ -398,11 +401,11 @@ def nwm_network_preprocess(
             # remove keys from connections dictionary
             for s in mainstem_segs:
                 connections.pop(s)
-            
+
             # update downstream connections of trib segs
             for us in trib_segs:
                 connections[us] = []
-    
+
     #============================================================================
     # Identify Independent Networks and Reaches by Network
     LOG.info("organizing connections into reaches ...")


### PR DESCRIPTION
When a single diffusive domain is applied for the hybrid routing in t-route, python dictionary refactored_reaches takes its values as a list of lists of reaches of diffusive mainstem domain. However, when multiple diffusive domains are applied, the dictionary values were somehow melted down to a list of a single list of all diffusive mainstem segments except downstream end segments of tributaries entering the mainstem.  This should be still the same format as a list of lists.  This is solved now.


## Additions

- Python dictionary refactored_reaches_batch takes a list of lists for each diffusive mainstem defined by a given TW and then keep the form in Python dictionary refactored_reaches. 

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
