### PR TITLE
troute network abstractions for NHD and Hy Features based networks

### DIFF
--- a/src/troute-network/setup.py
+++ b/src/troute-network/setup.py
@@ -72,12 +72,13 @@ rfc_reservoirs = Extension(
     extra_compile_args=["-g"],
 )
 
-package_data = {"troute.network": ["reach.pxd", "__init__.pxd"],
-                "troute.network.musking": ["mc_reach.pxd", "__init__.pxd"],
+package_data = {"troute": ["__init__.pxd"],
+                "troute.network": ["reach.pxd", "__init__.pxd", "reach_structs.h", "reach_structs.c"],
+                "troute.network.musking": ["mc_reach.pxd", "__init__.pxd", "mc_reach_structs.h", "mc_reach_structs.c"],
                 "troute.network.reservoirs":["__init__.pxd"],
-                "troute.network.reservoirs.levelpool":["__init__.pxd", "levelpool.pxd"],
-                #"troute.network.reservoirs.hybrid":["__init__.pxd", "hybrid.pxd"],
-                "troute.network.reservoirs.rfc":["__init__.pxd", "rfc.pxd"],
+                "troute.network.reservoirs.levelpool":["__init__.pxd", "levelpool.pxd", "levelpool_structs.h", "levelpool_structs.c"],
+                "troute.network.reservoirs.hybrid":["__init__.pxd", "hybrid.pxd", "hybrid_structs.h", "hybrid_structs.c"],
+                "troute.network.reservoirs.rfc":["__init__.pxd", "rfc.pxd", "rfc_structs.h", "rfc_structs.c"],
                  }
 ext_modules = [reach, levelpool_reservoirs, rfc_reservoirs, musk]
 
@@ -89,7 +90,7 @@ if USE_CYTHON:
 setup(
     name="troute.network",
     namespace_packages=["troute"],
-    packages=find_namespace_packages(include=["troute.*"]),#["troute.network", "troute.network.reservoirs", "troute.network.reservoirs.levelpool"],
+    packages=['troute']+find_namespace_packages(include=["troute.*"]),#["troute.network", "troute.network.reservoirs", "troute.network.reservoirs.levelpool"],
     ext_modules=ext_modules,
     ext_package="",
     package_data=package_data,

--- a/src/troute-network/troute/AbstractNetwork.py
+++ b/src/troute-network/troute/AbstractNetwork.py
@@ -1,0 +1,275 @@
+from abc import ABC, abstractmethod
+from functools import partial
+import pandas as pd
+from datetime import datetime
+import time
+
+from troute.nhd_network import reverse_dict, extract_connections, replace_waterbodies_connections, reverse_network, reachable_network, split_at_waterbodies_and_junctions, split_at_junction, dfs_decomposition
+
+__verbose__ = False
+__showtiming__ = False
+
+class AbstractNetwork(ABC):
+    """
+    
+    """
+    __slots__ = ["_dataframe", "_waterbody_connections", "_gages",  
+                "_terminal_codes", "_connections", "_waterbody_df", 
+                "_waterbody_types_df", "_independent_networks", 
+                "_reaches_by_tw", "_reverse_network", "_q0", "_t0", 
+                "_qlateral", "_break_segments"]
+    
+    def __init__(self, cols=None, terminal_code=None, break_points=None, verbose=False, showtiming=False):
+        global __verbose__, __showtiming__
+        __verbose__ = verbose
+        __showtiming__ = showtiming
+        if cols:
+            self._dataframe = self._dataframe[list(cols.values())]
+            # Rename parameter columns to standard names: from route-link names
+            #        key: "link"
+            #        downstream: "to"
+            #        dx: "Length"
+            #        n: "n"  # TODO: rename to `manningn`
+            #        ncc: "nCC"  # TODO: rename to `mannningncc`
+            #        s0: "So"  # TODO: rename to `bedslope`
+            #        bw: "BtmWdth"  # TODO: rename to `bottomwidth`
+            #        waterbody: "NHDWaterbodyComID"
+            #        gages: "gages"
+            #        tw: "TopWdth"  # TODO: rename to `topwidth`
+            #        twcc: "TopWdthCC"  # TODO: rename to `topwidthcc`
+            #        alt: "alt"
+            #        musk: "MusK"
+            #        musx: "MusX"
+            #        cs: "ChSlp"  # TODO: rename to `sideslope`
+            self._dataframe = self._dataframe.rename(columns=reverse_dict(cols))
+            self.set_index("key")
+            self.sort_index()
+        self._waterbody_connections = None
+        self._gages = None
+        self._connections = None
+        self._independent_networks = None
+        self._reverse_network = None
+        self._reaches_by_tw = None
+        self._q0 = None
+        self._t0 = None
+        self._qlateral = None
+        #qlat_const = forcing_parameters.get("qlat_const", 0)
+        #FIXME qlat_const
+        """ Figure out a good way to default initialize to qlat_const/c
+        qlat_const = 1.0
+        self._qlateral = pd.DataFrame(
+            qlat_const,
+            index=self._dataframe.index,
+            columns=range(nts // qts_subdivisions),
+            dtype="float32",
+        )
+        """
+        # there may be off-domain nodes that are not explicitly identified
+        # but which are terminal (i.e., off-domain) as a result of a mask or some other
+        # an interior domain truncation that results in a
+        # otherwise valid node value being pointed to, but which is masked out or
+        # being intentionally separated into another domain.
+        self._terminal_codes = set(
+            self._dataframe[
+                ~self._dataframe["downstream"].isin(self._dataframe.index)
+            ]["downstream"].values
+        )
+         # There can be an externally determined terminal code -- that's this value
+        self._terminal_codes.add(terminal_code)
+
+        self._break_segments = set()
+        if break_points:
+            if break_points["break_network_at_waterbodies"]:
+                self._break_segments = self._break_segments | set(self.waterbody_connections.values())
+            if break_points["break_network_at_gages"]:
+                self._break_segments = self._break_segments | set(self.gages.values())
+
+    @property
+    def network_break_segments(self):
+        """
+        """
+        return self._break_segments
+
+    @property
+    def reverse_network(self):
+        """
+        
+        """
+        if self._reverse_network is None:
+            self._reverse_network = reverse_network(self.connections)
+        return self._reverse_network
+
+    @property
+    def independent_networks(self):
+        """
+        
+        """
+        if self._independent_networks is None:
+            # STEP 2: Identify Independent Networks and Reaches by Network
+            if __showtiming__:
+                start_time = time.time()
+            if __verbose__:
+                print("organizing connections into reaches ...")
+
+            self._independent_networks = reachable_network(self.reverse_network)
+            
+            if __verbose__:
+                print("reach organization complete")
+            if __showtiming__:
+                print("... in %s seconds." % (time.time() - start_time))
+        return self._independent_networks
+    
+    @property
+    def reaches_by_tailwater(self):
+        """
+        
+        """
+        if self._reaches_by_tw is None:
+            self._reaches_by_tw = {}
+            for tw, net in self.independent_networks.items():
+                if self.network_break_segments:
+                    path_func = partial(
+                        split_at_waterbodies_and_junctions, self.network_break_segments, net
+                    )
+                else:
+                    path_func = partial(split_at_junction, net)
+
+                self._reaches_by_tw[tw] = dfs_decomposition(net, path_func)
+        return self._reaches_by_tw
+
+    @property
+    def waterbody_dataframe(self):
+        return self._waterbody_df
+    
+    @property
+    def waterbody_types_dataframe(self):
+        return self._waterbody_types_df
+
+    @property
+    def connections(self):
+        if self._connections is None:
+            self._connections = extract_connections(
+                self._dataframe, "downstream", terminal_codes=self._terminal_codes
+            )
+        return self._connections
+
+    @property
+    def qlateral(self):
+        """
+        
+        """
+        return self._qlateral
+
+    @property
+    def q0(self):
+        """
+            Initial channel segment flow values
+            If not set elsewhere, they are 0
+        """
+        if self._q0 is None:
+            self._q0 =  pd.DataFrame(
+            0, index=self._dataframe.index, columns=["qu0", "qd0", "h0"], dtype="float32",
+            )
+        return self._q0
+
+    @property
+    def t0(self):
+        """
+            Time 0 as a datetime object
+            If not set elsewhere, it defaults to "2015-08-16_00:00:00"
+        """
+        if self._t0 is None:
+            self._t0 = datetime.strptime("2015-08-16_00:00:00", "%Y-%m-%d_%H:%M:%S")
+        return self._t0
+
+    @t0.setter
+    def t0(self, value):
+        """
+        
+        """
+        if isinstance(value, datetime):
+            self._t0 = value
+        else:
+            self._t0 = datetime.strptime(value, "%Y-%m-%d_%H:%M:%S")
+
+    @property
+    @abstractmethod
+    def waterbody_connections(self):
+        pass
+
+    @property
+    @abstractmethod
+    def waterbody_null(self):
+        pass
+
+    @property
+    @abstractmethod
+    def gages(self):
+        pass
+
+    @property
+    def dataframe(self):
+        return self._dataframe
+
+    @property
+    def terminal_codes(self):
+        return self._terminal_codes
+
+    def set_synthetic_wb_segments(self, synthetic_wb_segments, synthetic_wb_id_offset):
+        """
+        
+        """
+        self._dataframe.reset_index(inplace=True) #reset index so key is now column
+        # rename the current key column to key32
+        key32_d = {"key":"key32"}
+        self._dataframe = self._dataframe.rename(columns=key32_d)
+        # create a key index that is int64
+        # copy the links into the new column
+        self._dataframe["key"] = self._dataframe.key32.astype("int64")
+        # update the values of the synthetic reservoir segments
+        fix_idx = self._dataframe.key.isin(set(synthetic_wb_segments))
+        self._dataframe.loc[fix_idx,"key"] = (self._dataframe[fix_idx].key + synthetic_wb_id_offset).astype("int64")
+        #Reset key to index
+        self.set_index("key")
+        self.sort_index()
+
+    def replace_waterbodies(self):
+        """
+
+        """
+        #Make sure to update held state self._connections
+        #but pass the property self.connectionsto ensure it gets properly instansiated
+        #in case it hasn't already been
+        self._connections = replace_waterbodies_connections(
+            self.connections, self._waterbody_connections
+        )
+
+    def set_index(self, key):
+        """
+        
+        """
+        #If the index name is already `key`, don't bother
+        if self._dataframe.index.name != key:
+            self._dataframe.set_index(key, inplace=True)
+    
+    def sort_index(self):
+        """
+        
+        """
+        self._dataframe = self._dataframe.sort_index()
+    
+    def drop(self, key, axis=1):
+        """
+            FIXME can be problematic to drop keys
+            before certain properties are intialized...
+        """
+        self._dataframe.drop(key, axis=axis, inplace=True)
+
+    def astype(self, type, columns=None):
+        """
+        
+        """
+        if columns:
+            self._dataframe[columns] = self._dataframe[columns].astype(type)
+        else:
+            self._dataframe = self._dataframe.astype(type)

--- a/src/troute-network/troute/DataAssimilation.py
+++ b/src/troute-network/troute/DataAssimilation.py
@@ -1,0 +1,118 @@
+from abc import ABC, abstractmethod
+import troute.nhd_io as nhd_io
+import pandas as pd
+import pathlib
+import time
+
+#FIXME parameterize into construciton
+showtiming = True
+verbose = True
+
+def build_data_assimilation_csv(data_assimilation_parameters):
+
+    return nhd_io.get_usgs_df_from_csv(
+        data_assimilation_parameters["data_assimilation_csv"],
+        data_assimilation_parameters["wrf_hydro_da_channel_ID_crosswalk_file"],
+    )
+
+def build_data_assimilation_folder(data_assimilation_parameters, run_parameters):
+
+    usgs_timeslices_folder = pathlib.Path(
+        data_assimilation_parameters["data_assimilation_timeslices_folder"],
+    ).resolve()
+    if "data_assimilation_filter" in data_assimilation_parameters:
+        da_glob_filter = data_assimilation_parameters["data_assimilation_filter"]
+        usgs_files = sorted(usgs_timeslices_folder.glob(da_glob_filter))
+    elif "usgs_timeslice_files" in data_assimilation_parameters:
+        usgs_files = data_assimilation_parameters.get("usgs_timeslice_files", None)
+        usgs_files = [usgs_timeslices_folder.joinpath(f) for f in usgs_files]
+    else:
+        print("No Files Found for DA")
+        # TODO: Handle this with a real exception
+
+    return nhd_io.get_usgs_from_time_slices_folder(
+        data_assimilation_parameters["wrf_hydro_da_channel_ID_crosswalk_file"],
+        usgs_files,
+        data_assimilation_parameters.get("qc_threshold", 1),
+        data_assimilation_parameters.get("data_assimilation_interpolation_limit", 59),
+        #FIXME/TODO collapse these into da parameters
+        run_parameters["dt"],
+        run_parameters["t0"],
+    )
+
+class DataAssimilation(ABC):
+    """
+    
+    """
+
+    @property
+    @abstractmethod
+    def usgs_df(self):
+        pass
+
+class NudgingDA(DataAssimilation):
+    """
+    
+    """
+    slots = ["_usgs_df", "_lastobs_df", "_da_params"]
+    def __init__(self, data_assimilation_parameters, run_parameters):
+        data_assimilation_csv = data_assimilation_parameters.get(
+            "data_assimilation_csv", None
+        )
+        data_assimilation_folder = data_assimilation_parameters.get(
+            "data_assimilation_timeslices_folder", None
+        )
+        # TODO: Copy comments from nhd_network_utilitys `build_data_assimilation_lastobs`
+        lastobs_file = data_assimilation_parameters.get("wrf_hydro_lastobs_file", None)
+        lastobs_start = data_assimilation_parameters.get(
+            "wrf_hydro_lastobs_lead_time_relative_to_simulation_start_time", 0
+        )
+        lastobs_type = data_assimilation_parameters.get("wrf_lastobs_type", "error-based")
+        lastobs_crosswalk_file = data_assimilation_parameters.get(
+            "wrf_hydro_da_channel_ID_crosswalk_file", None
+        )
+
+        self._da_params = {}
+
+        if data_assimilation_csv or data_assimilation_folder or lastobs_file:
+            self._da_params["da_decay_coefficient"] = data_assimilation_parameters.get("da_decay_coefficient", 120)
+            # TODO: Add parameters here for interpolation length (14/59), QC threshold (1.0)
+
+            if showtiming:
+                start_time = time.time()
+            if verbose:
+                print("creating usgs time_slice data array ...")
+            self._last_obs_df = nhd_io.build_lastobs_df(
+                lastobs_file,
+                lastobs_crosswalk_file,
+                lastobs_type,  # TODO: Confirm that we are using this; delete it if not.
+                lastobs_start,
+            )
+            if data_assimilation_csv:
+                self._usgs_df = build_data_assimilation_csv(data_assimilation_parameters)
+            elif data_assimilation_folder:
+                self._usgs_df = build_data_assimilation_folder(data_assimilation_parameters, run_parameters)
+
+            if not self._last_obs_df.index.empty:
+                if not self._usgs_df.empty and not self._usgs_df.index.equals(self._last_obs_df.index):
+                    print("USGS Dataframe Index Does Not Match Last Observations Dataframe Index")
+                    self._usgs_df = self._usgs_df.loc[self._last_obs_df.index]
+            if verbose:
+                print("usgs array complete")
+            if showtiming:
+                print("... in %s seconds." % (time.time() - start_time))
+        else:
+            self._last_obs_df = pd.DataFrame()
+            self._usgs_df = pd.DataFrame()
+
+    @property
+    def asssimilation_parameters(self):
+        return self._da_params
+    
+    @property
+    def last_obs(self):
+        return self._last_obs_df
+
+    @property
+    def usgs_df(self):
+        return self._usgs_df

--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -247,6 +247,15 @@ class HYFeaturesNetwork(AbstractNetwork):
                 #FIXME any reservoir operations requires some type
                 #So make this default to 1 (levelpool)
         #At this point, need to adjust some waterbody/channel parameters based on lakes/reservoirs
+        #HACK for bad hydrofabric
+        def make_list(s):
+            if isinstance(s, list):
+                return s
+            else:
+                return [s]
+
+        self._waterbody_df['member_wbs'] = self._waterbody_df['member_wbs'].apply(make_list)
+        self._waterbody_df['partial_length_percent'] = self._waterbody_df['partial_length_percent'].apply(make_list)
         adjust = [ zip(x, y) 
                    for x, y in 
                    zip(self._waterbody_df['member_wbs'], self._waterbody_df['partial_length_percent'])
@@ -258,8 +267,9 @@ class HYFeaturesNetwork(AbstractNetwork):
             #shouldn't they just not be in the topology???
             wb = node_key_func_wb(wb)
             #Need to adjust waterbodys/channels that  interact with this waterbody
-            #print(self._dataframe.loc[wb, 'dx'])
-            self._dataframe.loc[wb, 'dx'] = self._dataframe.loc[wb, 'dx'] - self._dataframe.loc[wb, 'dx']*percent
+            #Hack for wonky hydrofabric
+            if percent != 'NA':
+                self._dataframe.loc[wb, 'dx'] = self._dataframe.loc[wb, 'dx'] - self._dataframe.loc[wb, 'dx']*float(percent)
             #print(self._dataframe.loc[wb, 'dx'])
 
         if __verbose__:
@@ -302,6 +312,8 @@ class HYFeaturesNetwork(AbstractNetwork):
         #    .drop_duplicates(subset="key")
         #    .set_index("key")
         #)
+        self._dataframe.sort_index(inplace=True)
+        self._waterbody_df.sort_index(inplace=True)
 
     def extract_waterbody_connections(rows, target_col, waterbody_null=-9999):
         """Extract waterbody mapping from dataframe.

--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -252,31 +252,31 @@ class HYFeaturesNetwork(AbstractNetwork):
                 self._waterbody_types_df['reservoir_type'] = 1
                 #FIXME any reservoir operations requires some type
                 #So make this default to 1 (levelpool)
-            #At this point, need to adjust some waterbody/channel parameters based on lakes/reservoirs
-            #HACK for bad hydrofabric
-            def make_list(s):
-                if isinstance(s, list):
-                    return s
-                else:
-                    return [s]
+                #At this point, need to adjust some waterbody/channel parameters based on lakes/reservoirs
+                #HACK for bad hydrofabric
+                def make_list(s):
+                    if isinstance(s, list):
+                        return s
+                    else:
+                        return [s]
 
-            self._waterbody_df['member_wbs'] = self._waterbody_df['member_wbs'].apply(make_list)
-            self._waterbody_df['partial_length_percent'] = self._waterbody_df['partial_length_percent'].apply(make_list)
-            adjust = [ zip(x, y) 
-                       for x, y in 
-                       zip(self._waterbody_df['member_wbs'], self._waterbody_df['partial_length_percent'])
-                    ]
-            #adjust is a generator of a list of list of tuples...use chain to flatten
-            for wb, percent in chain.from_iterable(adjust):
-                #print(wb, percent)
-                #FIXME not sure why some of these are 100%, if that  is the case
-                #shouldn't they just not be in the topology???
-                wb = node_key_func_wb(wb)
-                #Need to adjust waterbodys/channels that  interact with this waterbody
-                #Hack for wonky hydrofabric
-                if percent != 'NA':
-                    self._dataframe.loc[wb, 'dx'] = self._dataframe.loc[wb, 'dx'] - self._dataframe.loc[wb, 'dx']*float(percent)
-                #print(self._dataframe.loc[wb, 'dx'])
+                self._waterbody_df['member_wbs'] = self._waterbody_df['member_wbs'].apply(make_list)
+                self._waterbody_df['partial_length_percent'] = self._waterbody_df['partial_length_percent'].apply(make_list)
+                adjust = [ zip(x, y) 
+                        for x, y in 
+                        zip(self._waterbody_df['member_wbs'], self._waterbody_df['partial_length_percent'])
+                        ]
+                #adjust is a generator of a list of list of tuples...use chain to flatten
+                for wb, percent in chain.from_iterable(adjust):
+                    #print(wb, percent)
+                    #FIXME not sure why some of these are 100%, if that  is the case
+                    #shouldn't they just not be in the topology???
+                    wb = node_key_func_wb(wb)
+                    #Need to adjust waterbodys/channels that  interact with this waterbody
+                    #Hack for wonky hydrofabric
+                    if percent != 'NA':
+                        self._dataframe.loc[wb, 'dx'] = self._dataframe.loc[wb, 'dx'] - self._dataframe.loc[wb, 'dx']*float(percent)
+                    #print(self._dataframe.loc[wb, 'dx'])
 
         if __verbose__:
             print("supernetwork connections set complete")

--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -54,10 +54,16 @@ def read_qlats(forcing_parameters, segment_index, nexus_to_downstream_flowpath_d
     )
     nexus_files = nexus_input_folder.glob(nexus_file_pattern_filter)
     #TODO Find a way to test that we found some files
-    #without consuming the generator...Otherwise, if nuxus_files
+    #without consuming the generator...Otherwise, if nexus_files
     #is empty, the following concat raises a ValueError which
     #It may be sufficient to catch this exception and warn that
     #there may not be any pattern matching files in the dir
+
+    nexus_files_list = list(nexus_files)
+
+    if len(nexus_files_list) == 0:
+        raise ValueError('No nexus input files found. Recommend checking \
+        nexus_input_folder path in YAML configuration.')
 
     #pd.concat((pd.read_csv(f, index_col=0, usecols=[1,2], header=None, engine='c').rename(columns={2:id_regex.match(f).group(1)}) for f in all_files[0:2]), axis=1).T
     id_regex = re.compile(r".*nex-(\d+)_.*.csv")
@@ -66,7 +72,7 @@ def read_qlats(forcing_parameters, segment_index, nexus_to_downstream_flowpath_d
             (pd.read_csv(f, index_col=0, usecols=[1,2], header=None, engine='c').rename(
                 #Rename the flow column to the id of the nexus
                 columns={2:int(id_regex.match(f.name).group(1))})
-            for f in nexus_files #Build the generator for each required file
+            for f in nexus_files_list #Build the generator for each required file
             ),  axis=1).T #Have now concatenated a single df (along axis 1).  Transpose it.
     missing = nexuses_flows_df[ nexuses_flows_df.isna().any(axis=1) ]
     if  not missing.empty:

--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -252,31 +252,31 @@ class HYFeaturesNetwork(AbstractNetwork):
                 self._waterbody_types_df['reservoir_type'] = 1
                 #FIXME any reservoir operations requires some type
                 #So make this default to 1 (levelpool)
-        #At this point, need to adjust some waterbody/channel parameters based on lakes/reservoirs
-        #HACK for bad hydrofabric
-        def make_list(s):
-            if isinstance(s, list):
-                return s
-            else:
-                return [s]
+            #At this point, need to adjust some waterbody/channel parameters based on lakes/reservoirs
+            #HACK for bad hydrofabric
+            def make_list(s):
+                if isinstance(s, list):
+                    return s
+                else:
+                    return [s]
 
-        self._waterbody_df['member_wbs'] = self._waterbody_df['member_wbs'].apply(make_list)
-        self._waterbody_df['partial_length_percent'] = self._waterbody_df['partial_length_percent'].apply(make_list)
-        adjust = [ zip(x, y) 
-                   for x, y in 
-                   zip(self._waterbody_df['member_wbs'], self._waterbody_df['partial_length_percent'])
-                ]
-        #adjust is a generator of a list of list of tuples...use chain to flatten
-        for wb, percent in chain.from_iterable(adjust):
-            #print(wb, percent)
-            #FIXME not sure why some of these are 100%, if that  is the case
-            #shouldn't they just not be in the topology???
-            wb = node_key_func_wb(wb)
-            #Need to adjust waterbodys/channels that  interact with this waterbody
-            #Hack for wonky hydrofabric
-            if percent != 'NA':
-                self._dataframe.loc[wb, 'dx'] = self._dataframe.loc[wb, 'dx'] - self._dataframe.loc[wb, 'dx']*float(percent)
-            #print(self._dataframe.loc[wb, 'dx'])
+            self._waterbody_df['member_wbs'] = self._waterbody_df['member_wbs'].apply(make_list)
+            self._waterbody_df['partial_length_percent'] = self._waterbody_df['partial_length_percent'].apply(make_list)
+            adjust = [ zip(x, y) 
+                       for x, y in 
+                       zip(self._waterbody_df['member_wbs'], self._waterbody_df['partial_length_percent'])
+                    ]
+            #adjust is a generator of a list of list of tuples...use chain to flatten
+            for wb, percent in chain.from_iterable(adjust):
+                #print(wb, percent)
+                #FIXME not sure why some of these are 100%, if that  is the case
+                #shouldn't they just not be in the topology???
+                wb = node_key_func_wb(wb)
+                #Need to adjust waterbodys/channels that  interact with this waterbody
+                #Hack for wonky hydrofabric
+                if percent != 'NA':
+                    self._dataframe.loc[wb, 'dx'] = self._dataframe.loc[wb, 'dx'] - self._dataframe.loc[wb, 'dx']*float(percent)
+                #print(self._dataframe.loc[wb, 'dx'])
 
         if __verbose__:
             print("supernetwork connections set complete")

--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -1,0 +1,337 @@
+from .AbstractNetwork import AbstractNetwork
+import pathlib
+import json
+import pandas as pd
+import numpy as np
+import time
+import re
+import troute.nhd_io as nhd_io #FIXME
+from itertools import chain
+
+__verbose__ = False
+__showtiming__ = False
+
+def node_key_func_nexus(x):
+    return int(x[4:])
+
+def node_key_func_wb(x):
+    return int(x[3:])
+    
+def read_qlats(forcing_parameters, segment_index, nexus_to_downstream_flowpath_dict):
+    # STEP 5: Read (or set) QLateral Inputs
+    if __showtiming__:
+        start_time = time.time()
+    if __verbose__:
+        print("creating qlateral array ...")
+    qts_subdivisions = forcing_parameters.get("qts_subdivisions", 1)
+    nts = forcing_parameters.get("nts", 1)
+    nexus_input_folder = forcing_parameters.get("nexus_input_folder", None)
+    nexus_input_folder = pathlib.Path(nexus_input_folder)
+    #rt0 = time.time() #FIXME showtiming flag
+    if not "nexus_file_pattern_filter" in forcing_parameters:
+        raise( RuntimeError("No value for nexus file pattern in config" ) )
+    
+    nexus_file_pattern_filter = forcing_parameters.get(
+        "nexus_file_pattern_filter", "nex-*"
+    )
+    nexus_files = nexus_input_folder.glob(nexus_file_pattern_filter)
+    #TODO Find a way to test that we found some files
+    #without consuming the generator...Otherwise, if nuxus_files
+    #is empty, the following concat raises a ValueError which
+    #It may be sufficient to catch this exception and warn that
+    #there may not be any pattern matching files in the dir
+
+    #pd.concat((pd.read_csv(f, index_col=0, usecols=[1,2], header=None, engine='c').rename(columns={2:id_regex.match(f).group(1)}) for f in all_files[0:2]), axis=1).T
+    id_regex = re.compile(r".*nex-(\d+)_.*.csv")
+    nexuses_flows_df = pd.concat(
+            #Read the nexus csv file
+            (pd.read_csv(f, index_col=0, usecols=[1,2], header=None, engine='c').rename(
+                #Rename the flow column to the id of the nexus
+                columns={2:int(id_regex.match(f.name).group(1))})
+            for f in nexus_files #Build the generator for each required file
+            ),  axis=1).T #Have now concatenated a single df (along axis 1).  Transpose it.
+    missing = nexuses_flows_df[ nexuses_flows_df.isna().any(axis=1) ]
+    if  not missing.empty:
+        raise ValueError("The following nexus inputs are incomplete: "+str(missing.index))
+    rt1 = time.time()
+    #print("Time to build nexus_flows_df: {} seconds".format(rt1-rt0))
+
+    qlat_df = pd.concat( (nexuses_flows_df.loc[int(k)].rename(index={int(k):v})
+        for k,v in nexus_to_downstream_flowpath_dict.items() ), axis=1
+        ).T
+    
+    # The segment_index has the full network set of segments/flowpaths. 
+    # Whereas the set of flowpaths that are downstream of nexuses is a 
+    # subset of the segment_index. Therefore, all of the segments/flowpaths
+    # that are not accounted for in the set of flowpaths downstream of
+    # nexuses need to be added to the qlateral dataframe and padded with
+    # zeros.
+
+    #tq0 = time.time()
+    all_df = pd.DataFrame( np.zeros( (len(segment_index), len(qlat_df.columns)) ), index=segment_index,
+            columns=qlat_df.columns )
+
+    all_df.loc[ qlat_df.index ] = qlat_df
+
+    #tq1 =  time.time()
+    #print("Time to fill null qlats: {}".format(tq1-tq0))
+    # Sort qlats
+    qlat_df = all_df.sort_index()
+
+    # Set new nts based upon total nexus inputs
+    nts = (qlat_df.shape[1]) * qts_subdivisions
+
+    max_col = 1 + nts // qts_subdivisions
+
+    if len(qlat_df.columns) > max_col:
+        qlat_df.drop(qlat_df.columns[max_col:], axis=1, inplace=True)
+
+    if __verbose__:
+        print("qlateral array complete")
+    if __showtiming__:
+        print("... in %s seconds." % (time.time() - start_time))
+
+    return qlat_df
+
+def read_nexus_file(nexus_file_path):
+
+    #Currently reading data in format:
+    #[
+       #{
+         #"ID": "wb-44",
+         #"toID": "nex-45"
+         #},
+    with open(nexus_file_path) as data_file:
+        json_data_list = json.load(data_file)
+
+    nexus_to_downstream_flowpath_dict_str = {}
+
+    for id_dict in json_data_list:
+        if "nex" in id_dict['ID']:
+            nexus_to_downstream_flowpath_dict_str[id_dict['ID']] = id_dict['toID']
+
+    # Extract the ID integer values
+    nexus_to_downstream_flowpath_dict = {node_key_func_nexus(k): node_key_func_wb(v) for k, v in nexus_to_downstream_flowpath_dict_str.items()}
+
+    return nexus_to_downstream_flowpath_dict
+
+def read_json(file_path):
+    dfs = []
+    with open(file_path) as data_file:
+        json_data = json.load(data_file)
+
+        def node_key_func(x):
+            return int(x[3:])
+        
+        for key_wb, value_params in json_data.items():
+            df = pd.json_normalize(value_params)
+            df['ID'] = node_key_func(key_wb)
+            dfs.append(df)
+    df_main = pd.concat(dfs, ignore_index=True)
+
+    return df_main
+
+class HYFeaturesNetwork(AbstractNetwork):
+    """
+    
+    """
+    __slots__ = ["_flowpath_dict"]
+    def __init__(self, supernetwork_parameters, waterbody_parameters=None, restart_parameters=None, forcing_parameters=None, verbose=False, showtiming=False):
+        """
+        
+        """
+        global __verbose__, __showtiming__
+        __verbose__ = verbose
+        __showtiming__ = showtiming
+        if __verbose__:
+            print("creating supernetwork connections set")
+        if __showtiming__:
+            start_time = time.time()
+        geo_file_path = supernetwork_parameters["geo_file_path"]
+        nexus_file_path = supernetwork_parameters["ngen_nexus_file"]
+        cols = supernetwork_parameters["columns"]
+        terminal_code = supernetwork_parameters.get("terminal_code", 0)
+        break_network_at_waterbodies = supernetwork_parameters.get(
+            "break_network_at_waterbodies", False
+        )
+        break_network_at_gages = supernetwork_parameters.get(
+            "break_network_at_gages", False
+        )
+        break_points = {"break_network_at_waterbodies": break_network_at_waterbodies,
+                        "break_network_at_gages": break_network_at_gages}
+        #df = pd.read_json(geo_file_path, orient="index")
+        #print(df)
+        #raise( "BREAK" )
+        self._dataframe = read_json(geo_file_path)
+        #df["NHDWaterbodyComID"].fillna(-9999, inplace=True)
+        #df["NHDWaterbodyComID"] = df["NHDWaterbodyComID"].astype("int64")
+        self._flowpath_dict = read_nexus_file(
+            pathlib.Path(nexus_file_path)
+        )
+        self._waterbody_types_df = pd.DataFrame()
+        self._waterbody_df = pd.DataFrame()
+        #FIXME the base class constructor is finiky
+        #as it requires the _dataframe, then sets some 
+        #initial default properties...which, at the moment
+        #are used by the subclass constructor.
+        #So it needs to be called at just the right spot...
+        super().__init__(cols, terminal_code, break_points)
+        #FIXME once again, order here can hurt....to hack `alt` in, either need to
+        #put it as a column in the config, or do this AFTER the super constructor
+        #otherwise the alt column gets sliced out...
+        self._dataframe['alt'] = 1.0 #FIXME get the right value for this...
+        #Load waterbody/reservoir info
+        #For ngen HYFeatures, the reservoirs to be simulated
+        #are determined by the lake.json file
+        #we limit waterbody_connections to only the flowpaths
+        #that coincide with a lake listed in this file
+        #see `waterbody_connections`
+
+        if waterbody_parameters:
+            #FIXME later, DO ALL LAKE PARAMS BETTER
+            levelpool_params = waterbody_parameters.get('level_pool', None)
+            if not levelpool_params:
+                #FIXME should not be a hard requirement
+                raise(RuntimeError("No supplied levelpool parameters in routing config"))
+            
+            lake_id = levelpool_params.get("level_pool_waterbody_id", "wb-id")
+            self._waterbody_df = nhd_io.read_ngen_waterbody_df(
+                levelpool_params["level_pool_waterbody_parameter_file_path"],
+                lake_id,
+                #self.waterbody_connections.values()
+            )
+            
+            # Remove duplicate lake_ids and rows
+            self._waterbody_df = (
+                self._waterbody_df.reset_index()
+                .drop_duplicates(subset=lake_id)
+                .set_index(lake_id)
+            )
+            self._waterbody_df["qd0"] = 0.0
+            self._waterbody_df["h0"] = -1e9
+
+            hybrid_params = waterbody_parameters.get('hybrid_and_rfc', None)
+            try: #FIXME for HYFeatures/ngen this will likely be a lot different...
+                self._waterbody_types_df = nhd_io.read_reservoir_parameter_file(
+                    hybrid_params["reservoir_parameter_file"],
+                    lake_id,
+                    #self.waterbody_connections.values(),
+                )
+                # Remove duplicate lake_ids and rows
+                self._waterbody_types_df = (
+                self._waterbody_types_df.reset_index()
+                .drop_duplicates(subset=lake_id)
+                .set_index(lake_id)
+                )
+            except:
+                self._waterbody_types_df = pd.DataFrame(index=self._waterbody_df.index)
+                self._waterbody_types_df['reservoir_type'] = 1
+                #FIXME any reservoir operations requires some type
+                #So make this default to 1 (levelpool)
+        #At this point, need to adjust some waterbody/channel parameters based on lakes/reservoirs
+        adjust = [ zip(x, y) 
+                   for x, y in 
+                   zip(self._waterbody_df['member_wbs'], self._waterbody_df['partial_length_percent'])
+                ]
+        #adjust is a generator of a list of list of tuples...use chain to flatten
+        for wb, percent in chain.from_iterable(adjust):
+            #print(wb, percent)
+            #FIXME not sure why some of these are 100%, if that  is the case
+            #shouldn't they just not be in the topology???
+            wb = node_key_func_wb(wb)
+            #Need to adjust waterbodys/channels that  interact with this waterbody
+            #print(self._dataframe.loc[wb, 'dx'])
+            self._dataframe.loc[wb, 'dx'] = self._dataframe.loc[wb, 'dx'] - self._dataframe.loc[wb, 'dx']*percent
+            #print(self._dataframe.loc[wb, 'dx'])
+
+        if __verbose__:
+            print("supernetwork connections set complete")
+        if __showtiming__:
+            print("... in %s seconds." % (time.time() - start_time))   
+        #TODO/FIXME reservoir restart load
+        #TODO/FIXME channel restart load
+        # STEP 4: Handle Channel Initial States
+        if __showtiming__:
+            start_time = time.time()
+        if __verbose__:
+            print("setting channel initial states ...")
+        #Get channel restarts
+        channel_restart_file = restart_parameters.get("channel_restart_file", None)
+
+        if channel_restart_file:
+            self._q0 = nhd_io.get_channel_restart_from_csv(channel_restart_file)
+            self._q0 = self._q0[self._q0.index.isin(self._dataframe.index)]
+            # TODO is this the same???
+            #self._q0 = self._q0.loc[self._dataframe.index]
+        #TODO/FIXME channel restart t0? self._t0 = ???
+        if __verbose__:
+          print("channel initial states complete")
+        if __showtiming__:
+          print("... in %s seconds." % (time.time() - start_time))
+        
+        self._qlateral = read_qlats(forcing_parameters, self._dataframe.index, self.downstream_flowpath_dict)
+
+        #FIXME should waterbody_df and param_df overlap IDS?  Doesn't seem like it should...
+        #self._dataframe.drop(self._waterbody_df.index, axis=0, inplace=True)
+        #For now, doing it in property waterbody_connections...
+        # Remove duplicate rows...but its not really duplicate...
+        #self._dataframe = (
+        #    self._dataframe.reset_index()
+        #    .drop_duplicates(subset="key")
+        #    .set_index("key")
+        #)
+
+    def extract_waterbody_connections(rows, target_col, waterbody_null=-9999):
+        """Extract waterbody mapping from dataframe.
+        TODO deprecate in favor of waterbody_connections property"""
+        return (
+            rows.loc[rows[target_col] != waterbody_null, target_col].astype("int").to_dict()
+        )
+            
+    @property
+    def downstream_flowpath_dict(self):
+        return self._flowpath_dict
+
+    @property
+    def waterbody_connections(self):
+        """
+            A dictionary where the keys are the reach/segment id, and the
+            value is the id to look up waterbody parameters
+        """
+        if( not self._waterbody_connections ):
+            #Funny story, NaN != NaN is true!!!!
+            #Drop the nan, then check for waterbody_null just in case
+            #waterbody_null happens to be NaN
+            #FIXME this drops ALL nan, not just `waterbody`
+            waterbody_segments = self._dataframe.dropna().loc[
+                self._dataframe["waterbody"] != self.waterbody_null, "waterbody"
+            ]
+            waterbody_segments = waterbody_segments.loc[self.waterbody_dataframe.index]
+            self._waterbody_connections = waterbody_segments.index\
+                .to_series(name = waterbody_segments.name)\
+                .astype("int")\
+                .to_dict()
+            #If we identify as a waterbody, drop from the main dataframe
+            #Ugh, but this drops everything that that MIGHT be a "lake"
+            #without knowing if it was defined as a lake in the lake params
+            #so this should just drop the waterbody_df index, not these segments...
+            #In fact, these waterbody connections should probably be entirely reworked
+            #with that in mind...
+            self._waterbody_connections = self._waterbody_df.index.to_series(name = self._waterbody_df.index.name).astype("int").to_dict()
+            self._dataframe.drop(self._waterbody_df.index, axis=0, inplace=True)
+        return self._waterbody_connections
+
+    @property
+    def gages(self):
+        """
+        FIXME
+        """
+        if self._gages is None and "gages" in self._dataframe.columns:
+            self._gages = nhd_io.build_filtered_gage_df(self._dataframe[["gages"]])
+        else:
+            self._gages = {}
+        return self._gages
+    
+    @property
+    def waterbody_null(self):
+        return pd.NA

--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -187,6 +187,7 @@ class HYFeaturesNetwork(AbstractNetwork):
         #print(df)
         #raise( "BREAK" )
         self._dataframe = read_json(geo_file_path)
+        self._dataframe['toID'] = self._dataframe['toID'].apply(node_key_func_nexus)
         #df["NHDWaterbodyComID"].fillna(-9999, inplace=True)
         #df["NHDWaterbodyComID"] = df["NHDWaterbodyComID"].astype("int64")
         self._flowpath_dict = read_nexus_file(

--- a/src/troute-network/troute/NHDNetwork.py
+++ b/src/troute-network/troute/NHDNetwork.py
@@ -1,0 +1,261 @@
+from  .AbstractNetwork import AbstractNetwork
+import xarray as xr
+import pathlib
+from collections import defaultdict
+import troute.nhd_io as nhd_io
+import pandas as pd
+import time
+
+__showtiming__ = True #FIXME pass flag
+__verbose__ = True #FIXME pass verbosity
+
+def read_qlats(forcing_parameters, segment_index):
+    # STEP 5: Read (or set) QLateral Inputs
+    if __showtiming__:
+        start_time = time.time()
+    if __verbose__:
+        print("creating qlateral array ...")
+    qts_subdivisions = forcing_parameters.get("qts_subdivisions", 1)
+    nts = forcing_parameters.get("nts", 1)
+    qlat_input_folder = forcing_parameters.get("qlat_input_folder", None)
+    qlat_input_file = forcing_parameters.get("qlat_input_file", None)
+    if qlat_input_folder:
+        qlat_input_folder = pathlib.Path(qlat_input_folder)
+        if "qlat_files" in forcing_parameters:
+            qlat_files = forcing_parameters.get("qlat_files")
+            qlat_files = [qlat_input_folder.joinpath(f) for f in qlat_files]
+        elif "qlat_file_pattern_filter" in forcing_parameters:
+            qlat_file_pattern_filter = forcing_parameters.get(
+                "qlat_file_pattern_filter", "*CHRT_OUT*"
+            )
+            qlat_files = sorted(qlat_input_folder.glob(qlat_file_pattern_filter))
+
+        qlat_file_index_col = forcing_parameters.get(
+            "qlat_file_index_col", "feature_id"
+        )
+        qlat_file_value_col = forcing_parameters.get("qlat_file_value_col", "q_lateral")
+
+        qlat_df = nhd_io.get_ql_from_wrf_hydro_mf(
+            qlat_files=qlat_files,
+            #ts_iterator=ts_iterator,
+            #file_run_size=file_run_size,
+            index_col=qlat_file_index_col,
+            value_col=qlat_file_value_col,
+        )
+        qlat_df = qlat_df[qlat_df.index.isin(segment_index)]
+    elif qlat_input_file:
+        qlat_df = nhd_io.get_ql_from_csv(qlat_input_file)
+    else:
+        qlat_const = forcing_parameters.get("qlat_const", 0)
+        qlat_df = pd.DataFrame(
+            qlat_const,
+            index=segment_index,
+            columns=range(nts // qts_subdivisions),
+            dtype="float32",
+        )
+    
+    max_col = 1 + nts // qts_subdivisions
+    
+    if len(qlat_df.columns) > max_col:
+        qlat_df.drop(qlat_df.columns[max_col:], axis=1, inplace=True)
+    
+    if not segment_index.empty:
+        qlat_df = qlat_df[qlat_df.index.isin(segment_index)]
+
+    if __verbose__:
+        print("qlateral array complete")
+    if __showtiming__:
+        print("... in %s seconds." % (time.time() - start_time))
+
+    return qlat_df
+
+class NHDNetwork(AbstractNetwork):
+    """
+    
+    """
+    
+    def __init__(self, supernetwork_parameters, waterbody_parameters=None, restart_parameters=None, forcing_parameters=None, verbose=False, showtiming=False, layer_string=None, driver_string=None,):
+        """
+        
+        """
+        global __verbose__, __showtiming__
+        __verbose__ = verbose
+        __showtiming__ = showtiming
+        if __verbose__:
+            print("creating supernetwork connections set")
+        if __showtiming__:
+            start_time = time.time()
+        geo_file_path = pathlib.Path(supernetwork_parameters["geo_file_path"])
+        cols = supernetwork_parameters["columns"]
+        terminal_code = supernetwork_parameters.get("terminal_code", 0)
+        mask = supernetwork_parameters.get("mask_file_path", None)
+        mask_layer = supernetwork_parameters.get("mask_layer_string", None)
+        mask_key = supernetwork_parameters.get("mask_key", None)
+        break_network_at_waterbodies = supernetwork_parameters.get(
+        "break_network_at_waterbodies", False
+        )
+        break_network_at_gages = supernetwork_parameters.get(
+            "break_network_at_gages", False
+        )
+        break_points = {"break_network_at_waterbodies": break_network_at_waterbodies,
+                        "break_network_at_gages": break_network_at_gages}
+        with xr.open_dataset(geo_file_path) as ds:
+            self._dataframe = ds.to_dataframe()
+        
+        if mask:
+            data_mask = nhd_io.read_mask(
+                pathlib.Path(mask),
+                layer_string=mask_layer,
+            )
+            self._dataframe = self._dataframe.filter(
+                data_mask.iloc[:, mask_key], axis=0
+            )
+
+        self._waterbody_types_df = pd.DataFrame()
+        self._waterbody_df = pd.DataFrame()
+        #FIXME the base class constructor is finiky
+        #as it requires the _dataframe, then sets some 
+        #initial default properties...which, at the moment
+        #are used by the subclass constructor.
+        #So it needs to be called at just the right spot...
+        super().__init__(cols, terminal_code, break_points)
+        #Load waterbody/reservoir info
+        if waterbody_parameters:
+            #FIXME later, DO ALL LAKE PARAMS BETTER
+            levelpool_params = waterbody_parameters.get('level_pool', None)
+            if not levelpool_params:
+                raise(RuntimeError("No supplied levelpool parameters in routing config"))
+            
+            lake_id = levelpool_params.get("level_pool_waterbody_id", "lake_id")
+            self._waterbody_df = nhd_io.read_level_pool_waterbody_df(
+                levelpool_params["level_pool_waterbody_parameter_file_path"],
+                lake_id,
+                self.waterbody_connections.values()
+            )
+            # Remove duplicate lake_ids and rows
+            self._waterbody_df = (
+                self._waterbody_df.reset_index()
+                .drop_duplicates(subset=lake_id)
+                .set_index(lake_id)
+            )
+            self._waterbody_df["qd0"] = 0.0
+            self._waterbody_df["h0"] = -1e9
+            hybrid_params = waterbody_parameters.get('hybrid_and_rfc', None)
+            try:
+                self._waterbody_types_df = nhd_io.read_reservoir_parameter_file(
+                    hybrid_params["reservoir_parameter_file"],
+                    lake_id,
+                    self.waterbody_connections.values(),
+                )
+                # Remove duplicate lake_ids and rows
+                self._waterbody_types_df = (
+                self._waterbody_types_df.reset_index()
+                .drop_duplicates(subset=lake_id)
+                .set_index(lake_id)
+                )
+            except:
+                self._waterbody_types_df = pd.DataFrame()
+        if __verbose__:
+            print("supernetwork connections set complete")
+        if __showtiming__:
+            print("... in %s seconds." % (time.time() - start_time))
+            
+        if __verbose__:
+            print("setting waterbody initial states ...")
+        if __showtiming__:
+            start_time = time.time()
+        waterbodies_initial_states_df = pd.DataFrame(columns=self._waterbody_df.columns, index=self._waterbody_df.index)
+        waterbodies_initial_states_df['qd0'] = 0.0 #Create the qd0 column
+        waterbodies_initial_states_df['h0'] = -1e9 #Create  the h0 column
+        if restart_parameters.get("wrf_hydro_waterbody_restart_file", None):
+            waterbodies_initial_states_df = nhd_io.get_reservoir_restart_from_wrf_hydro(
+                restart_parameters["wrf_hydro_waterbody_restart_file"],
+                restart_parameters["wrf_hydro_waterbody_ID_crosswalk_file"],
+                restart_parameters["wrf_hydro_waterbody_ID_crosswalk_file_field_name"],
+                restart_parameters["wrf_hydro_waterbody_crosswalk_filter_file"],
+                restart_parameters[
+                    "wrf_hydro_waterbody_crosswalk_filter_file_field_name"
+                ],
+            )
+
+        #Merge the data, keep the initial states by defining `how="right"`
+        #self._waterbody_df = pd.merge(
+        #    self._waterbody_df, waterbodies_initial_states_df, on="lake_id", suffixes=("_default", None)
+        #)
+        #NJF easier just to copy only what is needed?
+        self._waterbody_df['qd0'] = waterbodies_initial_states_df['qd0'].astype('float32')
+        self._waterbody_df['h0'] = waterbodies_initial_states_df['h0'].astype('float32')
+        print(self._waterbody_df)
+        if __verbose__:
+            print("waterbody initial states complete")
+        if __showtiming__:
+            print("... in %s seconds." % (time.time() - start_time))
+            start_time = time.time()
+        # STEP 4: Handle Channel Initial States
+        if __showtiming__:
+            start_time = time.time()
+        if __verbose__:
+            print("setting channel initial states ...")
+        #Get channel restarts
+        channel_restart_file = restart_parameters.get("channel_restart_file", None)
+
+        wrf_hydro_channel_restart_file = restart_parameters.get(
+            "wrf_hydro_channel_restart_file", None
+        )
+
+        if channel_restart_file:
+            self._q0 = nhd_io.get_channel_restart_from_csv(channel_restart_file)
+            self._q0 = self._q0[self._q0.index.isin(self._dataframe.index)]
+            # TODO is this the same???
+            #self._q0 = self._q0.loc[self._dataframe.index]
+        elif wrf_hydro_channel_restart_file:
+
+            self._q0 = nhd_io.get_channel_restart_from_wrf_hydro(
+                restart_parameters["wrf_hydro_channel_restart_file"],
+                restart_parameters["wrf_hydro_channel_ID_crosswalk_file"],
+                restart_parameters["wrf_hydro_channel_ID_crosswalk_file_field_name"],
+                restart_parameters["wrf_hydro_channel_restart_upstream_flow_field_name"],
+                restart_parameters["wrf_hydro_channel_restart_downstream_flow_field_name"],
+                restart_parameters["wrf_hydro_channel_restart_depth_flow_field_name"],
+            )
+            self._q0 = self._q0[self._q0.index.isin(self._dataframe.index)]
+            # TODO is this the same???
+            #self._q0 = self._q0.loc[self._dataframe.index]
+            self.t0 = nhd_io.get_param_str(wrf_hydro_channel_restart_file, "Restart_Time")
+        if __verbose__:
+          print("channel initial states complete")
+        if __showtiming__:
+          print("... in %s seconds." % (time.time() - start_time))
+        #Make sure waterbody parameter data is the correct type
+        #self._waterbody_df = self._waterbody_df[['']]
+        self._qlateral = read_qlats(forcing_parameters, self._dataframe.index)
+
+    def extract_waterbody_connections(rows, target_col, waterbody_null=-9999):
+        """Extract waterbody mapping from dataframe.
+        TODO deprecate in favor of below property???"""
+        return (
+            rows.loc[rows[target_col] != waterbody_null, target_col].astype("int").to_dict()
+        )
+
+    @property
+    def waterbody_connections(self):
+        if self._waterbody_connections is None :
+            self._waterbody_connections = self._dataframe.loc[
+                self._dataframe["waterbody"] != self.waterbody_null, "waterbody"
+            ].astype("int").to_dict()
+        return self._waterbody_connections
+
+    @property
+    def gages(self):
+        """
+        
+        """
+        if self._gages is None and "gages" in self._dataframe.columns:
+            self._gages = nhd_io.build_filtered_gage_df(self._dataframe[["gages"]])
+        else:
+            self._gages = {}
+        return self._gages
+
+    @property
+    def waterbody_null(self):
+        return -9999

--- a/src/troute-network/troute/nhd_network.py
+++ b/src/troute-network/troute/nhd_network.py
@@ -3,7 +3,9 @@ from itertools import chain
 from functools import reduce, partial
 from collections.abc import Iterable
 from toolz import pluck
-
+from deprecated import deprecated
+#Consider using sphinx for inlining deprecation into docstrings
+#from deprecated.sphinx import deprecated
 
 def reverse_dict(d):
     """
@@ -50,7 +52,7 @@ def extract_connections(rows, target_col, terminal_codes=None):
             network[src].append(dst)
     return network
 
-
+@deprecated(version='2.4.0', reason="Functionality moved to Network classes")
 def extract_waterbody_connections(rows, target_col = 'waterbody', waterbody_null=-9999):
     '''
     Extract waterbody mapping from parameter dataframe. Mapping segment ids to the lake ids they reside in

--- a/src/troute-routing/setup.py
+++ b/src/troute-routing/setup.py
@@ -80,4 +80,5 @@ setup(
     ext_modules=ext_modules,
     ext_packages="",
     package_data=package_data,
+    py_modules=["build_tests"],
 )


### PR DESCRIPTION
Add a base abstract class for a network, and implementations for both NHD and HY Features.
Manually cherry picked and patched the three classes so that they are consistent with the HEAD of the ngen branch.

The next steps will to look at 3b64c41e04e7a690bcef7c73fb952b0f94f1c964 and see how, at the time, `__main__` was refactored to use these structures.  From there, we can extend these data structures as needed and look at refactoring the current entry point to use them.

Along the way, it may be worth looking alt `nhd_io` and `nhd_network` and `nhd_network_utilities` to see what can be moved around and/or deprecated from those modules

## Additions

- AbstractNetwork
- NHDNetwork
- HY_FeaturesNetwork

## Changes
- Added a deprectation warning to extarct_waterbody_connections
## Testing

1. None, yet =(

## Notes

- This should remain in draft until all commits required from the ngen branch are reviewed and added as needed.

## Todos

- Testing?!?!

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [x] MacOS
- [x] Linux
