### PR TITLE
netcdf of nudge and flowveldepth combined

### DIFF
--- a/src/troute-nwm/src/nwm_routing/output.py
+++ b/src/troute-nwm/src/nwm_routing/output.py
@@ -195,8 +195,8 @@ def nwm_output_generator(
     if test:
         flowveldepth.to_pickle(Path(test))
         
-        # flowveldepth.to_csv('/home/amin/Amin_fork/t-route/test/LowerColorado_TX/output/flowveldepth.csv', sep='|')
-        nhd_io.write_flowveldepth_netcdf('/home/amin/Amin_fork/t-route/test/LowerColorado_TX/output/flowveldepth.nc', flowveldepth)
+        nudge = results[0][7]
+        nhd_io.write_flowveldepth_netcdf('../LowerColorado_TX/output', flowveldepth, nudge)
         
         
     if wbdyo and not waterbodies_df.empty:

--- a/src/troute-nwm/src/nwm_routing/output.py
+++ b/src/troute-nwm/src/nwm_routing/output.py
@@ -114,7 +114,7 @@ def nwm_output_generator(
     test = output_parameters.get("test_output", None)
     chano = output_parameters.get("chanobs_output", None)
     wbdyo = output_parameters.get("lakeout_output", None)
-
+    
     if csv_output:
         csv_output_folder = output_parameters["csv_output"].get(
             "csv_output_folder", None
@@ -191,10 +191,14 @@ def nwm_output_generator(
                 courant.set_index(fvdidxs, inplace = True)
             
         LOG.debug("Constructing the FVD DataFrame took %s seconds." % (time.time() - start))
-
+    
     if test:
         flowveldepth.to_pickle(Path(test))
-    
+        
+        # flowveldepth.to_csv('/home/amin/Amin_fork/t-route/test/LowerColorado_TX/output/flowveldepth.csv', sep='|')
+        nhd_io.write_flowveldepth_netcdf('/home/amin/Amin_fork/t-route/test/LowerColorado_TX/output/flowveldepth.nc', flowveldepth)
+        
+        
     if wbdyo and not waterbodies_df.empty:
         
         time_index, tmp_variable = map(list,zip(*i_df.columns.tolist()))

--- a/src/troute-routing/troute/routing/fast_reach/mc_reach.pyx
+++ b/src/troute-routing/troute/routing/fast_reach/mc_reach.pyx
@@ -639,11 +639,11 @@ cpdef object compute_network_structured(
                 nudge[gage_i, timestep] = da_buf[1]
                 lastobs_times[gage_i] = da_buf[2]
                 lastobs_values[gage_i] = da_buf[3]
-
+                
         # TODO: Address remaining TODOs (feels existential...), Extra commented material, etc.
 
         timestep += 1
-
+        
     #pr.disable()
     #pr.print_stats(sort='time')
     #IMPORTANT, free the dynamic array created
@@ -653,4 +653,29 @@ cpdef object compute_network_structured(
     #do the same for the upstream_array
     output_upstream = np.asarray(upstream_array[:,1:,:], dtype='float32')
     #return np.asarray(data_idx, dtype=np.intp), np.asarray(flowveldepth.base.reshape(flowveldepth.shape[0], -1), dtype='float32')
-    return np.asarray(data_idx, dtype=np.intp)[fill_index_mask], output.reshape(output.shape[0], -1)[fill_index_mask], 0, (np.asarray([data_idx[usgs_position_i] for usgs_position_i in usgs_positions]), np.asarray(lastobs_times), np.asarray(lastobs_values)), (usgs_idx, usgs_update_time-((timestep-1)*dt), usgs_prev_persisted_ouflow, usgs_prev_persistence_index, usgs_persistence_update_time-((timestep-1)*dt)), (usace_idx, usace_update_time-((timestep-1)*dt), usace_prev_persisted_ouflow, usace_prev_persistence_index, usace_persistence_update_time-((timestep-1)*dt)), output_upstream.reshape(output.shape[0], -1)[fill_index_mask]
+    return (
+        np.asarray(data_idx, dtype=np.intp)[fill_index_mask], 
+        output.reshape(output.shape[0], -1)[fill_index_mask], 
+        0, 
+        (
+            np.asarray([data_idx[usgs_position_i] for usgs_position_i in usgs_positions]), 
+            np.asarray(lastobs_times), 
+            np.asarray(lastobs_values)
+        ), 
+        (
+            usgs_idx, 
+            usgs_update_time-((timestep-1)*dt), 
+            usgs_prev_persisted_ouflow, 
+            usgs_prev_persistence_index, 
+            usgs_persistence_update_time-((timestep-1)*dt)
+        ), 
+        (
+            usace_idx, 
+            usace_update_time-((timestep-1)*dt), 
+            usace_prev_persisted_ouflow, 
+            usace_prev_persistence_index, 
+            usace_persistence_update_time-((timestep-1)*dt)
+        ), 
+        output_upstream.reshape(output.shape[0], -1)[fill_index_mask],
+        np.asarray(nudge)
+    )


### PR DESCRIPTION
nudge values returned from mc_reach.pyx, call it in output.py, 
a new function added in nhd.io that save flowveldepth and nudge in a netcdf

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
