### PR TITLE
update on NHD to read reservoir_persistence_usgs

### DIFF
--- a/src/troute-network/troute/NHDNetwork.py
+++ b/src/troute-network/troute/NHDNetwork.py
@@ -269,16 +269,16 @@ class NHDNetwork(AbstractNetwork):
             )
             
             if reservoir_da:
-                usgs_hybrid  = reservoir_da.get(
+                usgs_hybrid  = reservoir_da['reservoir_persistence_da'].get(
                     'reservoir_persistence_usgs', 
                     False
                 )
-                usace_hybrid = reservoir_da.get(
+                usace_hybrid = reservoir_da['reservoir_persistence_da'].get(
                     'reservoir_persistence_usace', 
                     False
                 )
                 param_file   = reservoir_da.get(
-                    'gage_lakeID_crosswalk_file',
+                    'reservoir_parameter_file',
                     None
                 )
             else:
@@ -287,18 +287,20 @@ class NHDNetwork(AbstractNetwork):
                 usgs_hybrid = False
                 
             # check if RFC-type reservoirs are set to true
-            rfc_params = self.waterbody_parameters.get('rfc')
+               
+            rfc_params = reservoir_da['reservoir_rfc_da'] 
             if rfc_params:
                 rfc_forecast = rfc_params.get(
                     'reservoir_rfc_forecasts',
                     False
                 )
-                param_file = rfc_params.get('reservoir_parameter_file',None)
+                param_file = reservoir_da.get('reservoir_parameter_file',None)
             else:
                 rfc_forecast = False
-
+            
             if (param_file and reservoir_da) or (param_file and rfc_forecast):
                 self._waterbody_type_specified = True
+                
                 (
                     self._waterbody_types_df, 
                     self._usgs_lake_gage_crosswalk, 
@@ -315,6 +317,9 @@ class NHDNetwork(AbstractNetwork):
                     reservoir_da.get('crosswalk_usace_lakeID_field', 'usace_lake_id'),
                     self.waterbody_connections.values(),
                 )
+                self._usgs_lake_gage_crosswalk['usgs_gage_id'] = self._usgs_lake_gage_crosswalk['usgs_gage_id'].apply(lambda x: x.decode('utf-8'))
+                self._usgs_lake_gage_crosswalk.index = self._usgs_lake_gage_crosswalk.index.astype(str).str.strip()
+
             else:
                 self._waterbody_type_specified = True
                 self._waterbody_types_df = pd.DataFrame(data = 1, index = self.waterbody_dataframe.index, columns = ['reservoir_type'])


### PR DESCRIPTION
Changes in NHDNetwork to be compatible with NHD yaml file V4. Also if `link_lake_df` is empty it was giving error on `reservoir_usgs_df`, now it checks if its empty create an empty dataframe for `reservoir_usgs_df`
 
## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
