### PR TITLE
-V3 test fix

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ $ ./compiler.sh
 
 # execute a demonstration test
 $ cd test/LowerColorado_TX
-$ python3 -m nwm_routing -f test_AnA.yaml
+$ python3 -m nwm_routing -V3 -f test_AnA.yaml
 ```
 
 ## Known issues

--- a/src/troute-nwm/src/nwm_routing/preprocess.py
+++ b/src/troute-nwm/src/nwm_routing/preprocess.py
@@ -1076,10 +1076,8 @@ def nwm_forcing_preprocess(
         
         # build dataframe that crosswalks segmentIDs to lakeIDs
         link_lake_df = (
-            gage_lake_df.
-            join(gage_link_df, how = 'inner').
-            reset_index().set_index('link').
-            drop(['index'], axis = 1)
+            gage_lake_df.join(gage_link_df, how = 'inner').
+            reset_index(drop=True).set_index('link')
         )
         
         # resample `usgs_df` to 15 minute intervals
@@ -1093,9 +1091,8 @@ def nwm_forcing_preprocess(
         # subset and re-index `usgs_df`, using the segID <> lakeID crosswalk
         reservoir_usgs_df = (
             usgs_df_15min.join(link_lake_df, how = 'inner').
-            reset_index().
-            set_index('usgs_lake_id').
-            drop(['index'], axis = 1)
+            reset_index(drop=True).
+            set_index('usgs_lake_id')
         )
         
         LOG.debug(


### PR DESCRIPTION
Fix for #658 #617
breakout from #660 

## Changes
- Updates dataframe joins in preprocessing.py to always drop the index _**regardless of the name**_. Fixes index not found error.
- Updates main README.md test command to include the required -V3 argument

## Testing

1. Tested on rockylinux:9.2 using a docker image #669 

### Before
```bash
Traceback (most recent call last):
  File "/usr/lib64/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib64/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/opt/venv/lib64/python3.9/site-packages/nwm_routing/__main__.py", line 2025, in <module>
    main_v03(v_args[1])
  File "/opt/venv/lib64/python3.9/site-packages/nwm_routing/__main__.py", line 1439, in main_v03
    ) = nwm_forcing_preprocess(
  File "/opt/venv/lib64/python3.9/site-packages/nwm_routing/preprocess.py", line 1095, in nwm_forcing_preprocess
    usgs_df_15min.join(link_lake_df, how = 'inner').
  File "/opt/venv/lib64/python3.9/site-packages/pandas/core/frame.py", line 5344, in drop
    return super().drop(
  File "/opt/venv/lib64/python3.9/site-packages/pandas/core/generic.py", line 4711, in drop
    obj = obj._drop_axis(labels, axis, level=level, errors=errors)
  File "/opt/venv/lib64/python3.9/site-packages/pandas/core/generic.py", line 4753, in _drop_axis
    new_axis = axis.drop(labels, errors=errors)
  File "/opt/venv/lib64/python3.9/site-packages/pandas/core/indexes/base.py", line 6992, in drop
    raise KeyError(f"{labels[mask].tolist()} not found in axis")
KeyError: "['index'] not found in axis"
```

### After
```bash
1611674    0.000077  0.006773   0.008970  ...  0.000062  0.005203   0.006017
1611676    0.000082  0.003280   0.015840  ...  0.000068  0.003036   0.014073
3763126    0.034257  0.000000  47.399315  ...  0.034257  0.000000  47.399315
3762962    0.002929  0.068917   0.012062  ...  0.002916  0.068801   0.012032
3762964    0.001314  0.043036   0.007198  ...  0.001310  0.042978   0.007183
...             ...       ...        ...  ...       ...       ...        ...
942080041  0.430877  0.224738   0.204465  ...  0.432033  0.224962   0.204790
942080042  0.303739  0.174873   0.147887  ...  0.303428  0.174805   0.147797
942080043  0.763043  0.228061   0.243238  ...  0.763939  0.228161   0.243407
942080044  3.947985  0.434812   0.492912  ...  3.808649  0.429271   0.482648
942080045  1.003426  0.294292   0.264091  ...  1.013184  0.296245   0.266902

[10806 rows x 864 columns]
2023-10-28 18:05:13,513   DEBUG [output.py:376 - nwm_output_generator()]: output complete in 0.6099920272827148 seconds.
2023-10-28 18:05:13,513   DEBUG [__main__.py:1645 -             main_v03()]: process complete in 5.491147756576538 seconds.
************ TIMING SUMMARY ************
----------------------------------------
Network graph construction: 0.19 secs, 3.45 %
Initial condition handling: 0.13 secs, 2.37 %
Forcing array construction: 1.72 secs, 31.33 %
Routing computations: 2.82 secs, 51.41 %
Output writing: 0.61 secs, 11.12 %
----------------------------------------
Total execution time: 5.47 secs
```

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser
