### PR TITLE
update to read the parquet file

### DIFF
--- a/src/troute-routing/troute/routing/diffusive_utils_v02.py
+++ b/src/troute-routing/troute/routing/diffusive_utils_v02.py
@@ -471,9 +471,14 @@ def fp_naturalxsec_map(
                         size_bathy_g[seg, frj] = nstations
                         
                         # populate cross section x, z and mannings n arrays
-                        x_bathy_g[0:nstations, seg, frj]    = topobathy_bytw.loc[seg_idx].xid_d
-                        z_bathy_g[0:nstations, seg, frj]    = topobathy_bytw.loc[seg_idx].z
-                        mann_bathy_g[0:nstations, seg, frj] = topobathy_bytw.loc[seg_idx].n
+                        if 'xid_d' not in topobathy_bytw.loc[seg_idx].columns:
+                            x_bathy_g[0:nstations, seg, frj]    = topobathy_bytw.loc[seg_idx].X
+                            z_bathy_g[0:nstations, seg, frj]    = topobathy_bytw.loc[seg_idx].Z
+                            mann_bathy_g[0:nstations, seg, frj] = topobathy_bytw.loc[seg_idx].roughness
+                        else:
+                            x_bathy_g[0:nstations, seg, frj]    = topobathy_bytw.loc[seg_idx].xid_d
+                            z_bathy_g[0:nstations, seg, frj]    = topobathy_bytw.loc[seg_idx].z
+                            mann_bathy_g[0:nstations, seg, frj] = topobathy_bytw.loc[seg_idx].n
                         
                         # if terminal node of the network, then adjust the cross section z data using
                         # channel slope and length data


### PR DESCRIPTION
This update read the parquet file. It checks if `topobathy_domain` is netdf or parquet and if its parquet clean it up. Including separating just cs_id = 1 which is the cross-section for upstream of each segment and drop the None values.

## Additions

- `read_parquet` function file that read, clean and return the parquet file
- edit in the `topobathy_df` property function to read topobathy_df with extension of `.parquet`

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
