### PR TITLE
Handling Warnings

### DIFF
--- a/src/troute-routing/troute/routing/diffusive_utils_v02.py
+++ b/src/troute-routing/troute/routing/diffusive_utils_v02.py
@@ -38,7 +38,7 @@ def adj_alt1(
 
                     # head segment id of downstream reach after a junction
                     dsrchID = reach["downstream_head_segment"]                    
-                    z_all[segID]["adj.alt"][0] = param_df.loc[dsrchID, 'alt']
+                    z_all[segID]["adj.alt"][0] = float(param_df.loc[dsrchID, 'alt'].iloc[0])
 
                 elif seg == ncomp - 1 and seg_list.count(dbfksegID) > 0:
                     # channel slope-adjusted bottom elevation at the bottom node of TW reach
@@ -542,7 +542,9 @@ def fp_da_map(
         missing_data = pd.DataFrame(-4444.0*np.ones((len(usgs_df), len(missing_timestamps))), 
                                     columns=missing_timestamps, 
                                     index=usgs_df.index)
-        usgs_df_complete = pd.concat([usgs_df_complete, missing_data], axis=1)
+        if not missing_data.empty:
+            usgs_df_complete = pd.concat([usgs_df_complete, missing_data], axis=1)
+
         usgs_df_complete = usgs_df_complete[timestamps]
 
         frj = -1


### PR DESCRIPTION
Running NHD was giving 2 Warning. first warning was `FutureWarning: Calling float on a single element Series is deprecated and will raise a TypeError in the future. Use float(ser.iloc[0]) instead` which line 41 handle that.

The other warning was for concatenating empty dataframe `FutureWarning: The behavior of array concatenation with empty entries is deprecated. In a future version, this will no longer exclude empty items when determining the result dtype. To retain the old behavior, exclude the empty entries before the concat operation.`
which line 545 checks if its empty won't concatenate it.
With these two minor changes there is no warning
## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
