### PR TITLE
Map back water elevation from refactored to unrefactored hydrofabric by interpolating water depth not elevation

### DIFF
--- a/src/kernel/diffusive/pydiffusive.f90
+++ b/src/kernel/diffusive/pydiffusive.f90
@@ -5,12 +5,12 @@ use diffusive, only: diffnw
 
 implicit none
 contains
-subroutine c_diffnw(timestep_ar_g, nts_ql_g, nts_ub_g, nts_db_g, ntss_ev_g, nts_qtrib_g, nts_da_g,    &
-                    mxncomp_g, nrch_g, z_ar_g, bo_ar_g, traps_ar_g, tw_ar_g, twcc_ar_g, mann_ar_g,    &
-                    manncc_ar_g, so_ar_g, dx_ar_g,                                                    &
-                    iniq, frnw_col, frnw_ar_g, qlat_g, ubcd_g, dbcd_g, qtrib_g,                       &
-                    paradim, para_ar_g, mxnbathy_g, x_bathy_g, z_bathy_g, mann_bathy_g, size_bathy_g, &                                      
-                    usgs_da_g, usgs_da_reach_g, rdx_ar_g, cwnrow_g, cwncol_g, crosswalk_g,            &
+subroutine c_diffnw(timestep_ar_g, nts_ql_g, nts_ub_g, nts_db_g, ntss_ev_g, nts_qtrib_g, nts_da_g,      &
+                    mxncomp_g, nrch_g, z_ar_g, bo_ar_g, traps_ar_g, tw_ar_g, twcc_ar_g, mann_ar_g,      &
+                    manncc_ar_g, so_ar_g, dx_ar_g,                                                      &
+                    iniq, frnw_col, frnw_ar_g, qlat_g, ubcd_g, dbcd_g, qtrib_g,                         &
+                    paradim, para_ar_g, mxnbathy_g, x_bathy_g, z_bathy_g, mann_bathy_g, size_bathy_g,   &                                      
+                    usgs_da_g, usgs_da_reach_g, rdx_ar_g, cwnrow_g, cwncol_g, crosswalk_g, z_thalweg_g, &
                     q_ev_g, elv_ev_g) bind(c)      
 
     integer(c_int), intent(in) :: nts_ql_g, nts_ub_g, nts_db_g, nts_qtrib_g, nts_da_g
@@ -33,6 +33,7 @@ subroutine c_diffnw(timestep_ar_g, nts_ql_g, nts_ub_g, nts_db_g, ntss_ev_g, nts_
     real(c_double), dimension(mxncomp_g, nrch_g),   intent(inout) :: so_ar_g
     real(c_double), dimension(mxncomp_g, nrch_g),   intent(in) :: dx_ar_g, rdx_ar_g
     real(c_double), dimension(mxncomp_g, nrch_g),   intent(in) :: iniq
+    real(c_double), dimension(mxncomp_g, nrch_g),   intent(in) :: z_thalweg_g
     real(c_double), dimension(nts_ub_g, nrch_g),    intent(in) :: ubcd_g
     real(c_double), dimension(nts_qtrib_g, nrch_g), intent(in) :: qtrib_g
     real(c_double), dimension(nts_da_g,    nrch_g), intent(in) :: usgs_da_g     
@@ -43,12 +44,12 @@ subroutine c_diffnw(timestep_ar_g, nts_ql_g, nts_ub_g, nts_db_g, ntss_ev_g, nts_
     real(c_double), dimension(cwnrow_g, cwncol_g),            intent(in ) :: crosswalk_g 
     real(c_double), dimension(ntss_ev_g, mxncomp_g, nrch_g),  intent(out) :: q_ev_g, elv_ev_g    
           
-    call diffnw(timestep_ar_g, nts_ql_g, nts_ub_g, nts_db_g, ntss_ev_g, nts_qtrib_g, nts_da_g,    &
-                mxncomp_g, nrch_g, z_ar_g, bo_ar_g, traps_ar_g, tw_ar_g, twcc_ar_g, mann_ar_g,    &
-                manncc_ar_g, so_ar_g, dx_ar_g,                                                    &
-                iniq, frnw_col, frnw_ar_g, qlat_g, ubcd_g, dbcd_g, qtrib_g,                       &
-                paradim, para_ar_g, mxnbathy_g, x_bathy_g, z_bathy_g, mann_bathy_g, size_bathy_g, &
-                usgs_da_g, usgs_da_reach_g, rdx_ar_g, cwnrow_g, cwncol_g, crosswalk_g,            &
+    call diffnw(timestep_ar_g, nts_ql_g, nts_ub_g, nts_db_g, ntss_ev_g, nts_qtrib_g, nts_da_g,      &
+                mxncomp_g, nrch_g, z_ar_g, bo_ar_g, traps_ar_g, tw_ar_g, twcc_ar_g, mann_ar_g,      &
+                manncc_ar_g, so_ar_g, dx_ar_g,                                                      &
+                iniq, frnw_col, frnw_ar_g, qlat_g, ubcd_g, dbcd_g, qtrib_g,                         &
+                paradim, para_ar_g, mxnbathy_g, x_bathy_g, z_bathy_g, mann_bathy_g, size_bathy_g,   &
+                usgs_da_g, usgs_da_reach_g, rdx_ar_g, cwnrow_g, cwncol_g, crosswalk_g, z_thalweg_g, &
                 q_ev_g, elv_ev_g)                                
     
 end subroutine c_diffnw

--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -1657,7 +1657,6 @@ def write_waterbody_netcdf(
     -------------
     
     '''
-    
     i_df.index.name = 'lake_id'
     i_df.columns = ['i']
     i_df = i_df.sort_index()
@@ -1837,6 +1836,7 @@ def write_waterbody_netcdf(
                     dimensions = ("feature_id"),
                     fill_value = -999900
                 )
+
             inflow[:] = i_df.i.tolist()
             f['inflow'].setncatts(
                 {

--- a/src/troute-nwm/src/nwm_routing/__main__.py
+++ b/src/troute-nwm/src/nwm_routing/__main__.py
@@ -548,6 +548,7 @@ def main_v03(argv):
         # create initial conditions for next loop itteration
         q0 = new_nwm_q0(run_results)
         waterbodies_df = get_waterbody_water_elevation(waterbodies_df, q0)
+
         
         # get reservoir DA initial parameters for next loop itteration
         reservoir_usgs_param_df, reservoir_usace_param_df = set_reservoir_da_prams(run_results)

--- a/src/troute-nwm/src/nwm_routing/__main__.py
+++ b/src/troute-nwm/src/nwm_routing/__main__.py
@@ -74,11 +74,12 @@ def nwm_route(
     waterbody_types_df,
     waterbody_type_specified,
     diffusive_network_data,
-    topobathy_data,
+    topobathy,
     refactored_diffusive_domain,
     refactored_reaches,
     subnetwork_list,
     coastal_boundary_depth_df,
+    nonrefactored_topobathy,
 ):
 
     ################### Main Execution Loop across ordered networks
@@ -126,14 +127,13 @@ def nwm_route(
         waterbody_type_specified,
         subnetwork_list,
     )
-
+    LOG.debug("MC computation complete in %s seconds." % (time.time() - start_time_mc))
     # returns list, first item is run result, second item is subnetwork items
     subnetwork_list = results[1]
     results = results[0]
     
     # run diffusive side of a hybrid simulation
-    if diffusive_network_data:         
-        LOG.debug("MC computation complete in %s seconds." % (time.time() - start_time_mc))
+    if diffusive_network_data:
         start_time_diff = time.time()
         '''
         # retrieve MC-computed streamflow value at upstream boundary of diffusive mainstem
@@ -170,10 +170,11 @@ def nwm_route(
                 lastobs_df,
                 da_parameter_dict,
                 waterbodies_df,
-                topobathy_data,
+                topobathy,
                 refactored_diffusive_domain,
                 refactored_reaches,
                 coastal_boundary_depth_df,
+                nonrefactored_topobathy, 
             )
         )
         LOG.debug("Diffusive computation complete in %s seconds." % (time.time() - start_time_diff))
@@ -364,7 +365,10 @@ def main_v03(argv):
             usgs_lake_gage_crosswalk, 
             usace_lake_gage_crosswalk,
             diffusive_network_data,
-            topobathy_data,
+            topobathy,
+            refactored_diffusive_domain,
+            refactored_reaches,
+            nonrefactored_topobathy,
         ) = unpack_nwm_preprocess_data(
             preprocessing_parameters
         )
@@ -387,9 +391,10 @@ def main_v03(argv):
             usgs_lake_gage_crosswalk, 
             usace_lake_gage_crosswalk,
             diffusive_network_data,
-            topobathy_data,
+            topobathy,
             refactored_diffusive_domain,
             refactored_reaches,
+            nonrefactored_topobathy,
         ) = nwm_network_preprocess(
             supernetwork_parameters,
             waterbody_parameters,
@@ -524,11 +529,12 @@ def main_v03(argv):
             waterbody_types_df,
             waterbody_type_specified,
             diffusive_network_data,
-            topobathy_data,
+            topobathy,
             refactored_diffusive_domain,
             refactored_reaches,
             subnetwork_list,
             coastal_boundary_depth_df,
+            nonrefactored_topobathy,
         )
         
         # returns list, first item is run result, second item is subnetwork items

--- a/src/troute-nwm/src/nwm_routing/output.py
+++ b/src/troute-nwm/src/nwm_routing/output.py
@@ -163,7 +163,7 @@ def nwm_output_generator(
             i_df = wbdy.iloc[:,wbdy_col_index]
             q_df = flow_df.iloc[:,0::3]
             d_df = flow_df.iloc[:,2::3]
-        
+
         # replace waterbody lake_ids with outlet link ids
         if link_lake_crosswalk:
             flowveldepth = _reindex_lake_to_link_id(flowveldepth, link_lake_crosswalk)
@@ -200,7 +200,7 @@ def nwm_output_generator(
         time_index, tmp_variable = map(list,zip(*i_df.columns.tolist()))
         LOG.info("- writing t-route flow results to LAKEOUT files")
         start = time.time()
-        
+
         for i in range(i_df.shape[1]):
             
             nhd_io.write_waterbody_netcdf(

--- a/src/troute-nwm/src/nwm_routing/preprocess.py
+++ b/src/troute-nwm/src/nwm_routing/preprocess.py
@@ -154,7 +154,7 @@ def nwm_network_preprocess(
             diffusive_network_data = None
             topobathy              = pd.DataFrame()
             LOG.info('No diffusive domain file specified in configuration file. This is an MC-only simulation')
-        nonrefactored_topobathy = pd.DataFrame()    
+        unrefactored_topobathy = pd.DataFrame()    
         #-------------------------------------------------------------------------
         # for refactored hydofabric 
         if run_hybrid and run_refactored and refactored_domain_file:
@@ -174,10 +174,10 @@ def nwm_network_preprocess(
                 # ... dataframe returned from read_netcdf, then the code would break here.
                 topobathy = (nhd_io.read_netcdf(refactored_topobathy_file).set_index('link'))
 
-                # nonrefactored_topobaty_data is passed to diffusive kernel to provide thalweg elevation of non_refactored topobathy 
+                # unrefactored_topobaty_data is passed to diffusive kernel to provide thalweg elevation of unrefactored topobathy 
                 # for crosswalking water elevations between non-refactored and refactored hydrofabrics. 
-                nonrefactored_topobathy       = (nhd_io.read_netcdf(topobathy_file).set_index('link'))
-                nonrefactored_topobathy.index = nonrefactored_topobathy.index.astype(int)
+                unrefactored_topobathy       = (nhd_io.read_netcdf(topobathy_file).set_index('link'))
+                unrefactored_topobathy.index = unrefactored_topobathy.index.astype(int)
                 
             else:
                 topobathy               = pd.DataFrame()
@@ -196,7 +196,7 @@ def nwm_network_preprocess(
         diffusive_domain                  = None
         diffusive_network_data            = None
         topobathy                         = pd.DataFrame()
-        nonrefactored_topobathy           = pd.DataFrame() 
+        unrefactored_topobathy           = pd.DataFrame() 
         refactored_diffusive_domain       = None
         refactored_diffusive_network_data = None   
         refactored_reaches                = {}
@@ -527,7 +527,7 @@ def nwm_network_preprocess(
         topobathy,
         refactored_diffusive_domain,
         refactored_reaches,
-        nonrefactored_topobathy,
+        unrefactored_topobathy,
     )
 
 def unpack_nwm_preprocess_data(preprocessing_parameters):
@@ -558,7 +558,7 @@ def unpack_nwm_preprocess_data(preprocessing_parameters):
         topobathy                    = inputs.get('topobathy_data',None)        
         refactored_diffusive_domain  = inputs.get('refactored_diffusive_domain',None)
         refactored_reaches           = inputs.get('refactored_reaches',None)
-        nonrefactored_topobathy      = inputs.get(' nonrefactored_topobathy',None)
+        unrefactored_topobathy       = inputs.get('unrefactored_topobathy',None)
 
     else:
         LOG.critical("use_preprocessed_data = True, but no preprocess_source_file is specified. Aborting the simulation.")
@@ -583,7 +583,7 @@ def unpack_nwm_preprocess_data(preprocessing_parameters):
         topobathy,
         refactored_diffusive_domain,
         refactored_reaches,
-        nonrefactored_topobathy,
+        unrefactored_topobathy,
     )
 
 

--- a/src/troute-nwm/src/nwm_routing/preprocess.py
+++ b/src/troute-nwm/src/nwm_routing/preprocess.py
@@ -86,7 +86,7 @@ def nwm_network_preprocess(
     rconn                       (dict of int: [int]): {segment id: [upstream adjacent segment ids]}
     pd.DataFrame.from_dict(gages)        (DataFrame): Gage ids and corresponding segment ids at which they are located
     diffusive_network_data            (dict or None): Network data objects for diffusive domain
-    topobathy_data                       (DataFrame): Natural cross section data for diffusive domain
+    topobathy                            (DataFrame): Natural cross section data for diffusive domain
     
     Notes
     -----
@@ -120,7 +120,7 @@ def nwm_network_preprocess(
         refactored_topobathy_file = hybrid_params.get("refactored_topobathy_domain", None)
         #-------------------------------------------------------------------------
         # for non-refactored hydofabric defined by RouteLink.nc
-        # TODO: By default, let's run both non-refactored and refactored hydrofabric for now. Place a switch in the future. 
+        # TODO: By default, make diffusive available for both non-refactored and refactored hydrofabric for now. Place a switch in the future. 
         if run_hybrid and domain_file:
             
             LOG.info('reading diffusive domain extent for MC/Diffusive hybrid simulation')
@@ -136,25 +136,25 @@ def nwm_network_preprocess(
                 # TODO: replace 'link' with a user-specified indexing variable name.
                 # ... if for whatever reason there is not a `link` variable in the 
                 # ... dataframe returned from read_netcdf, then the code would break here.
-                topobathy_data = (nhd_io.read_netcdf(topobathy_file).set_index('link'))
+                topobathy = (nhd_io.read_netcdf(topobathy_file).set_index('link'))
                 
                 # TODO: Request GID make comID variable an integer in their product, so
                 # we do not need to change variable types, here.
-                topobathy_data.index = topobathy_data.index.astype(int)
+                topobathy.index = topobathy.index.astype(int)
                 
             else:
-                topobathy_data = pd.DataFrame()
+                topobathy = pd.DataFrame()
                 LOG.debug('No natural cross section topobathy data provided. Hybrid simualtion will run on compound trapezoidal geometry.')
              
             # initialize a dictionary to hold network data for each of the diffusive domains
             diffusive_network_data = {}
         
         else:
-            diffusive_domain = None
+            diffusive_domain       = None
             diffusive_network_data = None
-            topobathy_data = pd.DataFrame()
+            topobathy              = pd.DataFrame()
             LOG.info('No diffusive domain file specified in configuration file. This is an MC-only simulation')
-            
+        nonrefactored_topobathy = pd.DataFrame()    
         #-------------------------------------------------------------------------
         # for refactored hydofabric 
         if run_hybrid and run_refactored and refactored_domain_file:
@@ -172,10 +172,15 @@ def nwm_network_preprocess(
                 # TODO: replace 'link' with a user-specified indexing variable name.
                 # ... if for whatever reason there is not a `link` variable in the 
                 # ... dataframe returned from read_netcdf, then the code would break here.
-                topobathy_data = (nhd_io.read_netcdf(refactored_topobathy_file).set_index('link'))
+                topobathy = (nhd_io.read_netcdf(refactored_topobathy_file).set_index('link'))
+
+                # nonrefactored_topobaty_data is passed to diffusive kernel to provide thalweg elevation of non_refactored topobathy 
+                # for crosswalking water elevations between non-refactored and refactored hydrofabrics. 
+                nonrefactored_topobathy       = (nhd_io.read_netcdf(topobathy_file).set_index('link'))
+                nonrefactored_topobathy.index = nonrefactored_topobathy.index.astype(int)
                 
             else:
-                topobathy_data = pd.DataFrame()
+                topobathy               = pd.DataFrame()
                 LOG.debug('No natural cross section topobathy data of refactored hydrofabric provided. Hybrid simualtion will run on compound trapezoidal geometry.')
              
             # initialize a dictionary to hold network data for each of the diffusive domains
@@ -190,7 +195,8 @@ def nwm_network_preprocess(
     else:
         diffusive_domain                  = None
         diffusive_network_data            = None
-        topobathy_data                    = pd.DataFrame()
+        topobathy                         = pd.DataFrame()
+        nonrefactored_topobathy           = pd.DataFrame() 
         refactored_diffusive_domain       = None
         refactored_diffusive_network_data = None   
         refactored_reaches                = {}
@@ -476,7 +482,7 @@ def nwm_network_preprocess(
                  'usgs_lake_gage_crosswalk': usgs_lake_gage_crosswalk, 
                  'usace_lake_gage_crosswalk': usace_lake_gage_crosswalk,
                  'diffusive_network_data': diffusive_network_data,
-                 'topobathy_data': topobathy_data,
+                 'topobathy_data': topobathy,
                 }
             )
             try:
@@ -518,9 +524,10 @@ def nwm_network_preprocess(
         usgs_lake_gage_crosswalk, 
         usace_lake_gage_crosswalk,
         diffusive_network_data,
-        topobathy_data,
+        topobathy,
         refactored_diffusive_domain,
         refactored_reaches,
+        nonrefactored_topobathy,
     )
 
 def unpack_nwm_preprocess_data(preprocessing_parameters):
@@ -533,23 +540,26 @@ def unpack_nwm_preprocess_data(preprocessing_parameters):
             LOG.critical('Canonot find %s' % pathlib.Path(preprocess_filepath))
             quit()
               
-        connections = inputs.get('connections',None)            
-        param_df = inputs.get('param_df',None)
-        wbody_conn = inputs.get('wbody_conn',None)
-        waterbodies_df = inputs.get('waterbodies_df',None)
-        waterbody_types_df = inputs.get('waterbody_types_df',None)
+        connections                  = inputs.get('connections',None)            
+        param_df                     = inputs.get('param_df',None)
+        wbody_conn                   = inputs.get('wbody_conn',None)
+        waterbodies_df               = inputs.get('waterbodies_df',None)
+        waterbody_types_df           = inputs.get('waterbody_types_df',None)
         break_network_at_waterbodies = inputs.get('break_network_at_waterbodies',None)
-        waterbody_type_specified = inputs.get('waterbody_type_specified',None)
-        link_lake_crosswalk = inputs.get('link_lake_crosswalk', None)
-        independent_networks = inputs.get('independent_networks',None)
-        reaches_bytw = inputs.get('reaches_bytw',None)
-        rconn = inputs.get('rconn',None)
-        gages = inputs.get('link_gage_df',None)
-        usgs_lake_gage_crosswalk = inputs.get('usgs_lake_gage_crosswalk',None)
-        usace_lake_gage_crosswalk = inputs.get('usace_lake_gage_crosswalk',None)
-        diffusive_network_data = inputs.get('diffusive_network_data',None)
-        topobathy_data = inputs.get('topobathy_data',None)
-                
+        waterbody_type_specified     = inputs.get('waterbody_type_specified',None)
+        link_lake_crosswalk          = inputs.get('link_lake_crosswalk', None)
+        independent_networks         = inputs.get('independent_networks',None)
+        reaches_bytw                 = inputs.get('reaches_bytw',None)
+        rconn                        = inputs.get('rconn',None)
+        gages                        = inputs.get('link_gage_df',None)
+        usgs_lake_gage_crosswalk     = inputs.get('usgs_lake_gage_crosswalk',None)
+        usace_lake_gage_crosswalk    = inputs.get('usace_lake_gage_crosswalk',None)
+        diffusive_network_data       = inputs.get('diffusive_network_data',None)
+        topobathy                    = inputs.get('topobathy_data',None)        
+        refactored_diffusive_domain  = inputs.get('refactored_diffusive_domain',None)
+        refactored_reaches           = inputs.get('refactored_reaches',None)
+        nonrefactored_topobathy      = inputs.get(' nonrefactored_topobathy',None)
+
     else:
         LOG.critical("use_preprocessed_data = True, but no preprocess_source_file is specified. Aborting the simulation.")
         quit()
@@ -570,7 +580,10 @@ def unpack_nwm_preprocess_data(preprocessing_parameters):
         usgs_lake_gage_crosswalk, 
         usace_lake_gage_crosswalk,
         diffusive_network_data,
-        topobathy_data,
+        topobathy,
+        refactored_diffusive_domain,
+        refactored_reaches,
+        nonrefactored_topobathy,
     )
 
 

--- a/src/troute-routing/troute/routing/compute.py
+++ b/src/troute-routing/troute/routing/compute.py
@@ -423,16 +423,7 @@ def compute_nhd_routing_v02(
                     else:
                         lake_segs = []
                         waterbodies_df_sub = pd.DataFrame()
-                    
-                    #check if any DA reservoirs are offnetwork. if so change reservoir type to
-                    #1: levelpool
-                    tmp_lake_ids = list(set(waterbody_types_df_sub.index).intersection(offnetwork_upstreams))
 
-                    if tmp_lake_ids: 
-                        #waterbody_types_df_sub.at[tmp_lake_ids,'reservoir_type'] = 1
-                        for idx in tmp_lake_ids:
-                            waterbody_types_df_sub.at[idx,'reservoir_type'] = 1
-                    
                     param_df_sub = param_df.loc[
                         common_segs,
                         ["dt", "bw", "tw", "twcc", "dx", "n", "ncc", "cs", "s0", "alt"],
@@ -1150,7 +1141,7 @@ def compute_diffusive_routing(
     refactored_diffusive_domain,
     refactored_reaches,
     coastal_boundary_depth_df, 
-    nonrefactored_topobathy,
+    unrefactored_topobathy,
     ):
 
     results_diffusive = []
@@ -1179,14 +1170,16 @@ def compute_diffusive_routing(
             # create topobathy data for diffusive mainstem segments related to this given tw segment        
             if refactored_diffusive_domain:
                 topobathy_bytw               = topobathy.loc[refactored_diffusive_domain[tw]['rlinks']] 
-                nonrefactored_topobathy_bytw = nonrefactored_topobathy.loc[diffusive_network_data[tw]['mainstem_segs']]                 
+                # TODO: missing topobathy data in one of diffuisve domains, so inactivate the next line for now. 
+                #unrefactored_topobathy_bytw  = unrefactored_topobathy.loc[diffusive_network_data[tw]['mainstem_segs']]
+                unrefactored_topobathy_bytw = pd.DataFrame()
             else:
                 topobathy_bytw               = topobathy.loc[diffusive_network_data[tw]['mainstem_segs']] 
-                nonrefactored_topobathy_bytw = pd.DataFrame()
+                unrefactored_topobathy_bytw = pd.DataFrame()
             
         else:
             topobathy_bytw = pd.DataFrame()
-            nonrefactored_topobathy_bytw = pd.DataFrame()
+            unrefactored_topobathy_bytw = pd.DataFrame()
   
         # diffusive streamflow DA activation switch
         if da_parameter_dict['diffusive_streamflow_nudging']==True:
@@ -1232,7 +1225,7 @@ def compute_diffusive_routing(
             refactored_diffusive_domain_bytw,
             refactored_reaches_byrftw, 
             coastal_boundary_depth_bytw_df,
-            nonrefactored_topobathy_bytw,
+            unrefactored_topobathy_bytw,
         )
 
         # run the simulation

--- a/src/troute-routing/troute/routing/compute.py
+++ b/src/troute-routing/troute/routing/compute.py
@@ -1146,10 +1146,11 @@ def compute_diffusive_routing(
     lastobs_df,
     da_parameter_dict,
     waterbodies_df,
-    topobathy_data,
+    topobathy,
     refactored_diffusive_domain,
     refactored_reaches,
     coastal_boundary_depth_df, 
+    nonrefactored_topobathy,
     ):
 
     results_diffusive = []
@@ -1174,16 +1175,19 @@ def compute_diffusive_routing(
         # create DataFrame of junction inflow data            
         junction_inflows = pd.DataFrame(data = trib_flow, index = trib_segs)
 
-        if not topobathy_data.empty:
+        if not topobathy.empty:
             # create topobathy data for diffusive mainstem segments related to this given tw segment        
             if refactored_diffusive_domain:
-                topobathy_data_bytw  = topobathy_data.loc[refactored_diffusive_domain[tw]['rlinks']] 
+                topobathy_bytw               = topobathy.loc[refactored_diffusive_domain[tw]['rlinks']] 
+                nonrefactored_topobathy_bytw = nonrefactored_topobathy.loc[diffusive_network_data[tw]['mainstem_segs']]                 
             else:
-                topobathy_data_bytw  = topobathy_data.loc[diffusive_network_data[tw]['mainstem_segs']] 
+                topobathy_bytw               = topobathy.loc[diffusive_network_data[tw]['mainstem_segs']] 
+                nonrefactored_topobathy_bytw = pd.DataFrame()
             
         else:
-            topobathy_data_bytw = pd.DataFrame()
-            
+            topobathy_bytw = pd.DataFrame()
+            nonrefactored_topobathy_bytw = pd.DataFrame()
+  
         # diffusive streamflow DA activation switch
         if da_parameter_dict['diffusive_streamflow_nudging']==True:
             diff_usgs_df = usgs_df
@@ -1223,11 +1227,12 @@ def compute_diffusive_routing(
             nts,
             dt,
             waterbodies_df,
-            topobathy_data_bytw,
+            topobathy_bytw,
             diff_usgs_df,
             refactored_diffusive_domain_bytw,
             refactored_reaches_byrftw, 
             coastal_boundary_depth_bytw_df,
+            nonrefactored_topobathy_bytw,
         )
 
         # run the simulation

--- a/src/troute-routing/troute/routing/diffusive_utils.py
+++ b/src/troute-routing/troute/routing/diffusive_utils.py
@@ -385,7 +385,7 @@ def fp_dbcd_map(usgsID2tw=None, usgssDT=None, usgseDT=None, usgspCd=None):
 def fp_naturalxsec_map(
                 ordered_reaches,
                 mainstem_seg_list, 
-                topobathy_data_bytw,
+                topobathy_bytw,
                 param_df, 
                 mx_jorder, 
                 mxncomp_g, 
@@ -398,7 +398,7 @@ def fp_naturalxsec_map(
     ----------
     ordered_reaches -- (dict) reaches and reach metadata by junction order
     mainstem_seg_list -- (int) a list of link IDs of segs of related mainstem reaches 
-    topobathy_data_bytw --  
+    topobathy_bytw -- (DataFrame) natural cross section's x and z values with manning's N   
     param_df --(DataFrame) geomorphic parameters
     mx_jorder -- (int) max junction order
     mxncomp_g -- (int) maximum number of nodes in a reach
@@ -419,10 +419,10 @@ def fp_naturalxsec_map(
       except TW reach where the bottom node bathy is interpolated by bathy of the last segment 
       with so*0.5*dx 
     """  
-    if not topobathy_data_bytw.empty:
+    if not topobathy_bytw.empty:
         
         # maximum number of stations along a single cross section
-        mxnbathy_g = topobathy_data_bytw.index.value_counts().max()
+        mxnbathy_g = topobathy_bytw.index.value_counts().max()
 
         # initialize arrays to store cross section data
         x_bathy_g    = np.zeros((mxnbathy_g, mxncomp_g, nrch_g))
@@ -468,15 +468,15 @@ def fp_naturalxsec_map(
                             seg_idx = segID
                             
                         # how many stations are in the node cross section?
-                        nstations = len(topobathy_data_bytw.loc[seg_idx])
+                        nstations = len(topobathy_bytw.loc[seg_idx])
                         
                         # populate cross section size (# of stations) array
                         size_bathy_g[seg, frj] = nstations
                         
                         # populate cross section x, z and mannings n arrays
-                        x_bathy_g[0:nstations, seg, frj]    = topobathy_data_bytw.loc[seg_idx].xid_d
-                        z_bathy_g[0:nstations, seg, frj]    = topobathy_data_bytw.loc[seg_idx].z
-                        mann_bathy_g[0:nstations, seg, frj] = topobathy_data_bytw.loc[seg_idx].n
+                        x_bathy_g[0:nstations, seg, frj]    = topobathy_bytw.loc[seg_idx].xid_d
+                        z_bathy_g[0:nstations, seg, frj]    = topobathy_bytw.loc[seg_idx].z
+                        mann_bathy_g[0:nstations, seg, frj] = topobathy_bytw.loc[seg_idx].n
                         
                         # if terminal node of the network, then adjust the cross section z data using
                         # channel slope and length data
@@ -792,7 +792,7 @@ def fp_refactored_naturalxsec_map(
     tw,
     mxncomp_g,
     nrch_g,                                                    
-    topobathy_data_bytw, 
+    topobathy_bytw, 
     param_df,
     rfrnw_g, 
     rpynw,
@@ -808,7 +808,7 @@ def fp_refactored_naturalxsec_map(
     tw,
     mxncomp_g -- (int) maximum number of nodes in a reach
     nrch_g -- (int) number of reaches in the network
-    topobathy_data_bytw --(DataFrame) natural channel cross section data of a channel network draining into a tailwater node
+    topobathy_bytw --(DataFrame) natural channel cross section's x and z values with manning's N
     param_df --(DataFrame) geomorphic parameters
     rfrnw_g -- (nparray of int) Fortran-Python network mapping array on refactored hydrofabric
     rpynw -- (dict) ordered reach head segments on refactored hydrofabric
@@ -824,9 +824,9 @@ def fp_refactored_naturalxsec_map(
     mxnbathy_g -- (integer) maximum size of bathy data points on refactored hydrofabric
     """    
     
-    if not topobathy_data_bytw.empty:
+    if not topobathy_bytw.empty:
         # maximum number of stations along a single cross section
-        mxnbathy_g = topobathy_data_bytw.index.value_counts().max()
+        mxnbathy_g = topobathy_bytw.index.value_counts().max()
 
         # initialize arrays to store cross section data
         x_bathy_g    = np.zeros((mxnbathy_g, mxncomp_g, nrch_g))
@@ -864,15 +864,15 @@ def fp_refactored_naturalxsec_map(
                         rlinkid = rlink_list[rseg]
                     
                     # how many topo data points in a given cross section?
-                    nstations = len(topobathy_data_bytw.loc[rlinkid])
+                    nstations = len(topobathy_bytw.loc[rlinkid])
                         
                     # populate cross section size (# of stations) array
                     size_bathy_g[rseg, frj] = nstations
                         
                     # populate cross section x, z and mannings n arrays
-                    x_bathy_g[0:nstations, rseg, frj]    = topobathy_data_bytw.loc[rlinkid].xid_d
-                    z_bathy_g[0:nstations, rseg, frj]    = topobathy_data_bytw.loc[rlinkid].z
-                    mann_bathy_g[0:nstations, rseg, frj] = topobathy_data_bytw.loc[rlinkid].n
+                    x_bathy_g[0:nstations, rseg, frj]    = topobathy_bytw.loc[rlinkid].xid_d
+                    z_bathy_g[0:nstations, rseg, frj]    = topobathy_bytw.loc[rlinkid].z
+                    mann_bathy_g[0:nstations, rseg, frj] = topobathy_bytw.loc[rlinkid].n
                         
                     # if terminal node of the network, then adjust the cross section z data using
                     # channel slope and length data
@@ -1050,6 +1050,94 @@ def fp_coastal_boundary_input_map(
         dbcd_g[:] = 0.0               
 
     return dt_db_g, dsbd_option, nts_db_g, dbcd_g
+
+def fp_thalweg_elev_map(
+                ordered_reaches,
+                mainstem_seg_list, 
+                nonrefactored_topobathy_bytw,
+                param_df, 
+                mx_jorder, 
+                mxncomp_g, 
+                nrch_g,
+                dbfksegID):
+    """
+    natural cross section mapping between Python and Fortran using eHydro_ned_cross_sections data
+    
+    Parameters
+    ----------
+    ordered_reaches -- (dict) reaches and reach metadata by junction order
+    mainstem_seg_list -- (int) a list of link IDs of segs of related mainstem reaches 
+    nonrefactored_topobathy_bytw -- (DataFrame) natural cross section's x and z values with manning's N on non-refactored hydrofabric   
+    param_df --(DataFrame) geomorphic parameters
+    mx_jorder -- (int) max junction order
+    mxncomp_g -- (int) maximum number of nodes in a reach
+    nrch_g -- (int) number of reaches in the network
+    dbfksegID -- (int) segment ID of fake node (=bottom node) of TW reach that hosts downstream boundary 
+                        condition for a network that is being routed. 
+    
+    Returns
+    -------
+    z_thalweg_g -- (numpy of float64s) elevation of bathy data points
+
+    
+    Notes
+    -----
+    - In node-configuration, bottom node takes bathy of the first segment of the downtream reach
+      except TW reach where the bottom node bathy is interpolated by bathy of the last segment 
+      with so*0.5*dx 
+    """  
+    if not nonrefactored_topobathy_bytw.empty:
+        
+        # initialize arrays to store thalweg elevation values
+        z_thalweg_g  = np.zeros((mxncomp_g, nrch_g)) 
+
+        # loop over reach orders.
+        frj = -1
+        for x in range(mx_jorder, -1, -1):
+
+            # loop through all reaches of order x
+            for head_segment, reach in ordered_reaches[x]:
+                frj = frj + 1
+                # list of segments in this reach
+                seg_list = reach["segments_list"]
+                # number of segments in this reach
+                ncomp = reach["number_segments"]
+
+                # determine if this reach is part of the mainstem diffusive domain
+                if head_segment in mainstem_seg_list: 
+                    # loop through segments in mainstem reach
+                    for seg, segID in enumerate(seg_list):
+                        # identify the index in topobathy dataframe that contains
+                        # the data we want for this node.
+                        if seg == ncomp-1 and x > 0:                             
+                            # if last node of a reach, but not the last node in the network
+                            # use cross section of downstream neighbor
+                            seg_idx = reach["downstream_head_segment"][0]
+                        
+                        elif segID == dbfksegID:                            
+                            # if last node of reach AND last node in the network,
+                            # use cross section of upstream neighbor
+                            seg_idx = seg_list[seg-1]
+                            
+                        else:
+                            seg_idx = segID
+                        import pdb; pdb.set_trace()  
+                        # find channel bottom's lowest elevation value
+                        z_thalweg_g[seg, frj] = nonrefactored_topobathy_bytw.loc[seg_idx].z.min()
+              
+                        # if terminal node of the network, then adjust the thalweg elevation using
+                        # channel slope and length data
+                        if segID == dbfksegID:
+                            So = param_df.loc[seg_idx].s0
+                            dx = param_df.loc[seg_idx].dx
+                            z_thalweg_g[seg, frj] = z_thalweg_g[seg, frj] - So * dx  
+
+    else: 
+        #if the bathy dataframe is empty, then pass out empty arrays
+        z_thalweg_g  = np.array([]).reshape(0,0)
+    
+    return z_thalweg_g
+
      
 def diffusive_input_data_v02(
     tw,
@@ -1068,11 +1156,12 @@ def diffusive_input_data_v02(
     nsteps,
     dt,
     waterbodies_df,
-    topobathy_data_bytw,
+    topobathy_bytw,
     usgs_df,
     refactored_diffusive_domain,
     refactored_reaches,
     coastal_boundary_depth_df,
+    nonrefactored_topobathy_bytw,
 ):
     
     """
@@ -1090,7 +1179,7 @@ def diffusive_input_data_v02(
     initial_conditions -- (ndarray of float32) initial flow (m3/sec) and depth (m above ch bottom) states for network nodes
     upstream_results -- (dict) with values of 1d arrays upstream flow, velocity, and depth   
     qts_subdivisions -- (int) number of qlateral timestep subdivisions    
-    topobathy_data_bytw --(DataFrame) natural channel cross section data of a channel network draining into a tailwater node
+    topobathy_bytw --(DataFrame) natural channel cross section data of a channel network draining into a tailwater node
     usgs_df --(DataFrame) observed usgs flow data
     refactored_diffusive_domain -- (dict) geometric relationship information between original and refactored hydrofabrics
     refactored_reaches -- (list of lists) lists of stream segment IDs of diffusive mainstems on refactored hydrofabrics including 
@@ -1401,7 +1490,7 @@ def diffusive_input_data_v02(
         x_bathy_g, z_bathy_g, mann_bathy_g, size_bathy_g, mxnbathy_g = fp_naturalxsec_map(        
                                                                            ordered_reaches,                             
                                                                            mainstem_seg_list, 
-                                                                           topobathy_data_bytw,
+                                                                           topobathy_bytw,
                                                                            param_df, 
                                                                            mx_jorder,
                                                                            mxncomp_g, 
@@ -1442,7 +1531,6 @@ def diffusive_input_data_v02(
                                                                     trib_seg_list,
                                                                     refactored_diffusive_domain,
                                                                     refactored_reaches,
-                                                                    #upstream_boundary_link,        
                                                                     )
 
     # ---------------------------------------------------------------------------------
@@ -1498,13 +1586,25 @@ def diffusive_input_data_v02(
                 tw,
                 mxncomp_g,
                 nrch_g,                                                    
-                topobathy_data_bytw, 
+                topobathy_bytw, 
                 param_df,
                 rfrnw_g, 
                 rpynw,
                 rordered_reaches,            
-                refactored_diffusive_domain,
-                )  
+                refactored_diffusive_domain,                          
+                )
+        # find thalweg elevation values of non-refactored hydrofabric. Those values will be used for crosswalking water elev bt non-refactored
+        # and refactored hydrofabrics
+        z_thalweg_g = fp_thalweg_elev_map(
+                                          ordered_reaches,
+                                          mainstem_seg_list, 
+                                          nonrefactored_topobathy_bytw,
+                                          param_df, 
+                                          mx_jorder, 
+                                          mxncomp_g, 
+                                          nrch_g,
+                                          dbfksegID,
+                                          ) 
         
     # ---------------------------------------------------------------------------------------------
     #                              Step 0-12-3

--- a/src/troute-routing/troute/routing/fast_reach/diffusive.pyx
+++ b/src/troute-routing/troute/routing/fast_reach/diffusive.pyx
@@ -44,6 +44,7 @@ cdef void diffnw(
         int cwnrow_g,
         int cwncol_g,
         double[::1,:] crosswalk_g,
+        double[::1,:] z_thalweg_g,
         double[:,:,:] out_q,
         double[:,:,:] out_elv,
 ):
@@ -90,7 +91,8 @@ cdef void diffnw(
         &rdx_ar_g[0,0],
         &cwnrow_g,
         &cwncol_g,
-        &crosswalk_g[0,0],       
+        &crosswalk_g[0,0],  
+        &z_thalweg_g[0,0],
         &q_ev_g[0,0,0],
         &elv_ev_g[0,0,0]
     )
@@ -142,7 +144,8 @@ cpdef object compute_diffusive(
         double[::1,:] rdx_ar_g = np.asfortranarray(diff_inputs["rdx_ar_g"])
         int cwnrow_g = diff_inputs["cwnrow_g"]
         int cwncol_g = diff_inputs["cwncol_g"]
-        double[::1,:] crosswalk_g = np.asfortranarray(diff_inputs["crosswalk_g"])       
+        double[::1,:] crosswalk_g = np.asfortranarray(diff_inputs["crosswalk_g"]) 
+        double[::1,:] z_thalweg_g = np.asfortranarray(diff_inputs["z_thalweg_g"])
         double[:,:,:] out_q = np.empty([ntss_ev_g,mxncomp_g,nrch_g], dtype = np.double)
         double[:,:,:] out_elv = np.empty([ntss_ev_g,mxncomp_g,nrch_g], dtype = np.double)
 
@@ -186,6 +189,7 @@ cpdef object compute_diffusive(
         cwnrow_g,
         cwncol_g,
         crosswalk_g,
+        z_thalweg_g,
         out_q,
         out_elv
     )

--- a/src/troute-routing/troute/routing/fast_reach/fortran_wrappers.pxd
+++ b/src/troute-routing/troute/routing/fast_reach/fortran_wrappers.pxd
@@ -77,7 +77,8 @@ cdef extern from "pydiffusive.h":
                      double *rdx_ar_g,
                      int *cwnrow_g,
                      int *cwncol_g,
-                     double *crosswalk_g,                  
+                     double *crosswalk_g, 
+                     double *z_thalweg_g,
                      double *q_ev_g,
                      double *elv_ev_g) nogil;
     

--- a/src/troute-routing/troute/routing/fast_reach/pydiffusive.h
+++ b/src/troute-routing/troute/routing/fast_reach/pydiffusive.h
@@ -36,5 +36,6 @@ extern void c_diffnw(double *timestep_ar_g,
                      int *cwnrow_g,
                      int *cwncol_g,
                      double *crosswalk_g,  
+                     double *z_thalweg_g,
                      double *q_ev_g,
                      double *elv_ev_g);


### PR DESCRIPTION
Mapping back water elevation from refactored to unrefactored hydrofabric was performed by interpolation water elevation, but this estimation occasionally produce negative water depth due to discrepancy in thalwegs between refactored and unrefactored hydrofabrics. Now, the interpolation is performed on water depth instead to solve this issue. 

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
