### PR TITLE
Simplify compilation of t-route on WSL

### DIFF
--- a/compiler.sh
+++ b/compiler.sh
@@ -37,6 +37,16 @@ fi
 if [ -z "$NETCDF" ]
 then
     export NETCDFINC=/usr/include/openmpi-x86_64/
+    # set alternative NETCDF variable include path, for example for WSL
+    # (Windows Subsystems for Linux).
+    #
+    # EXAMPLE USAGE: export NETCDFALTERNATIVE=$HOME/.conda/envs/py39/include/
+    # (before ./compiler.sh)
+    if [ -n "$NETCDFALTERNATIVE" ]
+    then
+	echo "using alternative NETCDF inc ${NETCDFALTERNATIVE}"
+	export NETCDFINC=$NETCDFALTERNATIVE
+    fi
 else
     export NETCDFINC="${NETCDF}"
 fi


### PR DESCRIPTION
To simplify compilation of t-route on non-traditional compute environments such as WSL, added the option to set a new alternative NETCDF environment variable, without interfering with the existing compile procedures (if said NETCDFALTERNATIVE is not defined). The value-add here is that no custom conda environment is needed any longer to set the pesky NETCDF include path on WSL. 

## Additions

- Adding optional logic for NETCDFALTERNATIVE to compiler.sh

## Removals

-

## Changes

-

## Testing

1. On environments such as WSL, set your own alternative NETCDF include directory, e.g.:
        export NETCDFALTERNATIVE=$HOME/.conda/envs/py39/include/,
    Then run ./compiler.sh as before. 

2. If that is not desired, follow present instructions, there are no changes. 

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
