### PR TITLE
added synthetic_wb_segments parameter under supernetwork_parameters i…

### DIFF
--- a/test/HurricaneLaura/test_AnA.yaml
+++ b/test/HurricaneLaura/test_AnA.yaml
@@ -11,6 +11,11 @@ network_topology_parameters:
         #----------
         geo_file_path: domain/RouteLink_NWMv2.1.nc  
         mask_file_path: domain/coastal_10diffusive.txt
+        synthetic_wb_segments:
+            - 4800002
+            - 4800004
+            - 4800006
+            - 4800007
     waterbody_parameters:
         #----------
         break_network_at_waterbodies: True 


### PR DESCRIPTION
…n the HurricaneLaura test file

Added the list of 4 synthetic waterbody segments to the test_AnA.yaml file for HurricaneLaura. This parameter must be included to run CONUS simulations.

## Additions

- Added 4800002, 4800004, 4800006, & 4800007 under synthetic_wb_segments in the test_AnA.yaml file.

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
