### PR TITLE
simple fix for empty lastobs_df when streamnudging unknowingly turned on while no usgs data is available

### DIFF
--- a/src/troute-network/troute/AbstractRouting.py
+++ b/src/troute-network/troute/AbstractRouting.py
@@ -237,10 +237,8 @@ class MCwithDiffusive(AbstractRouting):
             # drop indices from param_df. Make sure when mainstem_segs accidently includes lake ids, exclude them 
             # from id list to be dropped from dataframe as dataframe only handles channel parameters. 
             existing_indicies_in_dataframe = [id for id in mainstem_segs if id in dataframe.index]
-            #dataframe = dataframe.drop(mainstem_segs)
             dataframe = dataframe.drop(existing_indicies_in_dataframe)
             
-
             # remove keys from connections dictionary
             for s in mainstem_segs:
                 connections.pop(s)

--- a/src/troute-network/troute/DataAssimilation.py
+++ b/src/troute-network/troute/DataAssimilation.py
@@ -238,10 +238,12 @@ class NudgingDA(AbstractDA):
             - lastobs_df               (DataFrame): Last gage observations data for DA
         '''
         streamflow_da_parameters = self._data_assimilation_parameters.get('streamflow_da', None)
- 
+
         if streamflow_da_parameters:
             if streamflow_da_parameters.get('streamflow_nudging', False):
-                self._last_obs_df = new_lastobs(run_results, time_increment)
+                if not run_results[0][3][0].size == 0:
+                    # call new_lastobs only when last obs. time and discharge are updated in mc_reach.pyx 
+                    self._last_obs_df = new_lastobs(run_results, time_increment)
 
     def update_for_next_loop(self, network, da_run,):
         '''
@@ -1282,6 +1284,7 @@ def new_lastobs(run_results, time_increment):
     --------
     - lastobs_df (DataFrame): Last gage observations data for DA
     """
+
     df = pd.concat(
         [
             pd.DataFrame(

--- a/src/troute-network/troute/DataAssimilation.py
+++ b/src/troute-network/troute/DataAssimilation.py
@@ -241,9 +241,7 @@ class NudgingDA(AbstractDA):
 
         if streamflow_da_parameters:
             if streamflow_da_parameters.get('streamflow_nudging', False):
-                if not run_results[0][3][0].size == 0:
-                    # call new_lastobs only when last obs. time and discharge are updated in mc_reach.pyx 
-                    self._last_obs_df = new_lastobs(run_results, time_increment)
+                self._last_obs_df = new_lastobs(run_results, time_increment)
 
     def update_for_next_loop(self, network, da_run,):
         '''
@@ -1294,7 +1292,6 @@ def new_lastobs(run_results, time_increment):
                 columns=["time_since_lastobs", "lastobs_discharge"]
             )
             for rr in run_results
-            if not rr[3][0].size == 0
         ],
         copy=False,
     )

--- a/src/troute-nwm/src/nwm_routing/output.py
+++ b/src/troute-nwm/src/nwm_routing/output.py
@@ -375,7 +375,7 @@ def nwm_output_generator(
 
             nudging_true = streamflow_da.get('streamflow_nudging', None)
 
-        if nudging_true and lastobs_output_folder:
+        if nudging_true and lastobs_output_folder and not lastobs_df.empty:
 
             LOG.info("- writing lastobs files")
             start = time.time()


### PR DESCRIPTION
This fix provides a solution when lastobs_df is empty because no usgs data is available while stream nudging is unknowingly activated in the config file. More solid solution will be provided soon.  Also, in diffusive_routing mainstem_list now has a list  of stream segments aligned in order from upstream to downstream.  Moreover, missing topobathy data for a stream segment get filled in by looking up the newly aligned list.

## Additionns
**AbstractRouting.py**
- removed sort() to mainstem_list to align a list of stream segments in order from upstream to downstream
- modified the way to search for an upstream segment id for a given mainstem segment that has no channel xsec topobathy data

**DataAssimilation.py**
- Added a condition not to call new_lastobs function when there is no lastobs related values updated from mc_reach.pyx

**output.py**
- Added a condition not to call lastobs_df_output when there is no lastobs related values updated from mc_reach.pyx

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
