### PR TITLE
Raise error with unknown extensions.

### DIFF
--- a/src/troute-network/troute/hyfeature_network_utilities.py
+++ b/src/troute-network/troute/hyfeature_network_utilities.py
@@ -296,5 +296,6 @@ def read_file(file_name):
     elif extension=='.parquet':
         df = pq.read_table(file_name).to_pandas().reset_index()
         df.index.name = None
-    
+    else:
+        raise ValueError("Unknown file extension")
     return df


### PR DESCRIPTION
Raise some sort of error when an unknown file extension is passed to read_file. This will avoid a unbound variable.