### PR TITLE
Make gage list extraction a testable function

### DIFF
--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -479,6 +479,30 @@ class HYFeaturesNetwork(AbstractNetwork):
             self._waterbody_type_specified = False
             self._link_lake_crosswalk = None
 
+
+    def get_da_gages(
+        self,
+        gages_df,
+        usgs_ind,
+        gages_id="gages",
+        val_id="value",
+        seq_id="hydroseq",
+        keep_opt="last",
+    ):
+        """Returns last gage in each segment to support data assimilation"""
+        idx_id=gages_df.index.name
+        return (
+            gages_df.loc[usgs_ind]
+            .reset_index()
+            .sort_values(seq_id)
+            .drop_duplicates([val_id], keep=keep_opt)
+            .set_index(idx_id)[[val_id]]
+            .rename(columns={val_id: gages_id})
+            .rename_axis(None, axis=0)
+            .to_dict()
+        )
+
+
     def preprocess_data_assimilation(self, network):
         if not network.empty:
             gages_df = network[['id','hl_uri','hydroseq']].drop_duplicates()
@@ -502,15 +526,9 @@ class HYFeaturesNetwork(AbstractNetwork):
             # transform dataframe into a dictionary where key is segment ID and value is gage ID
             usgs_ind = gages_df.value.str.isnumeric() #usgs gages used for streamflow DA
             # Use hydroseq information to determine furthest downstream gage when multiple are present.
-            idx_id = gages_df.index.name
-            if not idx_id:
-                idx_id = 'index'
-            self._gages = (
-                gages_df.loc[usgs_ind].reset_index()
-                .sort_values('hydroseq').drop_duplicates(['value'],keep='last')
-                .set_index(idx_id)[['value']].rename(columns={'value': 'gages'})
-                .rename_axis(None, axis=0).to_dict()
-            )
+            if not gages_df.index.name:
+                gages_df.index.name = 'index'
+            self._gages = self.get_da_gages(gages_df, usgs_ind)
             
             # Find furthest downstream gage and create our lake_gage_df to make crosswalk dataframes.
             lake_gage_hydroseq_df = gages_df[~gages_df['lake_id'].isnull()][['lake_id', 'value', 'hydroseq']].rename(columns={'value': 'gages'})


### PR DESCRIPTION
This was initiated to replace #684 and permit successful execution of the built-in `-V4` test on the Lower Colorado. 

A prior commit https://github.com/NOAA-OWP/t-route/commit/ce32c0364103c4e2f7b7a53bffe79dc27edef045 appears to have addressed this. So this just makes it so the pieces that were causing problems are more easily testable, though this PR does not actually implement the test. 

The integration tests...
```
cd test/LowerColorado_TX_v4
python3 -m nwm_routing -f -V4 test_AnA_V4_HYFeature.yaml
```

... and 
```
cd test/LowerColorado_TX
python3 -m nwm_routing -f -V4 test_AnA_V4_NHD.yaml
python3 -m nwm_routing -f -V3 test_AnA.yaml
```

... all work.
