### PR TITLE
a few changes to help with reservoir DA, fixing typo, moving some DA …

### DIFF
--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -718,7 +718,7 @@ def write_chrtout(
         LOG.debug("Reindexing the flow DataFrame to align with `feature_id` dimension in CHRTOUT files")
         start = time.time()
         
-        with xr.open_dataset(chrtout_files[0]) as ds:
+        with xr.open_dataset(chrtout_files[0],engine='netcdf4') as ds:
             newindex = ds.feature_id.values
             
         qtrt = flow.reindex(newindex).to_numpy().astype("float32")

--- a/src/troute-nwm/src/nwm_routing/__main__.py
+++ b/src/troute-nwm/src/nwm_routing/__main__.py
@@ -577,7 +577,7 @@ def main_v03(argv):
                     if reservoir_usace_df.empty and len(reservoir_usace_param_df.index) > 0:
                         reservoir_usace_df = pd.DataFrame(
                             data    = np.nan, 
-                            index   = reservoir_usgs_param_df.index, 
+                            index   = reservoir_usace_param_df.index, 
                             columns = [t0]
                         )
 

--- a/src/troute-routing/troute/routing/compute.py
+++ b/src/troute-routing/troute/routing/compute.py
@@ -139,7 +139,7 @@ def _prep_da_positions_byreach(reach_list, gage_index):
 
     return reach_key, gage_reach_i
 
-def _prep_reservoir_da_dataframes(reservoir_usgs_df, reservoir_usgs_param_df, reservoir_usace_df, reservoir_usace_param_df, waterbody_types_df_sub, t0):
+def _prep_reservoir_da_dataframes(reservoir_usgs_df, reservoir_usgs_param_df, reservoir_usace_df, reservoir_usace_param_df, waterbody_types_df_sub, t0, exclude_segments=None):
     '''
     Helper function to build reservoir DA data arrays for routing computations
 
@@ -173,6 +173,8 @@ def _prep_reservoir_da_dataframes(reservoir_usgs_df, reservoir_usgs_param_df, re
         usgs_wbodies_sub      = waterbody_types_df_sub[
                                     waterbody_types_df_sub['reservoir_type']==2
                                 ].index
+        if exclude_segments:
+            usgs_wbodies_sub = set(usgs_wbodies_sub).difference(set(exclude_segments))
         reservoir_usgs_df_sub = reservoir_usgs_df.loc[usgs_wbodies_sub]
         reservoir_usgs_df_time = (reservoir_usgs_df.columns - t0).total_seconds().to_numpy()
         reservoir_usgs_update_time = reservoir_usgs_param_df['update_time'].loc[usgs_wbodies_sub].to_numpy()
@@ -194,6 +196,8 @@ def _prep_reservoir_da_dataframes(reservoir_usgs_df, reservoir_usgs_param_df, re
         usace_wbodies_sub      = waterbody_types_df_sub[
                                     waterbody_types_df_sub['reservoir_type']==3
                                 ].index
+        if exclude_segments:
+            usace_wbodies_sub = set(usace_wbodies_sub).difference(set(exclude_segments))
         reservoir_usace_df_sub = reservoir_usace_df.loc[usace_wbodies_sub]
         reservoir_usace_df_time = (reservoir_usace_df.columns - t0).total_seconds().to_numpy()
         reservoir_usace_df_time = (reservoir_usace_df.columns - t0).total_seconds().to_numpy()
@@ -421,8 +425,8 @@ def compute_nhd_routing_v02(
                     
                     #check if any DA reservoirs are offnetwork. if so change reservoir type to
                     #1: levelpool
-                    tmp_lake_ids = list(set(waterbody_types_df_sub.index).intersection(offnetwork_upstreams))
-                    waterbody_types_df_sub.at[tmp_lake_ids,'reservoir_type'] = 1
+                    #tmp_lake_ids = list(set(waterbody_types_df_sub.index).intersection(offnetwork_upstreams))
+                    #waterbody_types_df_sub.at[tmp_lake_ids,'reservoir_type'] = 1
                     
                     param_df_sub = param_df.loc[
                         common_segs,
@@ -480,7 +484,8 @@ def compute_nhd_routing_v02(
                         reservoir_usace_df, 
                         reservoir_usace_param_df,
                         waterbody_types_df_sub, 
-                        t0
+                        t0,
+                        offnetwork_upstreams
                     )
                     
                     # results_subn[order].append(


### PR DESCRIPTION
…features into functions

Some minor tweaks related to reservoir DA. Fixed some typos and moved the logic that omits offnetwork_upstreams reservoirs from DA into the _prep_reservoir_da_dataframes function

## Additions

-Fixed a typo in main.py that allows reservoir persistence to continue across loops
-Moved the logic that checks whether or not a reservoir is in the actual network or in the offnetwork_upstreams list. This was done in compute_nhd_routing_v02 by changing the waterbody_types_df_sub dataframe. Now it is done in the _prep_reservoir_da_dataframes function which doesn't require editing any objects in compute_nhd_routing_v02

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
