### PR TITLE
fix - lock cython version, add missing pip deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ pyyaml
 toolz
 joblib
 deprecated
-pyarrow
+pyarrow<12.0
 geopandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-Cython==0.29.36
+Cython<3.0.4
 pandas>=1.1.5
 xarray
 netcdf4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,11 @@
 numpy
-Cython
+Cython==0.29.36
 pandas>=1.1.5
 xarray
 netcdf4
 pyyaml
 toolz
 joblib
+deprecated
+pyarrow
+geopandas


### PR DESCRIPTION
Fixes #651
breakout from #660 

# Summary

Adds required pip packages to requirements.txt
Locks cython version to fix ./compile.sh

## requirements.txt
### Additions
- pyarrow
- deprecated
- geopandas

### Changes
 - Cython==0.29.36

## Testing
### Before
```bash
#0 65.83 Compiler crash traceback from this point on:
#0 65.83   File "/opt/venv/lib64/python3.9/site-packages/Cython/Compiler/ExprNodes.py", line 4968, in analyse_types
#0 65.83     performance_hint(index.pos, "Index should be typed for more efficient access")
#0 65.83 TypeError: performance_hint() missing 1 required positional argument: 'env'
#0 65.83 Traceback (most recent call last):
#0 65.83   File "/t-route/src/troute-routing/setup.py", line 122, in <module>
#0 65.83 Fortran compiler type is: gnu95
#0 65.83 Compiling troute/routing/fast_reach/reach.pyx because it changed.
#0 65.83 Compiling troute/routing/fast_reach/mc_reach.pyx because it changed.
#0 65.83 Compiling troute/routing/fast_reach/diffusive.pyx because it changed.
#0 65.83 Compiling troute/routing/fast_reach/simple_da.pyx because it changed.
#0 65.83 [1/4] Cythonizing troute/routing/fast_reach/diffusive.pyx
#0 65.83 [2/4] Cythonizing troute/routing/fast_reach/mc_reach.pyx
#0 65.83     ext_modules = cythonize(ext_modules, compiler_directives={"language_level": 3})
#0 65.83   File "/opt/venv/lib64/python3.9/site-packages/Cython/Build/Dependencies.py", line 1154, in cythonize
#0 65.83     cythonize_one(*args)
#0 65.83   File "/opt/venv/lib64/python3.9/site-packages/Cython/Build/Dependencies.py", line 1321, in cythonize_one
#0 65.83     raise CompileError(None, pyx_file)
#0 65.83 Cython.Compiler.Errors.CompileError: troute/routing/fast_reach/mc_reach.pyx
------
Dockerfile.troute:20
--------------------
  18 |     RUN python -m pip install -r requirements.txt
  19 |
  20 | >>> RUN ./compiler.sh no-e
  21 |
  22 |     # increase max open files soft limit
--------------------
ERROR: failed to solve: process "/bin/sh -c ./compiler.sh no-e" did not complete successfully: exit code: 1
```

### After
![image](https://github.com/NOAA-OWP/t-route/assets/26720477/cfbb829c-aaf1-4f88-9d22-f611fa2cc1ea)
Screenshot is of a docker build step successfully running, before it would fail on that step.

## Notes

`Using legacy 'setup.py install' for troute.network, since package 'wheel' is not installed.` this warning does appear when compiling.
Without version locks on all the pip packages, it would be a good idea to have some schedulled tests to catch any breaking updates to packages. #669 or #670  could help?

## Todos

- [ ] Update ngen documentation [about installing those packages](https://github.com/NOAA-OWP/ngen/blob/master/doc/PYTHON_ROUTING.md#setup-virtual-environment)

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
