### PR TITLE
add water depth output variable to diffusive fortran kernel

### DIFF
--- a/src/kernel/diffusive/pydiffusive.f90
+++ b/src/kernel/diffusive/pydiffusive.f90
@@ -11,7 +11,7 @@ subroutine c_diffnw(timestep_ar_g, nts_ql_g, nts_ub_g, nts_db_g, ntss_ev_g, nts_
                     iniq, frnw_col, frnw_ar_g, qlat_g, ubcd_g, dbcd_g, qtrib_g,                         &
                     paradim, para_ar_g, mxnbathy_g, x_bathy_g, z_bathy_g, mann_bathy_g, size_bathy_g,   &                                      
                     usgs_da_g, usgs_da_reach_g, rdx_ar_g, cwnrow_g, cwncol_g, crosswalk_g, z_thalweg_g, &
-                    q_ev_g, elv_ev_g) bind(c)      
+                    q_ev_g, elv_ev_g, depth_ev_g) bind(c)      
 
     integer(c_int), intent(in) :: nts_ql_g, nts_ub_g, nts_db_g, nts_qtrib_g, nts_da_g
     integer(c_int), intent(in) :: ntss_ev_g
@@ -42,7 +42,7 @@ subroutine c_diffnw(timestep_ar_g, nts_ql_g, nts_ub_g, nts_db_g, ntss_ev_g, nts_
     real(c_double), dimension(mxnbathy_g, mxncomp_g, nrch_g), intent(in ) :: z_bathy_g
     real(c_double), dimension(mxnbathy_g, mxncomp_g, nrch_g), intent(in ) :: mann_bathy_g
     real(c_double), dimension(cwnrow_g, cwncol_g),            intent(in ) :: crosswalk_g 
-    real(c_double), dimension(ntss_ev_g, mxncomp_g, nrch_g),  intent(out) :: q_ev_g, elv_ev_g    
+    real(c_double), dimension(ntss_ev_g, mxncomp_g, nrch_g),  intent(out) :: q_ev_g, elv_ev_g, depth_ev_g    
           
     call diffnw(timestep_ar_g, nts_ql_g, nts_ub_g, nts_db_g, ntss_ev_g, nts_qtrib_g, nts_da_g,      &
                 mxncomp_g, nrch_g, z_ar_g, bo_ar_g, traps_ar_g, tw_ar_g, twcc_ar_g, mann_ar_g,      &
@@ -50,7 +50,7 @@ subroutine c_diffnw(timestep_ar_g, nts_ql_g, nts_ub_g, nts_db_g, ntss_ev_g, nts_
                 iniq, frnw_col, frnw_ar_g, qlat_g, ubcd_g, dbcd_g, qtrib_g,                         &
                 paradim, para_ar_g, mxnbathy_g, x_bathy_g, z_bathy_g, mann_bathy_g, size_bathy_g,   &
                 usgs_da_g, usgs_da_reach_g, rdx_ar_g, cwnrow_g, cwncol_g, crosswalk_g, z_thalweg_g, &
-                q_ev_g, elv_ev_g)                                
+                q_ev_g, elv_ev_g, depth_ev_g)                                
     
 end subroutine c_diffnw
 end module diffusive_interface

--- a/src/troute-routing/troute/routing/compute.py
+++ b/src/troute-routing/troute/routing/compute.py
@@ -1536,14 +1536,14 @@ def compute_diffusive_routing(
         )
 
         # run the simulation
-        out_q, out_elv = diffusive.compute_diffusive(diffusive_inputs)
+        out_q, out_elv, out_depth = diffusive.compute_diffusive(diffusive_inputs)
 
         # unpack results
         rch_list, dat_all = diff_utils.unpack_output(
             diffusive_inputs['pynw'], 
             diffusive_inputs['ordered_reaches'], 
             out_q, 
-            out_elv
+            out_depth, #out_elv
         )
         
         # mask segments for which we already have MC solution

--- a/src/troute-routing/troute/routing/fast_reach/diffusive.pyx
+++ b/src/troute-routing/troute/routing/fast_reach/diffusive.pyx
@@ -47,11 +47,13 @@ cdef void diffnw(
         double[::1,:] z_thalweg_g,
         double[:,:,:] out_q,
         double[:,:,:] out_elv,
+        double[:,:,:] out_depth,
 ):
 
     cdef:
-        double[::1,:,:] q_ev_g = np.empty([ntss_ev_g,mxncomp_g,nrch_g], dtype = np.double, order = 'F')
-        double[::1,:,:] elv_ev_g = np.empty([ntss_ev_g,mxncomp_g,nrch_g], dtype = np.double, order = 'F')
+        double[::1,:,:] q_ev_g     = np.empty([ntss_ev_g,mxncomp_g,nrch_g], dtype = np.double, order = 'F')
+        double[::1,:,:] elv_ev_g   = np.empty([ntss_ev_g,mxncomp_g,nrch_g], dtype = np.double, order = 'F')
+        double[::1,:,:] depth_ev_g = np.empty([ntss_ev_g,mxncomp_g,nrch_g], dtype = np.double, order = 'F')
     
     c_diffnw(
         &timestep_ar_g[0],
@@ -94,12 +96,15 @@ cdef void diffnw(
         &crosswalk_g[0,0],  
         &z_thalweg_g[0,0],
         &q_ev_g[0,0,0],
-        &elv_ev_g[0,0,0]
+        &elv_ev_g[0,0,0],
+        &depth_ev_g[0,0,0]
     )
     
     # copy data from Fortran to Python memory view
-    out_q[:,:,:] = q_ev_g[::1,:,:]
-    out_elv[:,:,:] = elv_ev_g[::1,:,:]
+    out_q[:,:,:]     = q_ev_g[::1,:,:]
+    out_elv[:,:,:]   = elv_ev_g[::1,:,:]
+    out_depth[:,:,:] = depth_ev_g[::1,:,:]
+
 
 cpdef object compute_diffusive(
     dict diff_inputs
@@ -148,6 +153,7 @@ cpdef object compute_diffusive(
         double[::1,:] z_thalweg_g = np.asfortranarray(diff_inputs["z_thalweg_g"])
         double[:,:,:] out_q = np.empty([ntss_ev_g,mxncomp_g,nrch_g], dtype = np.double)
         double[:,:,:] out_elv = np.empty([ntss_ev_g,mxncomp_g,nrch_g], dtype = np.double)
+        double[:,:,:] out_depth = np.empty([ntss_ev_g,mxncomp_g,nrch_g], dtype = np.double)
 
     # call diffusive compute kernel
     diffnw(
@@ -191,6 +197,7 @@ cpdef object compute_diffusive(
         crosswalk_g,
         z_thalweg_g,
         out_q,
-        out_elv
+        out_elv,
+        out_depth
     )
-    return np.asarray(out_q), np.asarray(out_elv)
+    return np.asarray(out_q), np.asarray(out_elv), np.asarray(out_depth)

--- a/src/troute-routing/troute/routing/fast_reach/fortran_wrappers.pxd
+++ b/src/troute-routing/troute/routing/fast_reach/fortran_wrappers.pxd
@@ -80,7 +80,8 @@ cdef extern from "pydiffusive.h":
                      double *crosswalk_g, 
                      double *z_thalweg_g,
                      double *q_ev_g,
-                     double *elv_ev_g) nogil;
+                     double *elv_ev_g,
+                     double *depth_ev_g) nogil;
     
 cdef extern from "pydiffusive_cnt.h":
     void c_diffnw_cnt(double *dtini_g,

--- a/src/troute-routing/troute/routing/fast_reach/pydiffusive.h
+++ b/src/troute-routing/troute/routing/fast_reach/pydiffusive.h
@@ -38,4 +38,5 @@ extern void c_diffnw(double *timestep_ar_g,
                      double *crosswalk_g,  
                      double *z_thalweg_g,
                      double *q_ev_g,
-                     double *elv_ev_g);
+                     double *elv_ev_g,
+                     double *depth_ev_g);


### PR DESCRIPTION
diffusive fortran kernel (diffusive.f90) has been outputting discharge and water elevation (from a given datum) so far. This commit adds an additional output variable for computed water depth to be consistent with returned variables of Muskingum-Cunge module.  

## Additions
- diffusive.f90: New returned variable depth_ev_g takes computed water depth values for each computation node (For example, one stream segment has one compute node at the upstream end and the other at the downstream end.   Consecutive stream segments share a common compute node that is either the lower end node of an upstream stream segment or the upper end node of the downstream stream segment.
- pydiffusive.f90:  added depth_ev_g accordingly.  
- diffusive.pyx:  added depth_ev_g and out_depth accordingly
- fortran_wrapper.pxd:  added depth_ev_g accordingly
- pydiffusive.h: added depth_ev_g accordingly
- compute.py: used out_depth instead of out_elv

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
