### PR TITLE
adding missing editable/no-editable functionality to network-config

### DIFF
--- a/compiler.sh
+++ b/compiler.sh
@@ -94,7 +94,7 @@ fi
 if [[ "$build_config" == true ]]; then
   #updates troute package with the execution script
   cd $REPOROOT/src/troute-config
-  pip install -e . || exit
+  pip install $E . || exit
 fi
 
 if [[ "$build_nwm" == true ]]; then


### PR DESCRIPTION
By adding missing editable/no-editable functionality to network-config. This should solve the #651 issue.

## Changes

- Enabled editable/no-editable functionality to network-config in [compiler.sh](https://github.com/NOAA-OWP/t-route/pull/657/files#diff-2ca6ed5bcf5279d22de0a0f3962be15b6870911788ec741a980b63c9e84765d5)

## Testing

1. Installation testing:
```bash
./compiler.sh no-e
```

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [X] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
