### PR TITLE
Fix troute-nwm package setup.cfg

### DIFF
--- a/src/troute-nwm/setup.cfg
+++ b/src/troute-nwm/setup.cfg
@@ -22,3 +22,6 @@ install_requires=
   pyyaml
   toolz
   joblib
+
+[options.packages.find]
+ where=src


### PR DESCRIPTION
Make sure the setup.cfg knows how to properly find the actual package under the `src` dir.  Otherwise, a standard install (`pip install troute-nwm/`) won't actually install the module source required (`-e` works/ed cause it just created a link to the src dir, but for actual packaging, it doesn't bundle the package code without this in the config.

For reference, check out [this useful reference on src/ layouts](https://setuptools.pypa.io/en/latest/userguide/declarative_config.html#using-a-src-layout)
