### PR TITLE
function that build diffusive domain

### DIFF
--- a/src/troute-network/troute/AbstractNetwork.py
+++ b/src/troute-network/troute/AbstractNetwork.py
@@ -622,7 +622,7 @@ class AbstractNetwork(ABC):
                     waterbodies_initial_states_df["index"] = range(
                         len(waterbodies_initial_states_df)
                     )
-            import pdb;pdb.set_trace()
+            
             if len(self.waterbody_dataframe) > 0:
                 self._waterbody_df = pd.merge(
                     self.waterbody_dataframe, waterbodies_initial_states_df, on=index_id

--- a/src/troute-network/troute/AbstractNetwork.py
+++ b/src/troute-network/troute/AbstractNetwork.py
@@ -622,11 +622,13 @@ class AbstractNetwork(ABC):
                     waterbodies_initial_states_df["index"] = range(
                         len(waterbodies_initial_states_df)
                     )
-            
-            self._waterbody_df = pd.merge(
-                self.waterbody_dataframe, waterbodies_initial_states_df, on=index_id
-            )
-
+            import pdb;pdb.set_trace()
+            if len(self.waterbody_dataframe) > 0:
+                self._waterbody_df = pd.merge(
+                    self.waterbody_dataframe, waterbodies_initial_states_df, on=index_id
+                )
+            else:
+                self._waterbody_df = pd.DataFrame()
             LOG.debug(
                 "waterbody initial states complete in %s seconds."\
                 % (time.time() - start_time))

--- a/src/troute-network/troute/AbstractRouting.py
+++ b/src/troute-network/troute/AbstractRouting.py
@@ -179,8 +179,8 @@ class MCwithDiffusive(AbstractRouting):
         diffusive_domain_all = {}
         
         for item in links_US_DS['US_DS_link_mainstem']:
-            headlink_mainstem, twlink_mainstem = ast.literal_eval(item)
-            diffusive_domain_all[twlink_mainstem] = self.diffusive_domain_by_both_ends_streamid(connections, headlink_mainstem, twlink_mainstem)
+            headlink_mainstem, twlink_mainstem, rfc_val, rpu_val = ast.literal_eval(item)
+            diffusive_domain_all[twlink_mainstem] = self.diffusive_domain_by_both_ends_streamid(connections, headlink_mainstem, twlink_mainstem, rfc_val, rpu_val)
             
         self._diffusive_domain = diffusive_domain_all
         rconn_diff0 = reverse_network(connections)
@@ -267,7 +267,7 @@ class MCwithDiffusive(AbstractRouting):
     def unrefactored_topobathy_df(self):
         return self._unrefactored_topobathy_df
         
-    def diffusive_domain_by_both_ends_streamid(self, connections, headlink_mainstem, twlink_mainstem):
+    def diffusive_domain_by_both_ends_streamid(self, connections, headlink_mainstem, twlink_mainstem, rfc_val, rpu_val):
         # This function build diffusive_domain using given headwater segment IDs at upper and tailwater at lower ends of mainstem.
         
         uslink_mainstem = headlink_mainstem
@@ -283,7 +283,7 @@ class MCwithDiffusive(AbstractRouting):
                 LOG.debug(f"KeyError: 'connections' does not have a key '{uslink_mainstem}'")
                 return None 
 
-        diffusive_domain = {'links':sorted(mainstem_list), 'rfc': ['wgrfc'], 'rpu': ['12c'], 'upstream_boundary_link_mainstem':[headlink_mainstem]}
+        diffusive_domain = {'links':sorted(mainstem_list), 'rfc': rfc_val, 'rpu': rpu_val, 'upstream_boundary_link_mainstem':[headlink_mainstem]}
                 
         return diffusive_domain
 

--- a/test/LowerColorado_TX_v4/domain/coastal_domain_LC_US_DS.yaml
+++ b/test/LowerColorado_TX_v4/domain/coastal_domain_LC_US_DS.yaml
@@ -1,0 +1,14 @@
+US_DS_link_mainstem:
+# please use a tuple of (upstream, downstream)
+# Lower Colorado River TX
+- (2421017, 2421105)
+# Guadalupe River, TX
+- (2405287, 2405359) 
+# Brazos River, TX
+- (2408552, 2408609) 
+# Brays Bayou, TX
+- (2398553, 2398446)
+# Goose Creek, TX
+- (2404194, 2404199)
+# Cedar Bayou, TX
+- (2404205, 2404220)

--- a/test/LowerColorado_TX_v4/domain/coastal_domain_LC_US_DS.yaml
+++ b/test/LowerColorado_TX_v4/domain/coastal_domain_LC_US_DS.yaml
@@ -1,14 +1,14 @@
 US_DS_link_mainstem:
 # please use a tuple of (upstream, downstream)
 # Lower Colorado River TX
-- (2421017, 2421105)
+- (2421017, 2421105, ['wgrfc'], ['12c'])
 # Guadalupe River, TX
-- (2405287, 2405359) 
+- (2405287, 2405359, ['wgrfc'], ['12c']) 
 # Brazos River, TX
-- (2408552, 2408609) 
+- (2408552, 2408609, ['wgrfc'], ['12c']) 
 # Brays Bayou, TX
-- (2398553, 2398446)
+- (2398553, 2398446, ['wgrfc'], ['12c'])
 # Goose Creek, TX
-- (2404194, 2404199)
+- (2404194, 2404199, ['wgrfc'], ['12c'])
 # Cedar Bayou, TX
-- (2404205, 2404220)
+- (2404205, 2404220, ['wgrfc'], ['12c'])


### PR DESCRIPTION
A function added that build diffusive_domain using given headwater, tailwater segment IDs from the yaml file, so user don't need coastal_domain yaml file. It will be created automatically. 

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
