### PR TITLE
Correction to reading schism data from file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 *.o
 *.so
 _site/
+*.mod
+*.a
+*.c
 
 # Packages #
 ############

--- a/src/troute-network/troute/AbstractNetwork.py
+++ b/src/troute-network/troute/AbstractNetwork.py
@@ -997,7 +997,6 @@ def read_SCHISM_output(ds):
     df = pd.merge(elevation_df, depth_df, on='link')
     df['waterdepth'] = df['elevation'] + df['depth']
     df = df.drop(['elevation','depth'], axis=1)
-    df
 
     #Replace 'time' columns of seconds with datetimes
     df['base_date'] = base_date


### PR DESCRIPTION
Fixes how t-route retrieves water depth from SCHISM output files. It now reads both `elevation` and `depth` variables and sums them to get water depth. 

## Additions

-

## Removals

-

## Changes
**AbstractNetwork.py**
- `read_SCHISM_output()` now adds `elevation` and `depth` variables from netcdf file to obtain water depth.

**.gitignore**
- added `*.mod`, `*.a`, & `*.c` to reduce output when `git status` is called. This is unrelated to coastal boundary information.

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
