### PR TITLE
Fix config issues relating to 'columns' default values and retrieving rfc da parameters

### DIFF
--- a/src/troute-config/troute/config/network_topology_parameters.py
+++ b/src/troute-config/troute/config/network_topology_parameters.py
@@ -1,6 +1,6 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
 
-from typing import Optional, List, Union
+from typing import Optional, List, Union, Dict, Any
 from typing_extensions import Literal
 
 from .types import FilePath, DirectoryPath
@@ -104,6 +104,49 @@ class SupernetworkParameters(BaseModel, extra='forbid'):
     # TODO: It would be nice if this were a literal / str
     driver_string: Union[str, Literal["NetCDF"]] = "NetCDF"
     layer_string: int = 0
+    
+    @validator("columns", always=True)
+    def get_columns(cls, columns: dict, values: Dict[str, Any]) -> dict:
+        if columns is None:
+            if values['network_type']=="HYFeaturesNetwork":
+                default_columns = {
+                    'key'       : 'id',
+                    'downstream': 'toid',
+                    'dx'        : 'length_m',
+                    'n'         : 'n',
+                    'ncc'       : 'nCC',
+                    's0'        : 'So',
+                    'bw'        : 'BtmWdth',
+                    'waterbody' : 'rl_NHDWaterbodyComID',
+                    'gages'     : 'rl_gages',
+                    'tw'        : 'TopWdth',
+                    'twcc'      : 'TopWdthCC',
+                    'musk'      : 'MusK',
+                    'musx'      : 'MusX',
+                    'cs'        : 'ChSlp',
+                    'alt'       : 'alt',
+                    }
+            else:
+                default_columns = {
+                    'key'       : 'link',
+                    'downstream': 'to',
+                    'dx'        : 'Length',
+                    'n'         : 'n',
+                    'ncc'       : 'nCC',
+                    's0'        : 'So',
+                    'bw'        : 'BtmWdth',
+                    'waterbody' : 'NHDWaterbodyComID',
+                    'gages'     : 'gages',
+                    'tw'        : 'TopWdth',
+                    'twcc'      : 'TopWdthCC',
+                    'alt'       : 'alt',
+                    'musk'      : 'MusK',
+                    'musx'      : 'MusX',
+                    'cs'        : 'ChSlp',
+                    }
+        else:
+            default_columns = columns
+        return default_columns
 
 
 class Columns(BaseModel, extra='forbid'):

--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -33,7 +33,7 @@ def read_geopkg(file_path, compute_parameters, waterbody_parameters, cpu_pool):
     streamflow_nudging = data_assimilation_parameters.get('streamflow_da',{}).get('streamflow_nudging',False)
     usgs_da = data_assimilation_parameters.get('reservoir_da',{}).get('reservoir_persistence_usgs',False)
     usace_da = data_assimilation_parameters.get('reservoir_da',{}).get('reservoir_persistence_usace',False)
-    rfc_da = waterbody_parameters.get('rfc',{}).get('reservoir_rfc_forecasts',False)
+    rfc_da = data_assimilation_parameters.get('reservoir_da',{}).get('reservoir_rfc_da',{}).get('reservoir_rfc_forecasts',False)
     if any([streamflow_nudging, usgs_da, usace_da, rfc_da]):
         layers.append('network')
     

--- a/test/LowerColorado_TX_v4/domain/coastal_domain_tw.yaml
+++ b/test/LowerColorado_TX_v4/domain/coastal_domain_tw.yaml
@@ -1,3 +1,13 @@
+##### Description #####
+# Format - 
+# Diffusive domain tailwater ID (int):
+#   headwater (int): Segment IDs identifying any headwaters of the diffusive domain. A value of '999999' indicates
+#                    to t-route that it should start at the tailwater ID and traverse upstream until a headwater or a waterbody
+#                    reached. Traversing upstream will stop at any additional IDs that are provided, essentially making them
+#                    headwaters of the diffusive domain.
+#   rfc: *outdated*
+#   rpu: *outdated*
+#######################
 
 #1 Lower Colorado River TX
 2421105:


### PR DESCRIPTION
Quick updates to config module/retrieval. Set default values for `columns` if user leaves this parameter blank. This includes a `@validator` to set defaults based on whether it is a `NHDNetwork` or `HYFeaturesNetwork`. 

Also fixed retrieving `rfc_da` parameters in `read_geopkg()` function. This was looking for these parameters in `waterbody_parameters` which was the old method. Now looks in `data_assimilation_parameters` where they actually are for V4.

## Additions
**network_topology_parameters.py**
- Default values for `columns` for both NHD and HYFeatures networks
- `@validator` to set appropriate default values based on `network_type`

## Removals

-

## Changes
**HYFeaturesNetwork.py**
- Updated where `rfc_da` parameters are retrieved from

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
