### PR TITLE
use only python version of RFC DA

### DIFF
--- a/src/troute-nwm/src/nwm_routing/__main__.py
+++ b/src/troute-nwm/src/nwm_routing/__main__.py
@@ -56,7 +56,7 @@ def main_v04(argv):
     run_parameters = {
         'dt': forcing_parameters.get('dt'),
         'nts': forcing_parameters.get('nts'),
-        'cpu_pool': compute_parameters.get('cpu_pool')
+        'cpu_pool': compute_parameters.get('cpu_pool'),
     }
     
     showtiming = log_parameters.get("showtiming", None)
@@ -1055,12 +1055,10 @@ def nwm_route(
     coastal_boundary_depth_df,
     unrefactored_topobathy_df,
     flowveldepth_interorder={},
-    from_files=True,
+    from_files=False,
 ):
 
-    ################### Main Execution Loop across ordered networks
-    
-    
+    ################### Main Execution Loop across ordered networks      
     start_time = time.time()
 
     if return_courant:

--- a/test/LowerColorado_TX_v4/test_AnA_V4_HYFeature.yaml
+++ b/test/LowerColorado_TX_v4/test_AnA_V4_HYFeature.yaml
@@ -9,7 +9,7 @@ network_topology_parameters:
     #----------
     supernetwork_parameters:
         #----------
-        geo_file_path: domain/LowerColorado_NGEN1.gpkg
+        geo_file_path: domain/LowerColorado_NGENv20.gpkg
         columns: 
             key: 'id'
             downstream: 'toid'
@@ -39,10 +39,9 @@ compute_parameters:
     cpu_pool               : 36
     restart_parameters:
         #----------
-        start_datetime: 2023-04-02_00:00
-        #lite_channel_restart_file            : restart/RESTART.2020082600_DOMAIN1
-
-        #lite_waterbody_restart_file          : restart/waterbody_restart_202006011200
+        start_datetime              : 2023-04-02_00:00
+        lite_channel_restart_file   : #restart/RESTART.2020082600_DOMAIN1
+        lite_waterbody_restart_file : #restart/waterbody_restart_202006011200
     hybrid_parameters:
         run_hybrid_routing: False
         diffusive_domain  : #domain/coastal_domain_subset.yaml  
@@ -64,34 +63,34 @@ compute_parameters:
     data_assimilation_parameters:
         #----------
         usgs_timeslices_folder   : usgs_timeslices/
-        usace_timeslices_folder  : #usace_timelices/
+        usace_timeslices_folder  : usace_timelices/
         streamflow_da:
             #----------
-            streamflow_nudging            : False
+            streamflow_nudging            : True
             diffusive_streamflow_nudging  : False                    
             lastobs_output_folder         : lastobs/
         reservoir_da:
             #----------
             reservoir_persistence_da:
                 #----------
-                reservoir_persistence_usgs  : False
-                reservoir_persistence_usace : False
+                reservoir_persistence_usgs  : True
+                reservoir_persistence_usace : True
             reservoir_rfc_da:
                 #----------
-                reservoir_rfc_forecasts                 : False
+                reservoir_rfc_forecasts                 : True
                 reservoir_rfc_forecasts_time_series_path: rfc_timeseries/
                 reservoir_rfc_forecasts_lookback_hours  : 28
                 reservoir_rfc_forecasts_offset_hours    : 28
 #--------------------------------------------------------------------------------
 output_parameters:
     #----------
-    test_output: output/lcr_flowveldepth.pkl
+    test_output : output/lcr_flowveldepth.pkl
     lite_restart:
         #----------
         lite_restart_output_directory: restart/
-    #lakeout_output: lakeout/
-    stream_output: 
+    lakeout_output: lakeout/
+    stream_output : 
         stream_output_directory: output/
         stream_output_time: 1 #[hr]
-        stream_output_type: '.nc' #please select only between netcdf '.nc' or '.csv' or '.pkl'
+        stream_output_type: '.pkl' #please select only between netcdf '.nc' or '.csv' or '.pkl'
         stream_output_internal_frequency: 60 #[min] it should be order of 5 minutes. For instance if you want to output every hour put 60    


### PR DESCRIPTION
When from_files is still True (which means not using BMI), it creates rfc_df and rfc_param_df only to use Python version of RFC DA because Fortran RFC DA keeps causing Deallocate related error.

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
