### PR TITLE
Fix preprocess param issue

### DIFF
--- a/src/troute-network/troute/AbstractNetwork.py
+++ b/src/troute-network/troute/AbstractNetwork.py
@@ -124,11 +124,9 @@ class AbstractNetwork(ABC):
         start_time = time.time()
         LOG.info("Creating a DataFrame of lateral inflow forcings ...")
 
-        from_file = True
-        if from_file:
-            self.build_qlateral_array(
-                run,
-            )
+        self.build_qlateral_array(
+            run,
+        )
         
         LOG.debug(
             "lateral inflow DataFrame creation complete in %s seconds." \

--- a/src/troute_model.py
+++ b/src/troute_model.py
@@ -92,6 +92,7 @@ class troute_model():
             data_assimilation_parameters=self._data_assimilation_parameters,
             compute_parameters=self._compute_parameters,
             hybrid_parameters=self._hybrid_parameters,
+            preprocessing_parameters=self._preprocessing_parameters,
             from_files=False, value_dict=values,
             bmi_parameters=self._bmi_parameters,)
 


### PR DESCRIPTION
Quick fix so preprocessing parameters are an input to HYFeatures in troute_model.py

## Additions

- preprocess parameters for HYFeatures using BMI

## Removals

- Check for `from_files` before building qlateral array

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
