### PR TITLE
fix checking for lite_restart and config test for lite_restart_directory

### DIFF
--- a/src/troute-config/troute/config/config.py
+++ b/src/troute-config/troute/config/config.py
@@ -224,3 +224,14 @@ class Config(BaseModel, extra='forbid'):
 
         return values
     
+    @root_validator(skip_on_failure=True)
+    def check_lite_restart_directory(cls, values):
+        if values['output_parameters']:
+            lite_restart = values['output_parameters'].lite_restart
+            import pdb; pdb.set_trace()
+            if lite_restart is not None:
+                lite_restart_directory = lite_restart.lite_restart_output_directory
+                assert lite_restart_directory, "lite_restart is present in output parameters, but no lite_restart_output_directory is provided."
+        
+        return values
+    

--- a/src/troute-config/troute/config/config.py
+++ b/src/troute-config/troute/config/config.py
@@ -228,7 +228,6 @@ class Config(BaseModel, extra='forbid'):
     def check_lite_restart_directory(cls, values):
         if values['output_parameters']:
             lite_restart = values['output_parameters'].lite_restart
-            import pdb; pdb.set_trace()
             if lite_restart is not None:
                 lite_restart_directory = lite_restart.lite_restart_output_directory
                 assert lite_restart_directory, "lite_restart is present in output parameters, but no lite_restart_output_directory is provided."

--- a/src/troute-nwm/src/nwm_routing/__main__.py
+++ b/src/troute-nwm/src/nwm_routing/__main__.py
@@ -216,7 +216,7 @@ def main_v04(argv):
         data_assimilation.update_after_compute(run_results, dt*nts)
 
         # TODO move the conditional call to write_lite_restart to nwm_output_generator.
-        if output_parameters.get('lite_restart',{}).get('lite_restart_output_directory', None):
+        if output_parameters['lite_restart'] is not None:
             nhd_io.write_lite_restart(
                 network.q0, 
                 network._waterbody_df, 

--- a/src/troute-nwm/src/nwm_routing/__main__.py
+++ b/src/troute-nwm/src/nwm_routing/__main__.py
@@ -216,13 +216,14 @@ def main_v04(argv):
         data_assimilation.update_after_compute(run_results, dt*nts)
 
         # TODO move the conditional call to write_lite_restart to nwm_output_generator.
-        if output_parameters['lite_restart'] is not None:
-            nhd_io.write_lite_restart(
-                network.q0, 
-                network._waterbody_df, 
-                t0 + timedelta(seconds = dt * nts), 
-                output_parameters['lite_restart']
-            )      
+        if output_parameters:
+            if output_parameters['lite_restart'] is not None:
+                nhd_io.write_lite_restart(
+                    network.q0, 
+                    network._waterbody_df, 
+                    t0 + timedelta(seconds = dt * nts), 
+                    output_parameters['lite_restart']
+                )      
 
         # Prepare input forcing for next time loop simulation when mutiple time loops are presented.
         if run_set_iterator < len(run_sets) - 1:


### PR DESCRIPTION
Redo a modification to how `output_parameters['lite_restart']` is checked prior to calling `write_lite_restart` in `__main__.py`.

This change existed, but was undone in [PR#695](https://github.com/NOAA-OWP/t-route/pull/695)

## Additions

-

## Removals

-

## Changes
__main__.py
- Check if `output_parameters['lite_restart']` is not `None`

config.py
- Add `@root_validator` to ensure a `lite_restart_output_directory` is provided if `lite_restart` is not `None`

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
