### PR TITLE
simple fix for flowpaths with unavailable 3Dxsec data

### DIFF
--- a/src/troute-network/troute/AbstractRouting.py
+++ b/src/troute-network/troute/AbstractRouting.py
@@ -77,7 +77,6 @@ def read_parquet(file_path):
     df = tbl.to_pandas().dropna()
     if 'hy_id' in df.columns and not df['hy_id'].str.isnumeric().all():
         df['hy_id'] = df['hy_id'].apply(lambda x: x.split('-')[-1])
-        #df = df[df['cs_id'] == 1]
     return df
 
 
@@ -278,7 +277,7 @@ class MCwithDiffusive(AbstractRouting):
             uslink_mainstem = dslink_mainstem   
         diffusive_domain={}
         diffusive_domain[twlink_mainstem] = mainstem_list
-        
+                
         return self._diffusive_domain
 
 
@@ -313,13 +312,12 @@ class MCwithDiffusiveNatlXSectionNonRefactored(MCwithDiffusive):
                             new_index = pd.Index([mainstem_segment]*len(temp_df))
                             temp_df.index = new_index
                             cs_id_max = temp_df['cs_id'].max()
-                            fill_in_topobathy_df = temp_df[temp_df.cs_id==cs_id_max]
+                            fill_in_topobathy_df = pd.DataFrame(temp_df[temp_df.cs_id==cs_id_max])
                             fill_in_topobathy_df.cs_id = fill_in_topobathy_df.cs_id.replace(cs_id_max,1) 
                             combined_df = pd.concat([self._topobathy_df, fill_in_topobathy_df])
                             self._topobathy_df = combined_df
                 # Among multiple xsec profiles, select one in the most upstream of stream segment
                 self._topobathy_df = self._topobathy_df[self._topobathy_df['cs_id'] == 1]
-
         return self._topobathy_df
 
 

--- a/src/troute-routing/troute/routing/diffusive_utils_v02.py
+++ b/src/troute-routing/troute/routing/diffusive_utils_v02.py
@@ -446,7 +446,7 @@ def fp_naturalxsec_map(
 
                     # loop through segments in mainstem reach
                     for seg, segID in enumerate(seg_list):
-
+                        
                         # identify the index in topobathy dataframe that contains
                         # the data we want for this node.
                         if seg == ncomp-1 and x > 0: 
@@ -469,10 +469,10 @@ def fp_naturalxsec_map(
                         
                         # populate cross section size (# of stations) array
                         size_bathy_g[seg, frj] = nstations
-                        
+  
                         # populate cross section x, z and mannings n arrays
-                        if 'xid_d' not in topobathy_bytw.loc[seg_idx].columns:
-                            x_bathy_g[0:nstations, seg, frj]    = topobathy_bytw.loc[seg_idx].X
+                        if 'cs_id' in topobathy_bytw.loc[seg_idx].columns:
+                            x_bathy_g[0:nstations, seg, frj]    = topobathy_bytw.loc[seg_idx].relative_dist
                             z_bathy_g[0:nstations, seg, frj]    = topobathy_bytw.loc[seg_idx].Z
                             mann_bathy_g[0:nstations, seg, frj] = topobathy_bytw.loc[seg_idx].roughness
                         else:


### PR DESCRIPTION
3D channel cross section data currently being developed for diffusive mainstem domains has missing topobathy data for some flowpaths in the domains.  The 3D data is based on v20.1 hydrofabric gpkg.  To temporarily fix this issue while waiting for more solid update, a simple solution was applied to fill the gap: Basically, a flowpath with no available topobathy data, it borrows the data from the closest upstream flowpath.  If the upstream has multiple topobathy data available, then it borrows the most downstream topobathy data.   Again, this is a simple and temporary solution for making diffusive module functionally run  and need to be updated along the way.
 

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
