### PR TITLE
Rename nc-config to nf-config

### DIFF
--- a/src/kernel/reservoir/makefile
+++ b/src/kernel/reservoir/makefile
@@ -1,5 +1,5 @@
-NETCDFINC := -I$(NETCDFINC) $(shell nc-config --fflags)
-NETCDFLIB := $(shell nc-config --flibs)
+NETCDFINC := -I$(NETCDFINC) $(shell nf-config --fflags)
+NETCDFLIB := $(shell nf-config --flibs)
 COMPILER90 = $(F90)
 
 F90FLAGSGFORTRAN = -w -c -ffree-form -ffree-line-length-none -fconvert=big-endian -frecord-marker=4 -static-libgfortran -lgfortran -lgcc -static-libgcc 


### PR DESCRIPTION
[Short description explaining the high-level reason for the pull request]

## Additions

-

## Removals

-

## Changes

- This PR fixes "unknown option: --fflags Usage: nc-config" by renaming `nc-config` to `nf-config` in `src/kernel/reservoir/makefile`.

## Testing

1. Without this PR, `./compile.sh` fails with an "unknown option: --fflags Usage: nc-config ..." error because `nc-config` doesn't support `--fflags` and `--flibs` anymore since https://github.com/Unidata/netcdf-c/pull/2619 (netcdf-4.9.2).
2. With this PR, the reservoir `makefile` calls `nf-config` from netcdf-fortran.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
