### PR TITLE
Reformat qlat inputs

### DIFF
--- a/src/troute-network/troute/hyfeature_network_utilities.py
+++ b/src/troute-network/troute/hyfeature_network_utilities.py
@@ -49,8 +49,8 @@ def build_forcing_sets(
             raise(RuntimeError("No output binary qlat folder supplied in config"))
         elif not os.path.exists(binary_folder):
             raise(RuntimeError("Output binary qlat folder supplied in config does not exist"))
-        elif len(os.listdir(binary_folder)) != 0:
-            raise(RuntimeError("Output binary qlat folder supplied in config is not empty"))
+        elif len(list(pathlib.Path(binary_folder).glob('*.parquet'))) != 0:
+            raise(RuntimeError("Output binary qlat folder supplied in config is not empty (already contains '.parquet' files)"))
 
         #Add tnx for backwards compatability
         nexus_files_list = list(nexus_files) + list(nexus_input_folder.glob('tnx*.csv'))

--- a/test/unit_test_hyfeature/unittest_hyfeature.yaml
+++ b/test/unit_test_hyfeature/unittest_hyfeature.yaml
@@ -61,9 +61,9 @@ compute_parameters:
         dt                          : 300 # [sec]
         qlat_input_folder           : channel_forcing/ 
         qlat_file_pattern_filter    : "*.CHRTOUT_DOMAIN1"
-        nexus_input_folder          : /home/sean.horvath/projects/data #channel_forcing/ 
-        nexus_file_pattern_filter   : "nex-*" #"*NEXOUT.csv"
-        binary_nexus_file_folder    : /home/sean.horvath/projects/data/parquet2
+        nexus_input_folder          : channel_forcing/ 
+        nexus_file_pattern_filter   : "*NEXOUT.csv" #OR "*NEXOUT.parquet" OR "nex-*"
+        binary_nexus_file_folder    : binary_files # this is required if nexus_file_pattern_filter="nex-*"
         coastal_boundary_input_file : channel_forcing/schout_1.nc  
         nts                         : 48 #288 for 1day
         max_loop_size               : 2 # [hr]  

--- a/test/unit_test_hyfeature/unittest_hyfeature.yaml
+++ b/test/unit_test_hyfeature/unittest_hyfeature.yaml
@@ -61,8 +61,9 @@ compute_parameters:
         dt                          : 300 # [sec]
         qlat_input_folder           : channel_forcing/ 
         qlat_file_pattern_filter    : "*.CHRTOUT_DOMAIN1"
-        nexus_input_folder           : channel_forcing/ 
-        nexus_file_pattern_filter    : "*NEXOUT.csv" 
+        nexus_input_folder          : /home/sean.horvath/projects/data #channel_forcing/ 
+        nexus_file_pattern_filter   : "nex-*" #"*NEXOUT.csv"
+        binary_nexus_file_folder    : /home/sean.horvath/projects/data/parquet2
         coastal_boundary_input_file : channel_forcing/schout_1.nc  
         nts                         : 48 #288 for 1day
         max_loop_size               : 2 # [hr]  


### PR DESCRIPTION
Added capability to convert nexus qlat csv files output by ngen (single file per nexus with all timesteps) into hourly parquet files (one file for every hour containing all nexus points) that conforms to t-route's current method of reading qlat input data.

## Additions

- If file filter for qlat input data is "nex-", these csv files will be read in and converted into hourly parquet files. These files are saved in a directory designated by new "binary_nexus_file_folder" parameter under "forcing_parameters" in the config file.
- Updates the "nexus_input_folder" and "nexus_file_pattern_filter" parameters to reflect the new parquet directory/files
- Runtime errors are raised if the binary_nexus_file_folder is not provided, does not exist, or is not empty.
- Update method of reading qlat files to be able to read either csv or parquet files.

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
