### PR TITLE
fix: support python 3.8

### DIFF
--- a/src/troute-config/troute/config/output_parameters.py
+++ b/src/troute-config/troute/config/output_parameters.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel, Field, conint, validator, confloat
 
-from typing import Optional, List, Annotated
-from typing_extensions import Literal
+from typing import Optional, List
+from typing_extensions import Annotated, Literal
 from .types import FilePath, DirectoryPath
 
 streamOutput_allowedTypes = Literal['.csv', '.nc', '.pkl']


### PR DESCRIPTION
`typing.Annotated` was introduced in python 3.9. Use `typing_extensions.Annotated` to support older versions of python.
