### PR TITLE
default creation of empty waterbody dataframes

### DIFF
--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -295,18 +295,21 @@ class HYFeaturesNetwork(AbstractNetwork):
                 raise(RuntimeError("No supplied levelpool parameters in routing config"))
                 
             lake_id = levelpool_params.get("level_pool_waterbody_id", "wb-id")
-            self._waterbody_df = read_ngen_waterbody_df(
-                        levelpool_params["level_pool_waterbody_parameter_file_path"],
-                        lake_id,
-                        )
-                
-            # Remove duplicate lake_ids and rows
-            self._waterbody_df = (
-                            self.waterbody_dataframe.reset_index()
-                            .drop_duplicates(subset=lake_id)
-                            .set_index(lake_id)
-                            .sort_index()
+            try:
+                self._waterbody_df = read_ngen_waterbody_df(
+                            levelpool_params["level_pool_waterbody_parameter_file_path"],
+                            lake_id,
                             )
+                    
+                # Remove duplicate lake_ids and rows
+                self._waterbody_df = (
+                                self.waterbody_dataframe.reset_index()
+                                .drop_duplicates(subset=lake_id)
+                                .set_index(lake_id)
+                                .sort_index()
+                                )
+            except ValueError:
+                self._waterbody_df = pd.DataFrame()
 
             try:
                 self._waterbody_types_df = read_ngen_waterbody_type_df(
@@ -327,6 +330,9 @@ class HYFeaturesNetwork(AbstractNetwork):
                 #So make this default to 1 (levelpool)
                 self._waterbody_types_df = pd.DataFrame(index=self.waterbody_dataframe.index)
                 self._waterbody_types_df['reservoir_type'] = 1
+        else:
+            self._waterbody_df = pd.DataFrame()
+            self._waterbody_types_df = pd.DataFrame()
     
     def load_bmi_data(self, value_dict, segment_attributes, waterbody_attributes):
         


### PR DESCRIPTION
Creates empty dataframes for waterbody_df and waterbody_types_df if no valid waterbody layer are found in the geopackage


## Additions

- try/except logic while reading waterbody layers in geopackage
- if there are no waterbody parameters, create empty waterbody dataframes.

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
