### PR TITLE
BMI restart and lastobs files

### DIFF
--- a/src/bmi_DAforcing.py
+++ b/src/bmi_DAforcing.py
@@ -41,7 +41,12 @@ class bmi_DAforcing(Bmi):
     #---------------------------------------------
     # Input variable names (CSDMS standard names)
     #---------------------------------------------
-    _input_var_names = []
+    _input_var_names = [
+        'flowvelocitydepth',
+        'flowvelocitydepth_ids',
+        'nudging',
+        'nudging_ids'
+    ]
 
     #---------------------------------------------
     # Output variable names (CSDMS standard names)
@@ -128,6 +133,11 @@ class bmi_DAforcing(Bmi):
         self._values['rfc_timeseries_df'] = self._model._rfc_timeseries_df
         self._values['lastobs_df'] = self._model._lastobs_df
 
+        self._values['flowvelocitydepth'] = np.zeros(0)
+        self._values['flowvelocitydepth_ids'] = np.zeros(0)
+        self._values['nudging'] = np.zeros(0)
+        self._values['nudging_ids'] = np.zeros(0)
+
     def get_value(self, var_name):
         """Copy of values.
         Parameters
@@ -147,13 +157,7 @@ class bmi_DAforcing(Bmi):
 
     def update(self):
         """Advance model by one time step."""
-        '''
-        if self._model._time==0.0:
-            self._model.preprocess_static_vars(self._values) 
-
         self._model.run(self._values)
-        '''
-        pass
 
     def update_until(self, until):
         """Update model until a particular time.

--- a/src/bmi_DAforcing.py
+++ b/src/bmi_DAforcing.py
@@ -131,12 +131,37 @@ class bmi_DAforcing(Bmi):
         self._values['reservoir_usgs_df'] = self._model._reservoir_usgs_df
         self._values['reservoir_usace_df'] = self._model._reservoir_usace_df
         self._values['rfc_timeseries_df'] = self._model._rfc_timeseries_df
-        self._values['lastobs_df'] = self._model._lastobs_df
+        
+        if not self._model._lastobs_df.empty:
+            self._values['lastobs_df'] = self._model._lastobs_df.values.flatten()
+            self._values['lastobs_df_ids'] = self._model._lastobs_df.index
+        else:
+            self._values['lastobs_df'] = np.zeros(0)
+            self._values['lastobs_df_ids'] = np.zeros(0)
+        
+        if not self._model._q0.empty:
+            self._values['q0'] = self._model._q0.values.flatten()
+            self._values['q0_ids'] = self._model._q0.index
+            self._values['t0'] = self._model._t0
+        else:
+            self._values['q0'] = np.zeros(0)
+            self._values['q0_ids'] = np.zeros(0)
+            self._values['t0'] = np.zeros(0)
+        
+        if not self._model._waterbody_df.empty:
+            self._values['waterbody_df'] = self._model._waterbody_df.values.flatten()
+            self._values['waterbody_df_ids'] = self._model._waterbody_df.index
+        else:
+            self._values['waterbody_df'] = np.zeros(0)
+            self._values['waterbody_df_ids'] = np.zeros(0)
 
         self._values['flowvelocitydepth'] = np.zeros(0)
         self._values['flowvelocitydepth_ids'] = np.zeros(0)
+        self._values['lakeout'] = np.zeros(0)
+        self._values['lakeout_ids'] = np.zeros(0)
         self._values['nudging'] = np.zeros(0)
         self._values['nudging_ids'] = np.zeros(0)
+        self._values['t-route_model_time'] = np.zeros(0)
 
     def get_value(self, var_name):
         """Copy of values.
@@ -158,6 +183,22 @@ class bmi_DAforcing(Bmi):
     def update(self):
         """Advance model by one time step."""
         self._model.run(self._values)
+
+    def set_value(self, var_name, src):
+        """
+        Set model values
+        
+        Parameters
+        ----------
+        var_name : str
+            Name of variable as CSDMS Standard Name.
+        src : array_like
+            Array of new values.
+        """
+        #val = self.get_value_ptr(var_name)
+        #val[:] = src.reshape(val.shape)
+        
+        self._values[var_name] = src
 
     def update_until(self, until):
         """Update model until a particular time.
@@ -310,22 +351,6 @@ class bmi_DAforcing(Bmi):
         """
         dest[:] = self.get_value_ptr(var_name).take(indices)
         return dest
-
-    def set_value(self, var_name, src):
-        """
-        Set model values
-        
-        Parameters
-        ----------
-        var_name : str
-            Name of variable as CSDMS Standard Name.
-        src : array_like
-            Array of new values.
-        """
-        val = self.get_value_ptr(var_name)
-        val[:] = src.reshape(val.shape)
-        
-        #self._values[var_name] = src
 
     def set_value_at_indices(self, name, inds, src):
         """Set model values at particular indices.

--- a/src/bmi_troute.py
+++ b/src/bmi_troute.py
@@ -208,6 +208,15 @@ class bmi_troute(Bmi):
         # that cycles through variables first, then time steps, then segment ids.
         self._values['fvd_results'] = np.zeros(0)
         self._values['fvd_index'] = np.zeros(0)
+        self._values['lakeout'] = np.zeros(0)
+        self._values['lakeout_index'] = np.zeros(0)
+        self._values['q0'] = np.zeros(0)
+        self._values['q0_index'] = np.zeros(0)
+        self._values['t0'] = np.zeros(0)
+        self._values['waterbody_df'] = np.zeros(0)
+        self._values['waterbody_df_index'] = np.zeros(0)
+        self._values['lastobs_df'] = np.zeros(0)
+        self._values['lastobs_df_index'] = np.zeros(0)
 
         # Data assimilation values
         self._values['usgs_df'] = np.zeros(0)

--- a/src/bmi_troute.py
+++ b/src/bmi_troute.py
@@ -215,6 +215,8 @@ class bmi_troute(Bmi):
         self._values['reservoir_usace_df'] = np.zeros(0)
         self._values['rfc_timeseries_df'] = np.zeros(0)
         self._values['lastobs_df'] = np.zeros(0)
+        self._values['nudging'] = np.zeros(0)
+        self._values['nudging_ids'] = np.zeros(0)
 
         '''
         self._values['gage_crosswalk__segID'] = np.zeros(0, dtype=int)

--- a/src/model_DAforcing.py
+++ b/src/model_DAforcing.py
@@ -18,17 +18,20 @@ class DAforcing_model():
         
         """
         __slots__ = ['_data_assimilation_parameters', '_forcing_parameters', '_compute_parameters',
-                     '_usgs_df', 'reservoir_usgs_df', 'reservoir_usace_df', '_rfc_timeseries_df', '_lastobs_df' ]
+                     '_output_parameters', '_usgs_df', 'reservoir_usgs_df', 'reservoir_usace_df', 
+                     '_rfc_timeseries_df', '_lastobs_df',]
 
         if bmi_cfg_file:
             (compute_parameters,
              forcing_parameters,
              data_assimilation_parameters,
+             output_parameters,
             ) = _read_config_file(bmi_cfg_file)
             
             self._compute_parameters = compute_parameters
             self._forcing_parameters = forcing_parameters
             self._data_assimilation_parameters = data_assimilation_parameters
+            self._output_parameters = output_parameters
 
             #############################
             # Read DA files:
@@ -119,7 +122,31 @@ class DAforcing_model():
 
         else:
             raise(RuntimeError("No config file provided."))
-            
+
+    def run(self, values: dict):
+        """
+        Write t-route output values to files. Namely, create restart files (channel and waterbody), 
+        lastobs files, and flowveldepth files to pass to coastal hydraulics models.
+        Parameters
+        ----------
+        values: dict
+            The static and dynamic values for the model.
+        Returns
+        -------
+        """
+        output_parameters = self._output_parameters
+        da_parameters = self._data_assimilation_parameters
+
+        if output_parameters.get('lite_restart',{}).get('lite_restart_output_directory'):
+            #write restart file
+            pass
+        if da_parameters.get('streamflow_da',{}).get('lastobs_output_folder'):
+            #write lastobs file
+            pass
+        if output_parameters.get('nudge_output',{}).get('qvd_nudge'):
+            #write flowveldepth file
+            pass
+
 
 # Utility functions -------
 def _read_config_file(custom_input_file):
@@ -147,11 +174,13 @@ def _read_config_file(custom_input_file):
     compute_parameters = config_dict.get("compute_parameters")
     forcing_parameters = compute_parameters.get("forcing_parameters")
     data_assimilation_parameters = compute_parameters.get("data_assimilation_parameters")
+    output_parameters = config_dict.get('output_parameters')
 
     return (
         compute_parameters,
         forcing_parameters,
         data_assimilation_parameters,
+        output_parameters,
         )
 
 def _read_timeslice_files(filepath, 

--- a/src/model_DAforcing.py
+++ b/src/model_DAforcing.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 from joblib import delayed, Parallel
 import xarray as xr
 import glob
+import pathlib
 
 from troute.routing.fast_reach.reservoir_RFC_da import _validate_RFC_data
 
@@ -19,7 +20,7 @@ class DAforcing_model():
         """
         __slots__ = ['_data_assimilation_parameters', '_forcing_parameters', '_compute_parameters',
                      '_output_parameters', '_usgs_df', 'reservoir_usgs_df', 'reservoir_usace_df', 
-                     '_rfc_timeseries_df', '_lastobs_df',]
+                     '_rfc_timeseries_df', '_lastobs_df', '_t0', '_q0', '_waterbody_df']
 
         if bmi_cfg_file:
             (compute_parameters,
@@ -32,6 +33,8 @@ class DAforcing_model():
             self._forcing_parameters = forcing_parameters
             self._data_assimilation_parameters = data_assimilation_parameters
             self._output_parameters = output_parameters
+
+            self._t0 = self._compute_parameters['restart_parameters']['start_datetime']
 
             #############################
             # Read DA files:
@@ -120,6 +123,22 @@ class DAforcing_model():
             if lastobs_file:
                 self._lastobs_df = _read_lastobs_file(lastobs_file)
 
+            #############################
+            # Read Restart files:
+            #############################
+
+            # Create empty default dataframes:
+            self._q0 = pd.DataFrame()
+            self._waterbody_df = pd.DataFrame()
+
+            lite_restart_file = self._compute_parameters['restart_parameters']['lite_channel_restart_file']
+            if lite_restart_file:
+                self._q0, self._t0 = _read_lite_restart(lite_restart_file)
+            
+            lite_restart_file = self._compute_parameters['restart_parameters']['lite_waterbody_restart_file']
+            if lite_restart_file:
+                self._waterbody_df, _ = _read_lite_restart(lite_restart_file)
+            
         else:
             raise(RuntimeError("No config file provided."))
 
@@ -137,13 +156,22 @@ class DAforcing_model():
         output_parameters = self._output_parameters
         da_parameters = self._data_assimilation_parameters
 
-        if output_parameters.get('lite_restart',{}).get('lite_restart_output_directory'):
-            #write restart file
-            pass
-        if da_parameters.get('streamflow_da',{}).get('lastobs_output_folder'):
-            #write lastobs file
-            pass
-        if output_parameters.get('nudge_output',{}).get('qvd_nudge'):
+        if output_parameters['lite_restart'] is not None:
+            _write_lite_restart(
+                values,
+                self._t0,
+                output_parameters['lite_restart']
+            )   
+
+        lastobs_output_folder = da_parameters.get('streamflow_da',{}).get('lastobs_output_folder', None)
+        if lastobs_output_folder:
+            _write_lastobs(
+                values,
+                self._t0,
+                lastobs_output_folder
+            )
+            
+        if output_parameters.get('stream_output',{}).get('qvd_nudge'):
             #write flowveldepth file
             pass
 
@@ -364,3 +392,118 @@ def _read_lastobs_file(
     lastobs_df['gages'] = lastobs_df['gages'].str.decode('utf-8')
 
     return lastobs_df
+
+def _read_lite_restart(file):
+    '''
+    Open lite restart pickle files. Can open either waterbody_restart or channel_restart
+    
+    Arguments
+    -----------
+        file (string): File path to lite restart file
+        
+    Returns
+    ----------
+        df (DataFrame): restart states
+        t0 (datetime): restart datetime
+    '''
+    # open pickle file to pandas DataFrame
+    df = pd.read_pickle(pathlib.Path(file))
+    
+    # extract restart time as datetime object
+    t0 = df['time'].iloc[0].to_pydatetime()
+    
+    return df.drop(columns = 'time') , t0
+
+def _write_lite_restart(
+    values,
+    t0,
+    lite_restart
+):
+    '''
+    Save initial conditions dataframes as pickle files
+    
+    Arguments
+    -----------
+        q0 (DataFrame):
+        waterbodies_df (DataFrame):
+        t0 (datetime.datetime):
+        restart_parameters (string):
+        
+    Returns
+    -----------
+        
+    '''
+    
+    output_directory = lite_restart.get('lite_restart_output_directory', None)
+    if output_directory:
+        
+        # retrieve/reconstruct t-route produced output dataframes
+        q0 = values['q0']
+        q0_ids = values['q0_ids']
+        q0 = pd.DataFrame(data=q0.reshape(len(q0_ids), -1), 
+                          index=q0_ids,
+                          columns=['qu0','qd0','h0'])
+
+        waterbodies_df = values['waterbody_df']
+        waterbodies_ids = values['waterbody_df_ids']
+        
+        waterbodies_df = pd.DataFrame(data=waterbodies_df.reshape(len(waterbodies_ids), -1), 
+                                      index=waterbodies_ids,
+                                      columns=['ifd','LkArea','LkMxE','OrificeA','OrificeC','OrificeE',
+                                               'WeirC','WeirE','WeirL','qd0','h0','index'])
+        waterbodies_df.index.name = 'lake_id'
+
+        timestamp = t0 + timedelta(seconds=values['t-route_model_time'])
+
+        # create restart filenames
+        timestamp_str = timestamp.strftime("%Y%m%d%H%M")
+        channel_restart_filename = 'channel_restart_' + timestamp_str
+        waterbody_restart_filename = 'waterbody_restart_' + timestamp_str
+        
+        q0_out = q0.copy()
+        q0_out['time'] = timestamp
+        q0_out.to_pickle(pathlib.Path.joinpath(output_directory, channel_restart_filename))
+
+        if not waterbodies_df.empty:
+            wbody_initial_states = waterbodies_df.loc[:,['qd0','h0']]
+            wbody_initial_states['time'] = timestamp
+            wbody_initial_states.to_pickle(pathlib.Path.joinpath(output_directory, waterbody_restart_filename))
+
+def _write_lastobs(
+    values,
+    t0,
+    lastobs_output_folder=False,
+):
+
+    # join gageIDs to lastobs_df
+    lastobs_df = values['lastobs_df']
+    lastobs_df_ids = values['lastobs_df_ids']
+    lastobs_df = pd.DataFrame(data=lastobs_df.reshape(len(lastobs_df_ids), -1),
+                              index=lastobs_df_ids,
+                              columns=['time_since_lastobs','lastobs_discharge','gages'])
+
+    # timestamp of last simulation timestep
+    modelTimeAtOutput = t0 + timedelta(seconds = values['t-route_model_time'])
+    modelTimeAtOutput_str = modelTimeAtOutput.strftime('%Y-%m-%d_%H:%M:%S')
+
+    # timestamp of last observation
+    var = [timedelta(seconds=d) for d in lastobs_df.time_since_lastobs.fillna(0)]
+    lastobs_timestamp = [modelTimeAtOutput - d for d in var]
+    lastobs_timestamp_str = [d.strftime('%Y-%m-%d_%H:%M:%S') for d in lastobs_timestamp]
+    lastobs_timestamp_str_array = np.asarray(lastobs_timestamp_str,dtype = '|S19').reshape(len(lastobs_timestamp_str),1)
+
+    # create xarray Dataset similarly structured to WRF-generated lastobs netcdf files
+    ds = xr.Dataset(
+        {
+            "stationId": (["stationIdInd"], lastobs_df["gages"].to_numpy(dtype = '|S15')),
+            "time": (["stationIdInd", "timeInd"], np.asarray(lastobs_timestamp_str_array,dtype = '|S19')),
+            "discharge": (["stationIdInd", "timeInd"], lastobs_df["lastobs_discharge"].to_numpy().reshape(len(lastobs_df["lastobs_discharge"]),1)),
+        }
+    )
+    ds.attrs["modelTimeAtOutput"] = modelTimeAtOutput_str
+
+    # write-out LastObs file as netcdf
+    if isinstance(lastobs_output_folder, pathlib.Path):
+        lastobs_output_folder = str(lastobs_output_folder)
+    output_path = pathlib.Path(lastobs_output_folder + "/nudgingLastObs." + modelTimeAtOutput_str + ".nc").resolve()
+    ds.to_netcdf(str(output_path))

--- a/src/troute-network/troute/AbstractNetwork.py
+++ b/src/troute-network/troute/AbstractNetwork.py
@@ -35,7 +35,7 @@ class AbstractNetwork(ABC):
                 "hybrid_parameters", "preprocessing_parameters",
                 "verbose", "showtiming", "break_points", "_routing"]
     
-    def __init__(self,):
+    def __init__(self, from_files=True, value_dict={}):
 
         self._independent_networks = None
         self._reverse_network = None
@@ -74,7 +74,7 @@ class AbstractNetwork(ABC):
 
         self.create_independent_networks()
 
-        self.initial_warmstate_preprocess()
+        self.initial_warmstate_preprocess(from_files, value_dict)
 
 
     def assemble_forcings(self, run,):
@@ -517,7 +517,7 @@ class AbstractNetwork(ABC):
         
         LOG.debug("reach organization complete in %s seconds." % (time.time() - start_time))
 
-    def initial_warmstate_preprocess(self,):
+    def initial_warmstate_preprocess(self, from_files, value_dict):
 
         '''
         Assemble model initial condition data:
@@ -548,48 +548,78 @@ class AbstractNetwork(ABC):
             start_time = time.time()
             LOG.info("setting waterbody initial states ...")
 
-            # if a lite restart file is provided, read initial states from it.
-            if restart_parameters.get("lite_waterbody_restart_file", None):
+            if from_files:
+                # if a lite restart file is provided, read initial states from it.
+                if restart_parameters.get("lite_waterbody_restart_file", None):
+                    
+                    waterbodies_initial_states_df, _ = nhd_io.read_lite_restart(
+                        restart_parameters['lite_waterbody_restart_file']
+                    )
+                    
+                # read waterbody initial states from WRF-Hydro type restart file
+                elif restart_parameters.get("wrf_hydro_waterbody_restart_file", None):
+                    waterbodies_initial_states_df = nhd_io.get_reservoir_restart_from_wrf_hydro(
+                        restart_parameters["wrf_hydro_waterbody_restart_file"],
+                        restart_parameters["wrf_hydro_waterbody_ID_crosswalk_file"],
+                        restart_parameters.get("wrf_hydro_waterbody_ID_crosswalk_file_field_name", index_id),
+                        restart_parameters["wrf_hydro_waterbody_crosswalk_filter_file"],
+                        restart_parameters.get(
+                            "wrf_hydro_waterbody_crosswalk_filter_file_field_name",
+                            'NHDWaterbodyComID'
+                        ),
+                    )
                 
-                waterbodies_initial_states_df, _ = nhd_io.read_lite_restart(
-                    restart_parameters['lite_waterbody_restart_file']
-                )
-                
-            # read waterbody initial states from WRF-Hydro type restart file
-            elif restart_parameters.get("wrf_hydro_waterbody_restart_file", None):
-                waterbodies_initial_states_df = nhd_io.get_reservoir_restart_from_wrf_hydro(
-                    restart_parameters["wrf_hydro_waterbody_restart_file"],
-                    restart_parameters["wrf_hydro_waterbody_ID_crosswalk_file"],
-                    restart_parameters.get("wrf_hydro_waterbody_ID_crosswalk_file_field_name", index_id),
-                    restart_parameters["wrf_hydro_waterbody_crosswalk_filter_file"],
-                    restart_parameters.get(
-                        "wrf_hydro_waterbody_crosswalk_filter_file_field_name",
-                        'NHDWaterbodyComID'
-                    ),
-                )
+                # if no restart file is provided, default initial states
+                else:
+                    # TODO: Consider adding option to read cold state from route-link file
+                    waterbodies_initial_ds_flow_const = 0.0
+                    waterbodies_initial_depth_const = -1e9
+                    # Set initial states from cold-state
+                    waterbodies_initial_states_df = pd.DataFrame(
+                        0,
+                        index=self.waterbody_dataframe.index,
+                        columns=[
+                            "qd0",
+                            "h0",
+                        ],
+                        dtype="float32",
+                    )
+                    # TODO: This assignment could probably by done in the above call
+                    waterbodies_initial_states_df["qd0"] = waterbodies_initial_ds_flow_const
+                    waterbodies_initial_states_df["h0"] = waterbodies_initial_depth_const
+                    waterbodies_initial_states_df["index"] = range(
+                        len(waterbodies_initial_states_df)
+                    )
             
-            # if no restart file is provided, default initial states
             else:
-                # TODO: Consider adding option to read cold state from route-link file
-                waterbodies_initial_ds_flow_const = 0.0
-                waterbodies_initial_depth_const = -1e9
-                # Set initial states from cold-state
-                waterbodies_initial_states_df = pd.DataFrame(
-                    0,
-                    index=self.waterbody_dataframe.index,
-                    columns=[
-                        "qd0",
-                        "h0",
-                    ],
-                    dtype="float32",
-                )
-                # TODO: This assignment could probably by done in the above call
-                waterbodies_initial_states_df["qd0"] = waterbodies_initial_ds_flow_const
-                waterbodies_initial_states_df["h0"] = waterbodies_initial_depth_const
-                waterbodies_initial_states_df["index"] = range(
-                    len(waterbodies_initial_states_df)
-                )
-
+                waterbodies_initial_states_df = value_dict['waterbody_df']
+                waterbodies_initial_states_ids = value_dict['waterbody_df_index']
+                if len(waterbodies_initial_states_df)>0:
+                    waterbodies_initial_states_df = pd.DataFrame(
+                        data=waterbodies_initial_states_df.reshape(len(waterbodies_initial_states_ids), -1),
+                        index=waterbodies_initial_states_ids,
+                        columns=['qd0','h0'])
+                else:
+                    # TODO: Consider adding option to read cold state from route-link file
+                    waterbodies_initial_ds_flow_const = 0.0
+                    waterbodies_initial_depth_const = -1e9
+                    # Set initial states from cold-state
+                    waterbodies_initial_states_df = pd.DataFrame(
+                        0,
+                        index=self.waterbody_dataframe.index,
+                        columns=[
+                            "qd0",
+                            "h0",
+                        ],
+                        dtype="float32",
+                    )
+                    # TODO: This assignment could probably by done in the above call
+                    waterbodies_initial_states_df["qd0"] = waterbodies_initial_ds_flow_const
+                    waterbodies_initial_states_df["h0"] = waterbodies_initial_depth_const
+                    waterbodies_initial_states_df["index"] = range(
+                        len(waterbodies_initial_states_df)
+                    )
+            
             self._waterbody_df = pd.merge(
                 self.waterbody_dataframe, waterbodies_initial_states_df, on=index_id
             )
@@ -611,39 +641,57 @@ class AbstractNetwork(ABC):
         LOG.info("setting channel initial states ...")
 
         # if lite restart file is provided, the read channel initial states from it
-        if restart_parameters.get("lite_channel_restart_file", None):
-            self._q0, self._t0 = nhd_io.read_lite_restart(
-                restart_parameters['lite_channel_restart_file']
-            )
-        
-        elif restart_parameters.get("wrf_hydro_channel_restart_file", None):
-            self._q0 = nhd_io.get_channel_restart_from_wrf_hydro(
-                restart_parameters["wrf_hydro_channel_restart_file"],
-                restart_parameters["wrf_hydro_channel_ID_crosswalk_file"],
-                restart_parameters.get("wrf_hydro_channel_ID_crosswalk_file_field_name", 'link'),
-                restart_parameters.get("wrf_hydro_channel_restart_upstream_flow_field_name", 'qlink1'),
-                restart_parameters.get("wrf_hydro_channel_restart_downstream_flow_field_name", 'qlink2'),
-                restart_parameters.get("wrf_hydro_channel_restart_depth_flow_field_name", 'hlink'),
-                )
-
-            t0_str = nhd_io.get_param_str(
-                    restart_parameters["wrf_hydro_channel_restart_file"], 
-                    "Restart_Time"
+        if from_files:
+            if restart_parameters.get("lite_channel_restart_file", None):
+                self._q0, self._t0 = nhd_io.read_lite_restart(
+                    restart_parameters['lite_channel_restart_file']
                 )
             
-            # convert timestamp from string to datetime
-            self._t0 = datetime.strptime(t0_str, "%Y-%m-%d_%H:%M:%S")
+            elif restart_parameters.get("wrf_hydro_channel_restart_file", None):
+                self._q0 = nhd_io.get_channel_restart_from_wrf_hydro(
+                    restart_parameters["wrf_hydro_channel_restart_file"],
+                    restart_parameters["wrf_hydro_channel_ID_crosswalk_file"],
+                    restart_parameters.get("wrf_hydro_channel_ID_crosswalk_file_field_name", 'link'),
+                    restart_parameters.get("wrf_hydro_channel_restart_upstream_flow_field_name", 'qlink1'),
+                    restart_parameters.get("wrf_hydro_channel_restart_downstream_flow_field_name", 'qlink2'),
+                    restart_parameters.get("wrf_hydro_channel_restart_depth_flow_field_name", 'hlink'),
+                    )
+
+                t0_str = nhd_io.get_param_str(
+                        restart_parameters["wrf_hydro_channel_restart_file"], 
+                        "Restart_Time"
+                    )
+                
+                # convert timestamp from string to datetime
+                self._t0 = datetime.strptime(t0_str, "%Y-%m-%d_%H:%M:%S")
+            
+            else:
+                # Set cold initial state
+                # assume to be zero
+                # 0, index=connections.keys(), columns=["qu0", "qd0", "h0",], dtype="float32"
+                self._q0 = pd.DataFrame(
+                    0, index=self.segment_index, columns=["qu0", "qd0", "h0"], dtype="float32",
+                    )
+                
+                # get initial time from user inputs
+                self._t0 = restart_parameters.get("start_datetime")
         
         else:
-            # Set cold initial state
-            # assume to be zero
-            # 0, index=connections.keys(), columns=["qu0", "qd0", "h0",], dtype="float32"
-            self._q0 = pd.DataFrame(
-                0, index=self.segment_index, columns=["qu0", "qd0", "h0"], dtype="float32",
-                )
-            
-            # get initial time from user inputs
-            self._t0 = restart_parameters.get("start_datetime")
+            q0 = value_dict['q0']
+            q0_ids = value_dict['q0_index']
+            if len(q0)>0:
+                self._q0 = pd.DataFrame(data=q0.reshape(len(q0_ids), -1),
+                                        index=q0_ids,
+                                        columns=['qu0','qd0','h0'])
+                self._t0 = value_dict['t0']
+            else:
+                # Set cold initial state
+                self._q0 = pd.DataFrame(
+                    0, index=self.segment_index, columns=["qu0", "qd0", "h0"], dtype="float32",
+                    )
+                
+                # get initial time from user inputs
+                self._t0 = restart_parameters.get("start_datetime")
 
         LOG.debug(
             "channel initial states complete in %s seconds."\

--- a/src/troute-network/troute/DataAssimilation.py
+++ b/src/troute-network/troute/DataAssimilation.py
@@ -74,10 +74,26 @@ class NudgingDA(AbstractDA):
 
                 self._usgs_df = _reindex_link_to_lake_id(usgs_df, network.link_lake_crosswalk)
                 
-                lastobs = streamflow_da_parameters.get("bmi_lastobs", False)
+                lastobs = streamflow_da_parameters.get("lastobs_file", False)
                 self._last_obs_df = pd.DataFrame()
                 if lastobs:
-                    lastobs_df = value_dict['lastobs_df']
+                    lastobs_df = value_dict['lastobs_df'].set_index('gages')
+                    link_gage_df = network.link_gage_df.reset_index().set_index('gages')
+                    col_name = link_gage_df.columns[0]
+                    link_gage_df[col_name] = link_gage_df[col_name].astype(int)
+                    gages_dict = link_gage_df.to_dict().get(col_name)
+                    lastobs_df = lastobs_df.rename(index=gages_dict)
+                    # remove 'nan' values from index
+                    temp_df = lastobs_df.reset_index()
+                    temp_df = temp_df[temp_df['gages']!='nan']
+                    temp_df['gages'] = temp_df['gages'].astype(int)
+                    lastobs_df = temp_df.set_index('gages').dropna()
+                    '''
+                    link_lake_dict = pd.DataFrame.from_dict(network.link_lake_crosswalk, orient='index').reset_index()
+                    link_lake_dict.columns = ['lake_id', 'link']
+                    link_lake_dict = link_lake_dict.set_index('link').to_dict().get('lake_id')
+                    '''
+                    
                     self._last_obs_df = _reindex_link_to_lake_id(lastobs_df, network.link_lake_crosswalk)
             
             else:

--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -10,6 +10,7 @@ from itertools import chain
 from joblib import delayed, Parallel
 from collections import defaultdict
 import xarray as xr
+import os
 
 import troute.nhd_io as nhd_io #FIXME
 from troute.nhd_network import reverse_dict, extract_connections, reverse_network, reachable
@@ -235,6 +236,9 @@ class HYFeaturesNetwork(AbstractNetwork):
         if self.preprocessing_parameters.get('use_preprocessed_data', False):
             self.read_preprocessed_data()
         else:
+            #FIXME: Temporary solution, from files should only be from command line.
+            # Update this once ngen framework is capable of providing this info via BMI.
+            from_files=True
             if from_files:
                 flowpaths, lakes, network = read_geo_file(
                     self.supernetwork_parameters,
@@ -247,7 +251,9 @@ class HYFeaturesNetwork(AbstractNetwork):
                     value_dict, 
                     bmi_parameters,
                     )
-
+            #FIXME: See FIXME above.
+            from_files=False
+            
             # Preprocess network objects
             self.preprocess_network(flowpaths)
 
@@ -270,7 +276,7 @@ class HYFeaturesNetwork(AbstractNetwork):
             print("... in %s seconds." % (time.time() - start_time))
             
 
-        super().__init__()   
+        super().__init__(from_files, value_dict)   
             
         # Create empty dataframe for coastal_boundary_depth_df. This way we can check if
         # it exists, and only read in SCHISM data during 'assemble_forcings' if it doesn't
@@ -466,10 +472,15 @@ class HYFeaturesNetwork(AbstractNetwork):
                 )
             # transform dataframe into a dictionary where key is segment ID and value is gage ID
             usgs_ind = gages_df.value.str.isnumeric() #usgs gages used for streamflow DA
-            self._gages = gages_df.loc[usgs_ind][['value']].rename(columns={'value': 'gages'}).to_dict()
-
             # Use hydroseq information to determine furthest downstream gage when multiple are present.
-            # Also create our lake_gage_df to make crosswalk dataframes.
+            self._gages = (
+                gages_df.loc[usgs_ind].reset_index()
+                .groupby('value').max('hydroseq').reset_index()
+                .set_index('index')[['value']].rename(columns={'value': 'gages'})
+                .rename_axis(None, axis=0).to_dict()
+            )
+            
+            # Find furthest downstream gage and create our lake_gage_df to make crosswalk dataframes.
             lake_gage_hydroseq_df = gages_df[~gages_df['lake_id'].isnull()][['lake_id', 'value', 'hydroseq']].rename(columns={'value': 'gages'})
             lake_gage_hydroseq_df['lake_id'] = lake_gage_hydroseq_df['lake_id'].astype(int)
             lake_gage_df = lake_gage_hydroseq_df[['lake_id','gages']].drop_duplicates()
@@ -518,7 +529,8 @@ class HYFeaturesNetwork(AbstractNetwork):
             if rfc_da:
                 #FIXME: Temporary fix, read in predefined rfc lake gage crosswalk file for rfc reservoirs.
                 # Replace relevant waterbody_types as type 4.
-                rfc_lake_gage_crosswalk = pd.read_csv('/home/sean.horvath/projects/t-route/test/ngen/rfc_lake_gage_crosswalk.csv')
+                temp_rfc_file = Path(__file__).parent / 'rfc_lake_gage_crosswalk.csv'
+                rfc_lake_gage_crosswalk = pd.read_csv(temp_rfc_file)
                 self._rfc_lake_gage_crosswalk = rfc_lake_gage_crosswalk[rfc_lake_gage_crosswalk['rfc_lake_id'].isin(self.waterbody_dataframe.index)].set_index('rfc_lake_id')
                 self._waterbody_types_df.loc[self._rfc_lake_gage_crosswalk.index,'reservoir_type'] = 4
             

--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -236,7 +236,7 @@ class HYFeaturesNetwork(AbstractNetwork):
         if self.preprocessing_parameters.get('use_preprocessed_data', False):
             self.read_preprocessed_data()
         else:
-            #FIXME: Temporary solution, from files should only be from command line.
+            #FIXME: Temporary solution, from_files should only be from command line.
             # Update this once ngen framework is capable of providing this info via BMI.
             from_files=True
             if from_files:
@@ -253,7 +253,7 @@ class HYFeaturesNetwork(AbstractNetwork):
                     )
             #FIXME: See FIXME above.
             from_files=False
-            
+
             # Preprocess network objects
             self.preprocess_network(flowpaths)
 

--- a/src/troute_model.py
+++ b/src/troute_model.py
@@ -271,6 +271,8 @@ class troute_model():
         nudge = np.concatenate([r[8] for r in self._run_results])[:,1:]
         usgs_positions_id = np.concatenate([r[3][0] for r in self._run_results]).astype(int)
         self._nudge = pd.DataFrame(data=nudge, index=usgs_positions_id)
+        values['nudging'] = self._nudge
+        values['nudging_ids'] = usgs_positions_id
 
         # Get output from final timestep
         (values['channel_exit_water_x-section__volume_flow_rate'], 
@@ -279,7 +281,6 @@ class troute_model():
          values['lake_water~incoming__volume_flow_rate'], 
          values['lake_water~outgoing__volume_flow_rate'], 
          values['lake_surface__elevation'],
-         #TODO: add 'assimilated_value' as an output?
         ) = _retrieve_last_output(
             self._run_results, 
             nts, 

--- a/src/troute_model.py
+++ b/src/troute_model.py
@@ -267,6 +267,15 @@ class troute_model():
         )
         values['fvd_results'] = self._fvd.values.flatten()
         values['fvd_index'] = self._fvd.index
+        values['lakeout'] = self._lakeout.values.flatten()
+        values['lakeout_index'] = self._lakeout.index
+        values['q0'] = self._network.q0.values.flatten()
+        values['q0_index'] = self._network.q0.index
+        values['waterbody_df'] = self._network.waterbody_dataframe.values.flatten()
+        values['waterbody_df_index'] = self._network.waterbody_dataframe.index
+        lastobs_df = self._data_assimilation.lastobs_df.join(self._network.link_gage_df)
+        values['lastobs_df'] = lastobs_df.values.flatten()
+        values['lastobs_df_index'] = lastobs_df.index
 
         nudge = np.concatenate([r[8] for r in self._run_results])[:,1:]
         usgs_positions_id = np.concatenate([r[3][0] for r in self._run_results]).astype(int)


### PR DESCRIPTION
Add functionality to pass info pertaining to restart and lastobs files from troute_model to DAforcing_model, which in turn can write/read appropriate files.

## Additions

- Read/write restart and lastobs files from DAforcing_model
- Pass relevant info via BMI between troute and DAforcing
- Handle accepting restart and lastobs info via BMI in network classes
- Update creating gages dictionary to only include the linked flowpath that is furthest downstream (when multiple flowpaths are associated with the same gage)

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
