### PR TITLE
Check before performing CRS reprojection

### DIFF
--- a/src/troute-network/troute/AbstractNetwork.py
+++ b/src/troute-network/troute/AbstractNetwork.py
@@ -32,7 +32,7 @@ class AbstractNetwork(ABC):
                 "_qlateral", "_break_segments", "_segment_index", "_coastal_boundary_depth_df",
                 "supernetwork_parameters", "waterbody_parameters","data_assimilation_parameters",
                 "restart_parameters", "compute_parameters", "forcing_parameters",
-                "hybrid_parameters", "preprocessing_parameters",
+                "hybrid_parameters", "preprocessing_parameters", "output_parameters",
                 "verbose", "showtiming", "break_points", "_routing"]
     
     def __init__(self, from_files=True, value_dict={}):

--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -507,7 +507,7 @@ class HYFeaturesNetwork(AbstractNetwork):
                 idx_id = 'index'
             self._gages = (
                 gages_df.loc[usgs_ind].reset_index()
-                .groupby('value').max('hydroseq').reset_index()
+                .sort_values('hydroseq').drop_duplicates(['value'],keep='last')
                 .set_index(idx_id)[['value']].rename(columns={'value': 'gages'})
                 .rename_axis(None, axis=0).to_dict()
             )

--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -502,10 +502,13 @@ class HYFeaturesNetwork(AbstractNetwork):
             # transform dataframe into a dictionary where key is segment ID and value is gage ID
             usgs_ind = gages_df.value.str.isnumeric() #usgs gages used for streamflow DA
             # Use hydroseq information to determine furthest downstream gage when multiple are present.
+            idx_id = gages_df.index.name
+            if not idx_id:
+                idx_id = 'index'
             self._gages = (
                 gages_df.loc[usgs_ind].reset_index()
                 .groupby('value').max('hydroseq').reset_index()
-                .set_index('index')[['value']].rename(columns={'value': 'gages'})
+                .set_index(idx_id)[['value']].rename(columns={'value': 'gages'})
                 .rename_axis(None, axis=0).to_dict()
             )
             

--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -433,7 +433,7 @@ class HYFeaturesNetwork(AbstractNetwork):
                 self._waterbody_df['lon'] = np.nan
                 self._waterbody_df['lat'] = np.nan
                 self._waterbody_df['crs'] = np.nan
-            import pdb; pdb.set_trace()
+            
             # Create wbody_conn dictionary:
             wbody_conn = self.dataframe[['waterbody']].dropna()
             wbody_conn = (

--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -1999,7 +1999,7 @@ def write_flowveldepth_netcdf(stream_output_directory,
     qvd_ndg = qvd_ndg[new_order]
     
     # Create time step values based on t0
-    time_steps = [t0 + timedelta(hours= (i * stream_output_timediff)) for i in range(1, nsteps//nstep_nc+1)]
+    time_steps = [t0 + timedelta(hours= (i * stream_output_timediff)) for i in range(nsteps//nstep_nc)]
     time_dim = [t * stream_output_internal_frequency*60 for t in range(1, int(stream_output_timediff * 60 / stream_output_internal_frequency) + 1)]
     
     for counter, i in enumerate(range(0, nsteps, nstep_nc)):
@@ -2088,6 +2088,7 @@ def write_flowveldepth_netcdf(stream_output_directory,
                             'TITLE': 'OUTPUT FROM T-ROUTE',
                             'Time step (sec)': f'{stream_output_internal_frequency}',
                             'model_initialization_time': t0.strftime('%Y-%m-%d_%H:%M:%S'),
+                            'model_reference_time': time_steps[counter].strftime('%Y-%m-%d_%H:%M:%S'),
                             'comment': f'The file includes {stream_output_timediff} hour data which includes {len(time_dim)} timesteps',
                             'code_version': '',
                         }

--- a/src/troute-nwm/src/nwm_routing/__main__.py
+++ b/src/troute-nwm/src/nwm_routing/__main__.py
@@ -85,6 +85,7 @@ def main_v04(argv):
                                     forcing_parameters,
                                     hybrid_parameters,
                                     preprocessing_parameters,
+                                    output_parameters,
                                     verbose=True, showtiming=showtiming) 
         
     elif supernetwork_parameters["network_type"] == 'NHDNetwork':


### PR DESCRIPTION
t-route now checks if LAKEOUT files are too be created (set in yaml file under output_parameters -> lakeout_output:) before performing re-projection of waterbody_dataframe to get latitude, longitude, and crs information. 

This is an issue that arose due to sqlite3 versioning. This doesn't actually fix that problem, but is a workaround for now.

## Additions
AbstractNetwork.py
- add `output_parameters` slot

HYFeaturesNetwork.py
- Check if LAKEOUT files are to be created. If so, reproject geopandas.dataframe geometry column to get lat, lon, and crs columns
- If not creating LAKEOUT files, assign those columns np.nan
- Unrelated, but fix `pd.DataFrame.set_index()` error for `gage_df `

AbstractNetwork.py
- add `output_parameters` as input to `HYFeatures()`

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
