### PR TITLE
Nex to bin speedup

### DIFF
--- a/src/troute-network/troute/AbstractNetwork.py
+++ b/src/troute-network/troute/AbstractNetwork.py
@@ -879,10 +879,10 @@ def get_timesteps_from_nex(nexus_files):
     return output_file_timestamps
 
 
-def split_csv_file(nexus_file, cat_id, binary_folder):
+def split_csv_file(nexus_file, catchment_id, binary_folder):
     # Split the csv file into multiple csv files
     # Unescaped command: awk -F ', ' '{print "114085, "$NF >> "test/outputfile_"$1".txt"}' nex-114085_output.csv
-    os.system(f'awk -F \', \' \'{{print "{cat_id}, "$NF >> "{binary_folder}/tempfile_"$1".csv"}}\' {nexus_file}')
+    os.system(f'awk -F \', \' \'{{print "{catchment_id}, "$NF >> "{binary_folder}/tempfile_"$1".csv"}}\' {nexus_file}')
 
 
 def rewrite_to_parquet(tempfile_id, output_file_id, binary_folder):
@@ -902,12 +902,12 @@ def nex_files_to_binary(nexus_files, binary_folder):
     
     # Split the csv file into multiple csv files
     for nexus_file in nexus_files:
-        cat_id = get_id_from_filename(nexus_file)
-        split_csv_file(nexus_file, cat_id, binary_folder)
+        catchment_id = get_id_from_filename(nexus_file)
+        split_csv_file(nexus_file, catchment_id, binary_folder)
     
     # Rewrite the temp csv files to parquet
-    for i, nexus_file in enumerate(output_timesteps):
-        rewrite_to_parquet(i, nexus_file, binary_folder)
+    for tempfile_id, nexus_file in enumerate(output_timesteps):
+        rewrite_to_parquet(tempfile_id, nexus_file, binary_folder)
     
     # Clean up the temp files
     os.system(f'rm -rf {binary_folder}/tempfile_*.csv')


### PR DESCRIPTION
Mostly Resolves performance issues mentioned in #713 


## Changes
### nex_files_to_binary
- Restructured operations to perform most of the file manipulation with bash commands instead of expensive python operations
#### Old pseudocode
```pseudocode
for each nexus file
    read as csv
    format and pivot data
    for each timestep
        open the parquet for that timestep
        write one entry to the parquet
        close the parquet
```
#### New pseudocode
```pseudocode
for each nexusfile
    bash command to split csv as plaintext into timestep files
for each timestepfile
    read timestepfile csv
    convert timestepfile to parquet
    save parquetfile
```
The data is still being written the same amount of times, but it's mostly plaintext appends which bypasses the expensive parquet IO  until the final pass.

## Testing

[data I used](https://ciroh-ua-ngen-data.s3.us-east-2.amazonaws.com/AWI-002/AWI_03W_113060_002.tar.gz)    
`python -m nwm_routing -V4 config/ngen.yaml`

1. follow instructions [here](https://github.com/CIROH-UA/NGIAB-CloudInfra) to download some test data and a docker file capable of running t-route 
2. go through guide.sh until it asks you to if you want to run serial or parallel, keep the terminal open at this step
3. Open a new terminal, exec into the container
4. Find the python file that needs updating with `find / -type f -name "AbstractNetwork.py"`
5. open that file and update it to the changes in this pr
6. go back to guide.sh terminal and run in parallel


## Screenshots
### Comparison of just file IO sections
![image](https://github.com/NOAA-OWP/t-route/assets/26720477/1f63a2a4-ba5e-475c-b2d5-8e7f7bf019c9)

### master test
![image](https://github.com/NOAA-OWP/t-route/assets/26720477/8f4d5fce-6a5c-4cc7-b17a-a451ea12745c)

### PR Changes test
![image](https://github.com/NOAA-OWP/t-route/assets/26720477/ab878365-89ce-4ed3-93b3-3127e1953434)


## Notes
- Tests were performed on a sata ssd with ~450MB/s IO
- Those last two tests are using the NGIAB image so the last 3 times are including ngen
- The Forcing array construction times are what this effects
- This still is executing sequentially, further improvement could be had by performing the bash commands in parallel and the parquet conversion in parallel
- Even more performance could be gained from saving the temp csv files as larger parquet files with multiple timesteps, but that's a much larger change 

