### PR TITLE
fix read_geopkg() to skip reading lakes and network tables if not needed

### DIFF
--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -53,8 +53,14 @@ def read_geopkg(file_path, data_assimilation_parameters, waterbody_parameters, c
         flowpaths = gpd.read_file(file_path, layer='flowpaths')
         flowpath_attributes = gpd.read_file(file_path, layer='flowpath_attributes')
         flowpaths = pd.merge(flowpaths, flowpath_attributes, on='id')
-        lakes = gpd.read_file(file_path, layer='lakes')
-        network = gpd.read_file(file_path, layer='network')
+        # If waterbodies are being simulated, read lakes table
+        lakes = pd.DataFrame()
+        if waterbody_parameters.get('break_network_at_waterbodies', False):
+            lakes = gpd.read_file(file_path, layer='lakes')
+        # If any DA is activated, read network table as well for gage information
+        network = pd.DataFrame()
+        if any([streamflow_nudging, usgs_da, usace_da, rfc_da]):
+            network = gpd.read_file(file_path, layer='network')
 
     return flowpaths, lakes, network
 


### PR DESCRIPTION
Update reading geopackage in serial. Fixes an error in trying to read the 'lakes' and 'network' attribute tables even when these features are not needed.

## Additions

-

## Removals

-

## Changes

- Add if statements to check if we need to read the 'lakes' and 'network' attribute tables from the geopackage.

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
