### PR TITLE
actually fix numpy str type deprecation

### DIFF
--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -1054,8 +1054,8 @@ def _read_timeslice_file(f):
         t         = ds.variables['time'][:].filled(fill_value = np.nan)
         qual      = ds.variables['discharge_quality'][:].filled(fill_value = np.nan)
         
-    stationId = np.apply_along_axis(''.join, 1, stns.astype(np.dtype.str))
-    time_str = np.apply_along_axis(''.join, 1, t.astype(np.dtype.str))
+    stationId = np.apply_along_axis(''.join, 1, stns.astype(str))
+    time_str = np.apply_along_axis(''.join, 1, t.astype(str))
     stationId = np.char.strip(stationId)
     
     timeslice_observations = (pd.DataFrame({


### PR DESCRIPTION
The fix in #623 served only to mute the module attribute/reference issue of `numpy.str` being deprecated.  The `numpy.dtype.str` isn't a suitable replacement of `numpy.str`, as the `str` attribute here, according to the docs, is
```
attribute

dtype.str
The array-protocol typestring of this data-type object.
```
which is not a compatible [string datatype](https://numpy.org/doc/stable/reference/arrays.dtypes.html#string-dtype-note).  The below error seen when using this as a `dtype` has been similarly reported while trying to run t-route since merging #623.

It seems that native python types are reasonably supported, though they may not be the most efficient.  Using `str` for the `astype` arg should work, as seen below, this converts to a unicode string.

```sh
Successfully installed numpy-1.25.2
(venv) nelsfrazier@Lynkers-MBP t-route % python
Python 3.11.4 (main, Jul 25 2023, 17:36:13) [Clang 14.0.3 (clang-1403.0.22.14.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import numpy as np
>>> test = np.zeros(2)
>>> test
array([0., 0.])
>>> test.dtype
dtype('float64')
>>> test.astype(np.dtype.str)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: Cannot interpret '<attribute 'str' of 'numpy.dtype' objects>' as a data type
>>> test.astype(str)
array(['0.0', '0.0'], dtype='<U32')
```

I believe this should close #616 with the default unicode string conversion.