### PR TITLE
fix setting 'num_files' to 1 if it is 0

### DIFF
--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -2135,7 +2135,8 @@ def write_flowveldepth(
     
     num_files = flowveldepth.shape[1]//3*dt//(stream_output_timediff*60*60)
     if num_files==0:
-        num_files==1
+        num_files=1
+
     file_name_time = t0
     jobs = []
     for _ in range(num_files):


### PR DESCRIPTION
Fix setting `num_files` to 1 if it is 0. It can be zero if the timesteps within `flowveldepth` are less than the `stream_output_time` parameters. A value of 0 would write no output, but 1 will at least write a single output file.

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
