### PR TITLE
Fix bugs in v3_doc.yaml

### DIFF
--- a/doc/v3_doc.yaml
+++ b/doc/v3_doc.yaml
@@ -517,7 +517,7 @@ compute_parameters:
         # USACE TimeSlice files are only used for reservoir DA
         # at USACE reservoirs
         # (!!) mandatory for USACE reservoir DA 
-        usgs_timeslices_folder: 
+        usace_timeslices_folder: 
         # ---------------
         # int, the number of hours prior to the simulation start that TimeSlice files are searched for
         # For example, if the start time of the simulation is 2022-10-10 12:00 and the timeslice_lookback_hours

--- a/doc/v3_doc.yaml
+++ b/doc/v3_doc.yaml
@@ -671,7 +671,7 @@ output_parameters:
         wrf_hydro_restart_dir:
         # ---------------
         # string. Unique file pattern of restart files (e.g. HYDRO_RST.*)
-        # optional, defaults to 'HYDRO_RST*'
+        # optional, defaults to 'HYDRO_RST.*'
         wrf_hydro_channel_restart_pattern_filter:
     # ---------------
     # paramters controlling a single-segment parity assessment between t-route and WRF-hydro


### PR DESCRIPTION
I found a few bugs/typos in `v3_doc.yaml`. This PR resolves the issues I found.

Bugs / Typos:

- The configuration option key, `usace_timeslices_folder`, was missing and double listed as `usgs_timeslices_folder`.
- Listed default option for `wrf_hydro_channel_restart_pattern_filter` was `HYDRO_RST*` but should have been `HYDRO_RST.*`.