### PR TITLE
Updated get_values() functionality

### DIFF
--- a/src/bmi_reservoirs.py
+++ b/src/bmi_reservoirs.py
@@ -142,7 +142,7 @@ class bmi_reservoir(Bmi):
         self._values['ifd'] = np.zeros(1)
         self._values['upstream_ids'] = np.zeros(1, dtype=int)
         self._values['reservoir_type'] = np.zeros(1)
-        self._values['lake_water~incoming__volume_flow_rate'] = np.zeros(25)
+        self._values['lake_water~incoming__volume_flow_rate'] = np.zeros(12)
         self._values['lake_water~outgoing__volume_flow_rate'] = np.zeros(1)
 
 

--- a/src/bmi_troute.py
+++ b/src/bmi_troute.py
@@ -199,6 +199,12 @@ class bmi_troute(Bmi):
         self._values['upstream_id'] = np.zeros(n_upstream, dtype=int)
         self._values['upstream_fvd'] = np.zeros(3*12)
 
+        # flattened fvd values to be used as offnetwork upstream flows
+        # number of segments*3(flow, velocity, depth)*12(number of timesteps in 1 hour)
+        #TODO: coordinate with model engine team on order of values here. this is a 1d array
+        # that cycles through variables first, then time steps, then segment ids.
+        self._values['fvd_results'] = np.zeros(n_segment*3*12)
+
         """
         #TODO Update loading RFC data not through Fortran reservoir module.
         self._values['rfc_gage_observation__volume_flow_rate'] = np.zeros(0)

--- a/src/bmi_troute.py
+++ b/src/bmi_troute.py
@@ -204,6 +204,7 @@ class bmi_troute(Bmi):
         #TODO: coordinate with model engine team on order of values here. this is a 1d array
         # that cycles through variables first, then time steps, then segment ids.
         self._values['fvd_results'] = np.zeros(n_segment*3*12)
+        self._values['fvd_index'] = np.zeros(1)
 
         """
         #TODO Update loading RFC data not through Fortran reservoir module.

--- a/src/troute_model.py
+++ b/src/troute_model.py
@@ -213,6 +213,7 @@ class troute_model():
             self._network._waterbody_df,
         )
         values['fvd_results'] = self._fvd.values.flatten()
+        values['fvd_index'] = self._fvd.index
         
         # Get output from final timestep
         (values['channel_exit_water_x-section__volume_flow_rate'], 

--- a/src/troute_model.py
+++ b/src/troute_model.py
@@ -321,10 +321,7 @@ def _read_config_file(custom_input_file): #TODO: Update this function, I dont' t
 
 def _retrieve_last_output(results, nts, waterbodies_df,):
     """
-    Run this model into the future, updating the state stored in the provided model dict appropriately.
-    Note that the model assumes the current values set for input variables are appropriately for the time
-    duration of this update (i.e., ``dt``) and do not need to be interpolated any here.
-    Parameters
+    Retrieve calculated values for the last timestep.
     ----------
     results: list
         The results from nwm_routing.
@@ -389,9 +386,7 @@ def _retrieve_last_output(results, nts, waterbodies_df,):
 
 def _create_output_dataframes(results, nts, waterbodies_df,):
     """
-    Run this model into the future, updating the state stored in the provided model dict appropriately.
-    Note that the model assumes the current values set for input variables are appropriately for the time
-    duration of this update (i.e., ``dt``) and do not need to be interpolated any here.
+    Retrieve calculated flowveldepth values and waterbody inflow, outflow, and elevation.
     Parameters
     ----------
     results: list
@@ -400,22 +395,12 @@ def _create_output_dataframes(results, nts, waterbodies_df,):
         The number of time steps the model was run.
     waterbodies_df: pd.DataFrame
         Dataframe containing waterbody parameters (specifically, IDs stored in index)
-    link_lake_crosswalk: dict #TODO: Can we remove this?
-        Relates lake ids to outlet link ids.
     Returns
     -------
-    q_channel_df: pandas.core.series.Series
-        Streamflow rate for each segment
-    v_channel_df: pandas.core.series.Series
-        Streamflow velocity for each segment
-    d_channel_df: pandas.core.series.Series
-        Streamflow depth for each segment
-    i_lakeout_df: pandas.core.series.Series
-        Inflow for each waterbody
-    q_lakeout_df: pandas.core.series.Series
-        Outflow for each waterbody
-    d_lakeout_df: pandas.core.series.Series
-        Water elevation for each waterbody
+    flowveldepth: pandas.DataFrame
+        Flow, velocity, and depth results
+    lakeout: pandas.Dataframe
+        Waterbody inflow, outflow, and elevation
     """
     qvd_columns = pd.MultiIndex.from_product(
         [range(int(nts)), ["q", "v", "d"]]

--- a/test/BMI/run_bmi_persistence_example.py
+++ b/test/BMI/run_bmi_persistence_example.py
@@ -1,10 +1,10 @@
 
 
-#import sys
+import sys
 import numpy as np
 import pandas as pd
 
-#sys.path.append("src/")
+sys.path.append("src/")
 import bmi_troute
 import bmi_reservoirs
 
@@ -54,7 +54,7 @@ def create_output_dataframes(results, nts, waterbodies_df):
 #----------------------------------------------------------------
 # Initialize model with configuration file
 full_model = bmi_troute.bmi_troute()
-full_model.initialize(bmi_cfg_file='./../test/BMI/bmi_example.yaml')
+full_model.initialize(bmi_cfg_file='test/BMI/bmi_example.yaml')
 
 # Set static values
 #Segment parameters
@@ -91,14 +91,14 @@ full_model.set_value('reservoir_type', np.array([2]))
 #-----------------------
 # Initialize routing models with configuration file
 upper_routing_model = bmi_troute.bmi_troute()
-upper_routing_model.initialize(bmi_cfg_file='./../test/BMI/bmi_upper_example.yaml')
+upper_routing_model.initialize(bmi_cfg_file='test/BMI/bmi_upper_example.yaml')
 
 lower_routing_model = bmi_troute.bmi_troute()
-lower_routing_model.initialize(bmi_cfg_file='./../test/BMI/bmi_lower_example.yaml')
+lower_routing_model.initialize(bmi_cfg_file='test/BMI/bmi_lower_example.yaml')
 
 # Initialize reservoir model
 reservoir_model = bmi_reservoirs.bmi_reservoir()
-reservoir_model.initialize()
+reservoir_model.initialize(bmi_cfg_file='test/BMI/bmi_reservoir_example.yaml')
 
 # Set static values
 #Segment parameters, upper
@@ -164,8 +164,8 @@ for hr in range(120):
     # Full network
     # Set dynamic values
     full_model.set_value('land_surface_water_source__volume_flow_rate', forcing_vals[hr,:])
-    full_model.set_value('gage_observations', gage_vals)
-    full_model.set_value('gage_time', gage_times)
+    #full_model.set_value('gage_observations', gage_vals)
+    #full_model.set_value('gage_time', gage_times)
 
     full_model.update_until(3600)
     


### PR DESCRIPTION
Updates to bmi_troute and troute_model so we can retrieve flowveldepth dataframe as a 1d array after every call of update(). This will be used to connect separate networks by pulling the flowveldepth values calculated in an upstream network and passing these values to the downstream network.

## Additions

- New bmi variable, 'fvd_results'
- Populate fvd_results after every update call with a 1d array.
- Updates to run_bmi_persistence_example file

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
