### PR TITLE
Make empty nudge array returned from diffusive the proper size

### DIFF
--- a/src/troute-routing/troute/routing/compute.py
+++ b/src/troute-routing/troute/routing/compute.py
@@ -1562,7 +1562,7 @@ def compute_diffusive_routing(
                 # place-holder for rfc DA parameters
                 (np.asarray([]), np.asarray([]), np.asarray([])),
                 # place-holder for nudge values
-                (np.asarray([])),
+                (np.empty(shape=(0, nts + 1), dtype='float32')),
             )
         )
 


### PR DESCRIPTION
The empty `nudge` array that was returned from `compute_diffusive_routing()` had no shape, so an error was thrown when attempting to concatenate nudge values in `write_flowveldepth_netcdf()` on output. This assigns the proper shape to the `nudge` array.

## Additions

-

## Removals

-

## Changes
**compute.py**
- return an empty numpy array of shape `(0, nts)`. 

## Testing

1. Successfully ran a domain with multiple diffusive domains and wrote output files.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
