### PR TITLE
Build system updates for Intel compilers

### DIFF
--- a/compiler.sh
+++ b/compiler.sh
@@ -64,7 +64,7 @@ if [[ "$build_framework" == true ]]; then
   rm -rf build
   ##python setup.py --use-cython install
   ##python setup.py --use-cython develop
-  python setup.py build_ext --inplace --use-cython || exit
+  CC=${CC} python setup.py build_ext --inplace --use-cython || exit
   pip install -e . || exit
 fi
 
@@ -74,7 +74,7 @@ if [[ "$build_routing" == true ]]; then
   rm -rf build
   #python setup.py --use-cython install
   #python setup.py --use-cython develop
-  python setup.py build_ext --inplace --use-cython || exit
+  CC=${CC} python setup.py build_ext --inplace --use-cython || exit
   pip install -e . || exit
 fi
 

--- a/compiler.sh
+++ b/compiler.sh
@@ -21,7 +21,13 @@ fi
 #export LIBRARY_PATH=<paths>:$LIBRARY_PATH
 #if you have custom dynamic library paths, uncomment below and export them
 #export LD_LIBRARY_PATHS=<paths>:$LD_LIBRARY_PATHS
-export NETCDFINC=/usr/include/openmpi-x86_64/
+if [ -z "$NETCDF" ]
+then
+    export NETCDFINC=/usr/include/openmpi-x86_64/
+else
+    export NETCDFINC="${NETCDF}"
+fi
+echo "using NETCDFINC=${NETCDFINC}"
 
 if  [[ "$build_mc_kernel" == true ]]; then
   #building reach and resevoir kernel files .o

--- a/compiler.sh
+++ b/compiler.sh
@@ -14,8 +14,14 @@ build_nwm=true
 if [ -z "$F90" ]
 then
     export F90="gfortran"
-    echo "using F90='gfortran'"
+    echo "using F90=${F90}"
 fi
+if [ -z "$CC" ]
+then
+    export CC="gcc"
+    echo "using CC=${CC}"
+fi
+
 
 #if you have custom static library paths, uncomment below and export them
 #export LIBRARY_PATH=<paths>:$LIBRARY_PATH

--- a/src/kernel/diffusive/makefile
+++ b/src/kernel/diffusive/makefile
@@ -2,10 +2,14 @@
 FC := ${F90}
 
 # compile flags
-ifeq (${FC},gfortran)
-FCFLAGS = -g -c -O2 -fPIC -fbounds-check
+F90FLAGSGFORTRAN = -g -c -O2 -fPIC -fbounds-check
+F90FLAGSINTEL = -free -g -c -O2 -fPIC -I${NETCDF}/include
+ifeq ($(notdir ${FC}), ifort)
+FCFLAGS = $(F90FLAGSINTEL)
+else ifeq ($(notdir ${FC}), mpiifort)
+FCFLAGS = $(F90FLAGSINTEL)
 else
-FCFLAGS = -free -g -c -O2 -fPIC -I${NETCDF}/include
+FCFLAGS = $(F90FLAGSGFORTRAN)
 endif
 
 diffusive.o: diffusive.f90

--- a/src/kernel/diffusive/makefile
+++ b/src/kernel/diffusive/makefile
@@ -1,8 +1,12 @@
 # compiler
-FC := gfortran
+FC := ${F90}
 
 # compile flags
+ifeq (${FC},gfortran)
 FCFLAGS = -g -c -O2 -fPIC -fbounds-check
+else
+FCFLAGS = -free -g -c -O2 -fPIC -I${NETCDF}/include
+endif
 
 diffusive.o: diffusive.f90
 	$(FC) $(FCFLAGS) -o $@ $<

--- a/src/kernel/muskingum/makefile
+++ b/src/kernel/muskingum/makefile
@@ -3,9 +3,16 @@ FC := $(F90)
 
 # compile flags
 #FCFLAGS = -c -fdefault-real-8 -fno-align-commons -fbounds-check --free-form
-FCFLAGS = -g -c -O2 -fPIC
-# link flags
-FLFLAGS = -static-gfortran -static-libgcc -no-defaultlibs -lgfortran -lgcc
+F90FLAGSGFORTRAN = -g -c -O2 -fPIC -lgfortran -lgcc -static-gfortran -static-libgcc -no-defaultlibs
+F90FLAGSINTEL = -free -w -c -O2 -fPIC -fconvert=big-endian -frecord-marker=4
+ifeq ($(notdir ${FC}), ifort)
+F90FLAGS = $(F90FLAGSINTEL)
+else ifeq ($(notdir ${FC}), mpiifort)
+F90FLAGS = $(F90FLAGSINTEL)
+else
+F90FLAGS = $(F90FLAGSGFORTRAN)
+endif
+
 
 .PHONY: reach all install
 all: reach 
@@ -13,22 +20,22 @@ all: reach
 reach: mc_single_seg.o pymc_single_seg.o
 
 mc_single_seg.o: MCsingleSegStime_f2py_NOLOOP.f90 precis.mod
-	$(FC) $(FCFLAGS) -o $@ $<
+	$(FC) $(F90FLAGS) -o $@ $<
 
 pymc_single_seg.o: pyMCsingleSegStime_NoLoop.f90
-	$(FC) $(FCFLAGS) -o $@ $<
+	$(FC) $(F90FLAGS) -o $@ $<
 
 precis.mod: varPrecision.f90
-	$(FC) $(FCFLAGS) $<
+	$(FC) $(F90FLAGS) $<
 
 install:
 	cp *.o ../../../src/troute-routing/troute/routing/fast_reach
 
 %.o: %.F
-	$(FC) $(FCFLAGS) -o $@ $<
+	$(FC) $(F90FLAGS) -o $@ $<
 
 %.o: %.f90
-	$(FC) $(FCFLAGS) -o $@ $<
+	$(FC) $(F90FLAGS) -o $@ $<
 
 clean:
 	rm -f *.o *.mod

--- a/src/kernel/muskingum/makefile
+++ b/src/kernel/muskingum/makefile
@@ -3,7 +3,7 @@ FC := $(F90)
 
 # compile flags
 #FCFLAGS = -c -fdefault-real-8 -fno-align-commons -fbounds-check --free-form
-F90FLAGSGFORTRAN = -g -c -O2 -fPIC -lgfortran -lgcc -static-gfortran -static-libgcc -no-defaultlibs
+F90FLAGSGFORTRAN = -g -c -O2 -fPIC -lgfortran -lgcc -static-libgfortran -static-libgcc -nodefaultlibs
 F90FLAGSINTEL = -free -w -c -O2 -fPIC -fconvert=big-endian -frecord-marker=4
 ifeq ($(notdir ${FC}), ifort)
 F90FLAGS = $(F90FLAGSINTEL)

--- a/src/kernel/reservoir/makefile
+++ b/src/kernel/reservoir/makefile
@@ -2,7 +2,7 @@ NETCDFINC := -I$(NETCDFINC) $(shell nc-config --fflags)
 NETCDFLIB := $(shell nc-config --flibs)
 COMPILER90 = $(F90)
 
-F90FLAGSGFORTRAN = -w -c -ffree-form -ffree-line-length-none -fconvert=big-endian -frecord-marker=4 -static-libgfortran -lgfortran -lgcc
+F90FLAGSGFORTRAN = -w -c -ffree-form -ffree-line-length-none -fconvert=big-endian -frecord-marker=4 -static-libgfortran -lgfortran -lgcc -static-libgcc 
 F90FLAGSINTEL = -free -w -c -O2 -fconvert=big-endian -frecord-marker=4
 ifeq ($(notdir ${FC}), ifort)
 F90FLAGS = $(F90FLAGSINTEL)
@@ -12,7 +12,7 @@ else
 F90FLAGS = $(F90FLAGSGFORTRAN)
 endif
 
-F90FLAGS := -g $(F90FLAGS) $(NETCDFINC) $(NETCDFLIB)  -static-libgcc -nodefaultlibs -fPIC
+F90FLAGS := -g $(F90FLAGS) $(NETCDFINC) $(NETCDFLIB)  -nodefaultlibs -fPIC
 ARFLAGS = rc
 
 VPATH = ./Level_Pool ./Persistence_Level_Pool_Hybrid ./RFC_Forecasts
@@ -22,10 +22,10 @@ VPATH = ./Level_Pool ./Persistence_Level_Pool_Hybrid ./RFC_Forecasts
 all: binding_lp.a bind_hybrid.a bind_rfc.a
 
 test_main: test_main.o binding_lp.a bind_hybrid.a bind_rfc.a
-	gfortran -g -o $@ $^
+	$(COMPILER90) -g -o $@ $^
 
 test_main.o: test_binding.c
-	gcc -g -c -o $@ $<
+	$(COMPILER90) -g -c -o $@ $<
 
 module_levelpool.o: module_reservoir.o module_levelpool_properties.o module_levelpool_state.o
 

--- a/src/kernel/reservoir/makefile
+++ b/src/kernel/reservoir/makefile
@@ -1,11 +1,17 @@
 NETCDFINC := -I$(NETCDFINC) $(shell nc-config --fflags)
 NETCDFLIB := $(shell nc-config --flibs)
 COMPILER90 = $(F90)
-ifeq (${FC},gfortran)
-F90FLAGS = -w -c -ffree-form -ffree-line-length-none -fconvert=big-endian -frecord-marker=4 -static-libgfortran -lgfortran -lgcc 
+
+F90FLAGSGFORTRAN = -w -c -ffree-form -ffree-line-length-none -fconvert=big-endian -frecord-marker=4 -static-libgfortran -lgfortran -lgcc
+F90FLAGSINTEL = -free -w -c -O2 -fconvert=big-endian -frecord-marker=4
+ifeq ($(notdir ${FC}), ifort)
+F90FLAGS = $(F90FLAGSINTEL)
+else ifeq ($(notdir ${FC}), mpiifort)
+F90FLAGS = $(F90FLAGSINTEL)
 else
-F90FLAGS = -free -w -c -O2 -fconvert=big-endian -frecord-marker=4
+F90FLAGS = $(F90FLAGSGFORTRAN)
 endif
+
 F90FLAGS := -g $(F90FLAGS) $(NETCDFINC) $(NETCDFLIB)  -static-libgcc -nodefaultlibs -fPIC
 ARFLAGS = rc
 

--- a/src/kernel/reservoir/makefile
+++ b/src/kernel/reservoir/makefile
@@ -1,8 +1,12 @@
 NETCDFINC := -I$(NETCDFINC) $(shell nc-config --fflags)
 NETCDFLIB := $(shell nc-config --flibs)
 COMPILER90 = $(F90)
-F90FLAGS = -w -c -ffree-form -ffree-line-length-none -fconvert=big-endian -frecord-marker=4
-F90FLAGS := -g $(F90FLAGS) $(NETCDFINC) $(NETCDFLIB) -static-libgfortran -static-libgcc -nodefaultlibs -lgfortran -lgcc -fPIC
+ifeq (${FC},gfortran)
+F90FLAGS = -w -c -ffree-form -ffree-line-length-none -fconvert=big-endian -frecord-marker=4 -static-libgfortran -lgfortran -lgcc 
+else
+F90FLAGS = -free -w -c -O2 -fconvert=big-endian -frecord-marker=4
+endif
+F90FLAGS := -g $(F90FLAGS) $(NETCDFINC) $(NETCDFLIB)  -static-libgcc -nodefaultlibs -fPIC
 ARFLAGS = rc
 
 VPATH = ./Level_Pool ./Persistence_Level_Pool_Hybrid ./RFC_Forecasts

--- a/src/troute-network/setup.py
+++ b/src/troute-network/setup.py
@@ -50,7 +50,7 @@ elif "Intel" in result:
     fcompiler_type = 'intel'
 else:
     raise Exception("Could not identify fortran compiler!")
-print(f"Fortran compiler type is: {fcompiler_type}")
+print("Fortran compiler type is: {0}".format(fcompiler_type))
 
 class build_ext_subclass( build_ext ):
     def build_extensions(self):

--- a/src/troute-network/setup.py
+++ b/src/troute-network/setup.py
@@ -2,6 +2,9 @@ from setuptools import setup, find_namespace_packages
 from distutils.extension import Extension
 import sys
 import numpy as np
+from distutils.command.build_ext import build_ext
+import numpy.distutils.fcompiler
+import subprocess
 
 """
 If source ships with the cython generated .c code, then cython isn't a hard requirement
@@ -16,6 +19,48 @@ else:
     USE_CYTHON = False
 
 ext = "pyx" if USE_CYTHON else "c"
+
+# adapted from https://stackoverflow.com/a/5192738/489116 and https://stackoverflow.com/a/32192172/489116
+# also of interest: https://stackoverflow.com/a/60954137/489116
+fcompopt = {
+    'intel': [],
+    'gnu95' : ['-g']
+}
+flinkopt = {
+    'intel': [],
+    'gnu95' : []
+}
+flibs = {
+    'intel': ['mpifort','mpi','ifcoremt','ifport','imf','svml','intlc'],
+    'gnu95' : ['gfortran']
+}
+
+#new_fcompiler = fcompiler.new_compiler()
+#fcompiler_type = fcompiler.compiler_type
+# Open to better suggestions...
+fc = numpy.distutils.fcompiler.FCompiler()
+fc.customize()
+fc = fc.executables["compiler_f90"][0]
+result = subprocess.run([fc, '--version'], stdout=subprocess.PIPE)
+result = result.stdout.decode('utf-8')
+if "GNU" in result:
+    fcompiler_type = 'gnu95'
+elif "Intel" in result:
+    fcompiler_type = 'intel'
+else:
+    raise Exception("Could not identify fortran compiler!")
+print(f"Fortran compiler type is: {fcompiler_type}")
+
+class build_ext_subclass( build_ext ):
+    def build_extensions(self):
+        for e in self.extensions:
+            if fcompiler_type in fcompopt:
+                e.extra_compile_args.extend(fcompopt[fcompiler_type])
+            if fcompiler_type in flinkopt:
+                e.extra_link_args.extend(flinkopt[fcompiler_type])
+            if fcompiler_type in flibs:
+                e.libraries.extend(flibs[fcompiler_type])
+        build_ext.build_extensions(self)
 
 reach = Extension(
     "troute.network.reach",
@@ -46,7 +91,7 @@ levelpool_reservoirs = Extension(
              ],
     include_dirs=[np.get_include(),  "troute/network/"],
     extra_objects=["./libs/binding_lp.a"],
-    libraries=["gfortran", "netcdff", "netcdf"],
+    libraries=["netcdff", "netcdf"],
     extra_compile_args=["-g"],
 )
 
@@ -57,7 +102,7 @@ levelpool_reservoirs = Extension(
 #             ],
 #    include_dirs=[np.get_include()],
 #    extra_objects=["./libs/bind_hybrid.a"],
-#    libraries=["gfortran", "netcdff", "netcdf"],
+#    libraries=["netcdff", "netcdf"],
 #    extra_compile_args=["-g"],
 #)
 
@@ -68,7 +113,7 @@ rfc_reservoirs = Extension(
              ],
     include_dirs=[np.get_include()],
     extra_objects=["./libs/bind_rfc.a"],
-    libraries=["gfortran", "netcdff", "netcdf"],
+    libraries=["netcdff", "netcdf"],
     extra_compile_args=["-g"],
 )
 
@@ -94,4 +139,5 @@ setup(
     ext_modules=ext_modules,
     ext_package="",
     package_data=package_data,
+    cmdclass = {'build_ext': build_ext_subclass }
 )

--- a/src/troute-network/setup.py
+++ b/src/troute-network/setup.py
@@ -3,7 +3,7 @@ from distutils.extension import Extension
 import sys
 import numpy as np
 from distutils.command.build_ext import build_ext
-import numpy.distutils.fcompiler
+import os
 import subprocess
 
 """
@@ -38,9 +38,10 @@ flibs = {
 #new_fcompiler = fcompiler.new_compiler()
 #fcompiler_type = fcompiler.compiler_type
 # Open to better suggestions...
-fc = numpy.distutils.fcompiler.FCompiler()
-fc.customize()
-fc = fc.executables["compiler_f90"][0]
+#fc = numpy.distutils.fcompiler.FCompiler()
+#fc.customize()
+#fc = fc.executables["compiler_f90"][0]
+fc = os.environ['FC'] if 'FC' in os.environ else os.environ['F90'] if 'F90' in os.environ else subprocess.run(['which', 'fc'], capture_output=True).stdout.decode('UTF-8')[:-1]
 result = subprocess.run([fc, '--version'], stdout=subprocess.PIPE)
 result = result.stdout.decode('utf-8')
 if "GNU" in result:

--- a/src/troute-network/troute/network/reservoirs/levelpool/levelpool_structs.c
+++ b/src/troute-network/troute/network/reservoirs/levelpool/levelpool_structs.c
@@ -69,7 +69,7 @@ extern void assim(void* handle, float *updated_elevation,
  * Notes
  *
  */
-init_levelpool_reach(_Reach* reach, int lake_number,
+void init_levelpool_reach(_Reach* reach, int lake_number,
                      float dam_length, float area, float max_depth, 
                      float orifice_area, float orifice_coefficient, 
                      float orifice_elevation, float weir_coefficient, 

--- a/src/troute-network/troute/network/reservoirs/rfc/rfc_structs.c
+++ b/src/troute-network/troute/network/reservoirs/rfc/rfc_structs.c
@@ -16,7 +16,7 @@ extern void run_rfc(void* handle, float *inflow, float *lateral_inflow,
 
 extern void free_rfc(void* handle);
 
-init_rfc_reach(_Reach* reach, int lake_number,
+void init_rfc_reach(_Reach* reach, int lake_number,
                           float dam_length, float area, float max_depth,
                           float orifice_area, float orifice_coefficient, float orifice_elevation,
                           float weir_coefficient, float weir_elevation, float weir_length,

--- a/src/troute-routing/setup.py
+++ b/src/troute-routing/setup.py
@@ -50,7 +50,7 @@ elif "Intel" in result:
     fcompiler_type = 'intel'
 else:
     raise Exception("Could not identify fortran compiler!")
-print(f"Fortran compiler type is: {fcompiler_type}")
+print("Fortran compiler type is: {0}".format(fcompiler_type))
 
 class build_ext_subclass( build_ext ):
     def build_extensions(self):

--- a/src/troute-routing/setup.py
+++ b/src/troute-routing/setup.py
@@ -127,6 +127,5 @@ setup(
     ext_packages="",
     package_data=package_data,
     py_modules=["build_tests"],
-    cmdclass = {'build_ext': build_ext_subclass 
-}
+    cmdclass = {'build_ext': build_ext_subclass }
 )

--- a/src/troute-routing/setup.py
+++ b/src/troute-routing/setup.py
@@ -3,7 +3,7 @@ from distutils.extension import Extension
 import sys
 import numpy as np
 from distutils.command.build_ext import build_ext
-import numpy.distutils.fcompiler
+import os
 import subprocess
 
 """
@@ -38,9 +38,10 @@ flibs = {
 #new_fcompiler = fcompiler.new_compiler()
 #fcompiler_type = fcompiler.compiler_type
 # Open to better suggestions...
-fc = numpy.distutils.fcompiler.FCompiler()
-fc.customize()
-fc = fc.executables["compiler_f90"][0]
+#fc = numpy.distutils.fcompiler.FCompiler()
+#fc.customize()
+#fc = fc.executables["compiler_f90"][0]
+fc = os.environ['FC'] if 'FC' in os.environ else os.environ['F90'] if 'F90' in os.environ else subprocess.run(['which', 'fc'], capture_output=True).stdout.decode('UTF-8')[:-1]
 result = subprocess.run([fc, '--version'], stdout=subprocess.PIPE)
 result = result.stdout.decode('utf-8')
 if "GNU" in result:


### PR DESCRIPTION
Believed minimal set of changes to allow compilation with Intel (other?) compilers.

## Additions

- Mainly added the ability to specify the compiler and build environment settings via environment variables
- Some capability to control compiler flags to Cython extension building pipelines
- A few `void` return types that weren't C-spec that the compilers complained about

## Removals

- Explicit references to gcc, gfortran, libgfortran etc.

## Changes

- Nothing functional

## Testing

1. Tested with Intel OneAPI 2022.3.0 and also with GCC8 suite.
2. Integration test on [NOAA-OWP/ngen](https://github.com/NOAA-OWP/ngen/actions/runs/4512264572/jobs/7945473202)
3. Test case added that can be used with ngen+t-route master branch in `data/gauge_01073000` in [ngen PR#502](https://github.com/NOAA-OWP/ngen/pull/502/files)

## Screenshots


## Notes

-

## Todos

- 

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [X] Linux

