### PR TITLE
Speed up output

### DIFF
--- a/src/troute-nwm/src/nwm_routing/output.py
+++ b/src/troute-nwm/src/nwm_routing/output.py
@@ -202,15 +202,18 @@ def nwm_output_generator(
 
         nudge = np.concatenate([r[8] for r in results])
         usgs_positions_id = np.concatenate([r[3][0] for r in results])
-        nhd_io.write_flowveldepth_netcdf(Path(stream_output_directory), 
-                                         flowveldepth, 
-                                         nudge, 
-                                         usgs_positions_id, 
-                                         t0, 
-                                         int(stream_output_timediff), 
-                                         stream_output_type,
-                                         stream_output_internal_frequency,
-                                         cpu_pool = cpu_pool)
+        nhd_io.write_flowveldepth(
+            Path(stream_output_directory), 
+            flowveldepth, 
+            nudge, 
+            usgs_positions_id, 
+            t0, 
+            dt,
+            int(stream_output_timediff), 
+            stream_output_type,
+            stream_output_internal_frequency,
+            cpu_pool = cpu_pool
+            )
 
     if test:
         flowveldepth.to_pickle(Path(test))


### PR DESCRIPTION
Some changes to speed up writing output files, specifically flowveldepth netcdf for runs with many timesteps.

Enable t-route to use nex-* file as a forcing file, and only convert/write parquet files if `binary_nexus_file_folder` is provided.

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
