### PR TITLE
drop waterbodies with missing parameters

### DIFF
--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -402,8 +402,9 @@ class HYFeaturesNetwork(AbstractNetwork):
                        'OrificeC','OrificeE','WeirC','WeirE','WeirL']]
                 .rename(columns={'hl_link': 'lake_id'})
                 )
+
             self._waterbody_df['lake_id'] = self.waterbody_dataframe.lake_id.astype(float).astype(int)
-            self._waterbody_df = self.waterbody_dataframe.set_index('lake_id').drop_duplicates().sort_index()
+            self._waterbody_df = self.waterbody_dataframe.set_index('lake_id').drop_duplicates().sort_index().dropna()
             
             # Create wbody_conn dictionary:
             #FIXME temp solution for missing waterbody info in hydrofabric


### PR DESCRIPTION
Remove any waterbodies from waterbody_df that have missing parameters. We cannot compute reservoir routing without these params.

## Additions

-

## Removals

-

## Changes

- Drop rows with missing values in waterbody_df

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
