### PR TITLE
Fix NHD issues related to gage byte strings

### DIFF
--- a/src/troute-network/troute/DataAssimilation.py
+++ b/src/troute-network/troute/DataAssimilation.py
@@ -474,6 +474,12 @@ class PersistenceDA(AbstractDA):
                         ]
                     )
                     
+                    # replace link ids with lake ids, for gages at waterbody outlets, 
+                    # otherwise, gage data will not be assimilated at waterbody outlet
+                    # segments.
+                    if network.link_lake_crosswalk:
+                        usgs_df = _reindex_link_to_lake_id(usgs_df, network.link_lake_crosswalk)
+            
                     # create reservoir hybrid DA initial parameters dataframe    
                     if not reservoir_usgs_df.empty:
                         reservoir_usgs_param_df = pd.DataFrame(
@@ -624,6 +630,12 @@ class PersistenceDA(AbstractDA):
                     set_index('usgs_lake_id').
                     drop(['index'], axis = 1)
                 )
+                
+                # replace link ids with lake ids, for gages at waterbody outlets, 
+                # otherwise, gage data will not be assimilated at waterbody outlet
+                # segments.
+                if network.link_lake_crosswalk:
+                    usgs_df = _reindex_link_to_lake_id(usgs_df, network.link_lake_crosswalk)
         
         elif reservoir_da_parameters.get('reservoir_persistence_usgs', False):
             (
@@ -984,12 +996,6 @@ def _create_usgs_df(data_assimilation_parameters, streamflow_da_parameters, run_
             ).
             loc[network.link_gage_df.index]
         )
-		
-		# replace link ids with lake ids, for gages at waterbody outlets, 
-		# otherwise, gage data will not be assimilated at waterbody outlet
-		# segments.
-        if network.link_lake_crosswalk:
-            usgs_df = _reindex_link_to_lake_id(usgs_df, network.link_lake_crosswalk)
     
     else:
         usgs_df = pd.DataFrame()

--- a/src/troute-network/troute/NHDNetwork.py
+++ b/src/troute-network/troute/NHDNetwork.py
@@ -269,16 +269,16 @@ class NHDNetwork(AbstractNetwork):
             )
             
             if reservoir_da:
-                usgs_hybrid  = reservoir_da.get(
+                usgs_hybrid  = reservoir_da['reservoir_persistence_da'].get(
                     'reservoir_persistence_usgs', 
                     False
                 )
-                usace_hybrid = reservoir_da.get(
+                usace_hybrid = reservoir_da['reservoir_persistence_da'].get(
                     'reservoir_persistence_usace', 
                     False
                 )
                 param_file   = reservoir_da.get(
-                    'gage_lakeID_crosswalk_file',
+                    'reservoir_parameter_file',
                     None
                 )
             else:
@@ -287,13 +287,13 @@ class NHDNetwork(AbstractNetwork):
                 usgs_hybrid = False
                 
             # check if RFC-type reservoirs are set to true
-            rfc_params = self.waterbody_parameters.get('rfc')
+            rfc_params = reservoir_da['reservoir_rfc_da']
             if rfc_params:
                 rfc_forecast = rfc_params.get(
                     'reservoir_rfc_forecasts',
                     False
                 )
-                param_file = rfc_params.get('reservoir_parameter_file',None)
+                param_file = reservoir_da.get('reservoir_parameter_file', None)
             else:
                 rfc_forecast = False
 

--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -344,6 +344,7 @@ def read_reservoir_parameter_file(
                 columns = [usgs_gage_id_field]
             )
             usgs_crosswalk.index.name = usgs_lake_id_field
+            usgs_crosswalk[usgs_gage_id_field] = usgs_crosswalk[usgs_gage_id_field].apply(lambda x: x.decode('utf-8')).str.strip()
         else:
             usgs_crosswalk = None
         
@@ -354,6 +355,7 @@ def read_reservoir_parameter_file(
                 columns = [usace_gage_id_field]
             )
             usace_crosswalk.index.name = usace_lake_id_field
+            usace_crosswalk[usace_gage_id_field] = usace_crosswalk[usace_gage_id_field].apply(lambda x: x.decode('utf-8')).str.strip()
         else:
             usace_crosswalk = None
         

--- a/src/troute-network/troute/nhd_network.py
+++ b/src/troute-network/troute/nhd_network.py
@@ -95,7 +95,7 @@ def gage_mapping(segment_gage_df, gage_col="gages"):
     gage_list = list(map(bytes.strip, segment_gage_df[gage_col].values))
     gage_mask = list(map(bytes.isalnum, gage_list))
     segment_gage_df = segment_gage_df.loc[gage_mask, [gage_col]]
-    segment_gage_df[gage_col] = segment_gage_df[gage_col].apply(lambda x: x.decode('utf-8'))
+    segment_gage_df[gage_col] = segment_gage_df[gage_col].apply(lambda x: x.decode('utf-8')).str.strip()
     gage_map = segment_gage_df.to_dict()
     return gage_map
 

--- a/src/troute-nwm/src/nwm_routing/preprocess.py
+++ b/src/troute-nwm/src/nwm_routing/preprocess.py
@@ -996,12 +996,6 @@ def nwm_forcing_preprocess(
                 ).
                 loc[link_gage_df.index]
             )
-            
-            # replace link ids with lake ids, for gages at waterbody outlets, 
-            # otherwise, gage data will not be assimilated at waterbody outlet
-            # segments.
-            if link_lake_crosswalk:
-                usgs_df = _reindex_link_to_lake_id(usgs_df, link_lake_crosswalk)
 
         else:
             usgs_df = pd.DataFrame()
@@ -1159,7 +1153,13 @@ def nwm_forcing_preprocess(
         
     else:
         reservoir_usgs_df = pd.DataFrame()
-        
+    
+     # replace link ids with lake ids, for gages at waterbody outlets, 
+    # otherwise, gage data will not be assimilated at waterbody outlet
+    # segments.
+    if link_lake_crosswalk:
+        usgs_df = _reindex_link_to_lake_id(usgs_df, link_lake_crosswalk)
+                    
     # create USGS reservoir hybrid DA initial parameters dataframe    
     if reservoir_usgs_df.empty == False:
         reservoir_usgs_param_df = pd.DataFrame(


### PR DESCRIPTION
There was inconsistent handling of converting USGS gage IDs from byte strings to character strings. This resulted in link-gage-crosswalk and lake-gage-crosswalk having different character representations of the same gage IDs. The position where `_reindex_link_to_lake_id()` function was also caused issues as it replaced link IDs with lake IDs in `usgs_df` before creating `reservoir_usgs_df`. This resulted in missing lake IDs/gage IDs in `reservoir_usgs_df`.

## Additions

-

## Removals

-

## Changes
**DataAssimilation.py**
- Moved location of `_reindex_link_to_lake_id()`

**NHDNetwork.py**
- Updated accessing `reservoir_da` parameters to conform to config-module. This incorporates changes from PR #737

**nhd_io.py**
- Convert gage ID byte strings to character strings in a consistent way.

**nhd_network.py**
- Convert gage ID byte strings to character strings in a consistent way.

**preprocess.py**
- Moved location of `_reindex_link_to_lake_id()`

## Testing

1. Ran nwm_routing v3 and v4 on NHD network with extended_AnA configuration (1-day run).

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
