### PR TITLE
Diffusive tailwater latitude/longitude information

### DIFF
--- a/src/bmi_troute.py
+++ b/src/bmi_troute.py
@@ -218,6 +218,11 @@ class bmi_troute(Bmi):
         self._values['lastobs_df'] = np.zeros(0)
         self._values['lastobs_df_index'] = np.zeros(0)
 
+        # Diffusive domain tailwater locations
+        self._values['diffusive_tw_ids'] = np.zeros(0)
+        self._values['diffusive_tw_latitude'] = np.zeros(0)
+        self._values['diffusive_tw_longitude'] = np.zeros(0)
+        
         # Data assimilation values
         self._values['usgs_df'] = np.zeros(0)
         self._values['reservoir_usgs_df'] = np.zeros(0)

--- a/src/troute-network/troute/AbstractNetwork.py
+++ b/src/troute-network/troute/AbstractNetwork.py
@@ -485,6 +485,8 @@ class AbstractNetwork(ABC):
         ) = routing.update_routing_domain(self.dataframe, self.connections)
 
         self._routing = routing
+        
+        self.filter_diffusive_nexus_pts()
     
     def create_independent_networks(self,):
 
@@ -867,6 +869,22 @@ class AbstractNetwork(ABC):
                 j += 1
 
         return run_sets
+    
+    def filter_diffusive_nexus_pts(self,):
+        # Filter nexus dataframe containing lat/lon of nexus points for just the diffusive
+        # domain tailwaters.
+        nexus_latlon = self._nexus_latlon
+        diff_tw_ids = list(self._routing.diffusive_network_data.keys())
+        diff_tw_ids = ['nex-' + str(s) for s in diff_tw_ids]
+        nexus_latlon = nexus_latlon[nexus_latlon['id'].isin(diff_tw_ids)]
+        nexus_latlon['id'] = nexus_latlon['id'].str.split('-',expand=True).loc[:,1].astype(float).astype(int)
+        lat_lon_crs = nexus_latlon[['id','geometry']]
+        lat_lon_crs = lat_lon_crs.to_crs(crs=4326)
+        lat_lon_crs['lon'] = lat_lon_crs.geometry.x
+        lat_lon_crs['lat'] = lat_lon_crs.geometry.y
+        lat_lon_crs['crs'] = str(lat_lon_crs.crs)
+        lat_lon_crs = lat_lon_crs[['lon','lat','crs']]
+        self._nexus_latlon = nexus_latlon[['id']].join(lat_lon_crs)
 
 def get_timesteps_from_nex(nexus_files):
     # Return a list of output files

--- a/src/troute-network/troute/AbstractNetwork.py
+++ b/src/troute-network/troute/AbstractNetwork.py
@@ -485,8 +485,8 @@ class AbstractNetwork(ABC):
         ) = routing.update_routing_domain(self.dataframe, self.connections)
 
         self._routing = routing
-        
-        if self.supernetwork_parameters.get('network_type', None)=='HYFeaturesNetwork':
+        hyf = self.supernetwork_parameters.get('network_type', None)=='HYFeaturesNetwork'
+        if hyf and routing.diffusive_network_data:
             self.filter_diffusive_nexus_pts()
     
     def create_independent_networks(self,):

--- a/src/troute-network/troute/AbstractNetwork.py
+++ b/src/troute-network/troute/AbstractNetwork.py
@@ -486,7 +486,8 @@ class AbstractNetwork(ABC):
 
         self._routing = routing
         
-        self.filter_diffusive_nexus_pts()
+        if self.supernetwork_parameters.get('network_type', None)=='HYFeaturesNetwork':
+            self.filter_diffusive_nexus_pts()
     
     def create_independent_networks(self,):
 

--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -416,16 +416,11 @@ class HYFeaturesNetwork(AbstractNetwork):
             self.dataframe, "downstream", terminal_codes=self.terminal_codes
         )
         
-        # Create a dataframe containing lat/lon of nexus points. This will later be used to
-        # advertise tailwater locations of any diffusive domains to the model engine/coastal models
-        nexus['id'] = nexus['id'].str.split('-',expand=True).loc[:,1].astype(float).astype(int)
-        lat_lon_crs = nexus[['id','geometry']]
-        lat_lon_crs = lat_lon_crs.to_crs(crs=4326)
-        lat_lon_crs['lon'] = lat_lon_crs.geometry.x
-        lat_lon_crs['lat'] = lat_lon_crs.geometry.y
-        lat_lon_crs['crs'] = str(lat_lon_crs.crs)
-        lat_lon_crs = lat_lon_crs[['lon','lat','crs']]
-        self._nexus_latlon = nexus[['id']].join(lat_lon_crs)
+        # Store a dataframe containing info about nexus points. This will be reprojected to lat/lon
+        # and filtered for only diffusive domain tailwaters in AbstractNetwork.py.
+        # Location information will be used to advertise tailwater locations of diffusive domains 
+        # to the model engine/coastal models
+        self._nexus_latlon = nexus
 
     def preprocess_waterbodies(self, lakes):
         # If waterbodies are being simulated, create waterbody dataframes and dictionaries

--- a/src/troute_model.py
+++ b/src/troute_model.py
@@ -100,6 +100,10 @@ class troute_model():
             from_files=False, value_dict=values,
             bmi_parameters=self._bmi_parameters,)
 
+        values['diffusive_tw_ids'] = self._nexus_latlon.id.values
+        values['diffusive_tw_latitude'] = self._nexus_latlon.lat.values
+        values['diffusive_tw_longitude'] = self._nexus_latlon.lon.values
+        
         # Create data assimilation object with IDs but no dynamic variables yet.
         # Dynamic variables will be assigned during 'run' function. 
         self._data_assimilation = tr.DataAssimilation(

--- a/src/troute_model.py
+++ b/src/troute_model.py
@@ -100,9 +100,9 @@ class troute_model():
             from_files=False, value_dict=values,
             bmi_parameters=self._bmi_parameters,)
 
-        values['diffusive_tw_ids'] = self._nexus_latlon.id.values
-        values['diffusive_tw_latitude'] = self._nexus_latlon.lat.values
-        values['diffusive_tw_longitude'] = self._nexus_latlon.lon.values
+        values['diffusive_tw_ids'] = self._network._nexus_latlon.id.values
+        values['diffusive_tw_latitude'] = self._network._nexus_latlon.lat.values
+        values['diffusive_tw_longitude'] = self._network._nexus_latlon.lon.values
         
         # Create data assimilation object with IDs but no dynamic variables yet.
         # Dynamic variables will be assigned during 'run' function. 


### PR DESCRIPTION
t-route will now read the 'nexus' attribute table from the HYFeatures geopackage if diffusive routing is enabled. From this table, the latitude and longitude of all diffusive domain tailwater nexus points are determined and stored in the `values` BMI dictionary. These will be used to advertise geospatial locations to the model engine which can then determine the closest coastal model nodes to be used for diffusive boundary conditions.

## Additions
**HYFeaturesNetwork.py**
- Read "nexus" attribute table if diffusive routing is enabled
- Store this table as a data frame for later processing

**AbstractNetwork.py**
- Filter "nexus" data frame to only diffusive domain tailwater nexus points
- Reproject `geometry` column to be lat/lon friendly.

**bmi_troute.py**
- Create empty arrays for diffusive tailwater nexus point geo-locations

**troute_model.py**
- Store diffusive tailwater lat/lon/id info as 1d arrays in `values` dictionary

## Removals

-

## Changes

-

## Testing

1. I've verified that this information is processed and stored correctly, but have not tested passing it through BMI functions

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
