### PR TITLE
generalize bandaid() function to work on subdomains of CONUS

### DIFF
--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -623,12 +623,28 @@ class HYFeaturesNetwork(AbstractNetwork):
     #FIXME Temporary solution to hydrofabric issues. Fix specific instances here for now...
     def bandaid(self,):
         #This chunk assigns lake_ids to segments that reside within the waterbody:
-        self._dataframe.loc[[5548,5551,],'waterbody'] = '5194634'
-        self._dataframe.loc[[5539,5541,5542],'waterbody'] = '5194604'
-        self._dataframe.loc[[2710744,2710746],'waterbody'] = '120051895'
-        self._dataframe.loc[[1536065,1536067],'waterbody'] = '7100709'
-        self._dataframe.loc[[1536104,1536099,1536084,1536094],'waterbody'] = '120052233'
-        self._dataframe.loc[[2711040,2711044,2711047],'waterbody'] = '120052275'
+        wbody_replacement_dict = {
+            5548: '5194634',
+            5551: '5194634',
+            5539: '5194604',
+            5541: '5194604',
+            5542: '5194604',
+            2710744: '120051895',
+            2710746: '120051895',
+            1536065: '7100709',
+            1536067: '7100709',
+            1536104: '120052233',
+            1536099: '120052233',
+            1536084: '120052233',
+            1536094: '120052233',
+            2711040: '120052275',
+            2711044: '120052275',
+            2711047: '120052275'
+        }
+
+        for key, value in wbody_replacement_dict.items():
+            if key in self.dataframe.index:
+                self._dataframe.loc[[key],'waterbody'] = value
         
         #This chunk replaces waterbody_id 1711354 with 1710676. I don't know where the 
         #former came from, but the latter is listed in the flowpath_attributes table


### PR DESCRIPTION
Generalizes bandaid() function that fixes missing lake_id-segment connections in hydrofabric. Originally designed for CONUS, but now it is generalized to work on subdomains when these segments/waterbodies are not in the domain.

## Additions

-

## Removals

-

## Changes

- Edit bandaid() function in HYFeatures.py

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
