### PR TITLE
Repair output functions

### DIFF
--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -406,6 +406,18 @@ class HYFeaturesNetwork(AbstractNetwork):
             self._waterbody_df['lake_id'] = self.waterbody_dataframe.lake_id.astype(float).astype(int)
             self._waterbody_df = self.waterbody_dataframe.set_index('lake_id').drop_duplicates().sort_index()
             
+            # Convert to lat/lon for LAKEOUT files:
+            lat_lon_crs = lakes[['hl_link','hl_reference','geometry']].rename(columns={'hl_link': 'lake_id'})
+            lat_lon_crs = lat_lon_crs[lat_lon_crs['hl_reference']=='WBOut']
+            lat_lon_crs['lake_id'] = lat_lon_crs.lake_id.astype(float).astype(int)
+            lat_lon_crs = lat_lon_crs.set_index('lake_id').drop_duplicates().sort_index()
+            lat_lon_crs = lat_lon_crs.loc[self.waterbody_dataframe.index]
+            lat_lon_crs = lat_lon_crs.to_crs(crs=4326)
+
+            self._waterbody_df['lon'] = lat_lon_crs.geometry.x
+            self._waterbody_df['lat'] = lat_lon_crs.geometry.y
+            self._waterbody_df['crs'] = str(lat_lon_crs.crs)
+            
             #FIXME temp solution for missing waterbody info in hydrofabric
             self.bandaid()
             

--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -1982,13 +1982,18 @@ def write_flowveldepth_netcdf(stream_output_directory,
     qvd_ndg = flowveldepth.copy()
     # Create a list for names of the columns for nudge values
     ndg_columns = [(j,'ndg') for j in range(nsteps)]
-    # Add 'ndg' columns based on usgs_positions_id
-    for i, usgs_id in enumerate(usgs_positions_id):
-        # Extract the corresponding nudge values for the usgs_id
-        nudge_values = nudge[i]
 
-        # Assign nudge values to 'ndg' columns for the corresponding row
-        qvd_ndg.loc[usgs_id, ndg_columns] = nudge_values
+    if len(usgs_positions_id)>0:
+        # Add 'ndg' columns based on usgs_positions_id
+        for i, usgs_id in enumerate(usgs_positions_id):
+            # Extract the corresponding nudge values for the usgs_id
+            nudge_values = nudge[i]
+
+            # Assign nudge values to 'ndg' columns for the corresponding row
+            qvd_ndg.loc[usgs_id, ndg_columns] = nudge_values
+    else:
+        qvd_ndg.loc[:, ndg_columns] = -9999.0
+
     new_order = [(i, attr) for i in range(0, nsteps) for attr in ['q', 'v', 'd', 'ndg']]
     # Reorder the columns
     qvd_ndg = qvd_ndg[new_order]
@@ -2018,13 +2023,13 @@ def write_flowveldepth_netcdf(stream_output_directory,
                 file_name = f"{current_time_step}.flowveldepth.csv"
                 # Save the data to CSV file
                 subset_df.to_csv(f"{stream_output_directory}/{file_name}", index=True)
-                print(f"Flowveldepth data saved as CSV files in {stream_output_directory}")
+                LOG.debug(f"Flowveldepth data saved as CSV files in {stream_output_directory}")
 
             elif stream_output_type=='.pkl':
                 file_name = f"{current_time_step}.flowveldepth.pkl"
                 # Save the data to Pickle file
                 subset_df.to_pickle(f"{stream_output_directory}/{file_name}")
-                print(f"Flowveldepth data saved as PICKLE files in {stream_output_directory}")
+                LOG.debug(f"Flowveldepth data saved as PICKLE files in {stream_output_directory}")
                 
             else:
                 print('WRONG FORMAT')
@@ -2087,5 +2092,5 @@ def write_flowveldepth_netcdf(stream_output_directory,
                             'code_version': '',
                         }
                     )
-                    print(f"Flowveldepth data saved as NetCDF files in {stream_output_directory}")
+                    LOG.debug(f"Flowveldepth data saved as NetCDF files in {stream_output_directory}")
             


### PR DESCRIPTION
Fix some issues with writing flowveldepth files and LAKEOUT files

## Additions

- Add lat, lon, and crs info to waterbody_dataframe. Writing LAKEOUT files requires this info. Does not change any routing computations.

## Removals

-

## Changes

- Check if `usgs_positions_id` array is empty. If so, simply write -9999.0 values for all `nudge` values
- Change printing 'wrote such and such file' to a LOG.debug feature.

## Testing

1. Worked on LowerColorado_TX_v4 HYFeatures

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
