### PR TITLE
Create AbstractCompute class

### DIFF
--- a/src/troute-routing/troute/routing/AbstractCompute.py
+++ b/src/troute-routing/troute/routing/AbstractCompute.py
@@ -1,0 +1,117 @@
+from abc import ABC, abstractmethod
+
+
+
+# -----------------------------------------------------------------------------
+# Abstract Compute Class:
+# Define all slots and pass function definitions to child classes
+# -----------------------------------------------------------------------------
+class AbstractCompute(ABC):
+    """
+    This just defines all of the slots that are be used by child classes.
+    These need to be defined in a parent class so each child class can be
+    combined into a single DataAssimilation object without getting a 
+    'multiple-inheritance' error.
+    """
+    __slots__ = ["_reaches_ordered_bytw","_results",]
+    
+    def __init__(self,):
+        """
+        Run subnetworking pre-processing, then computing.
+        """
+        self._subset_domain()
+        
+        self._route()
+        
+    @property
+    def get_output(self,):
+        return self._results
+    
+    @abstractmethod
+    def _subset_domain(self,):
+        pass
+    
+    @abstractmethod
+    def _route(self,):
+        pass
+
+
+# -----------------------------------------------------------------------------
+# Compute class definitions:
+#   1. serial
+#   2. by_network
+#   3. by_subnetwork_jit
+#   4. by_subnetwork_jit_clustered: 
+# -----------------------------------------------------------------------------
+class serial(AbstractCompute):
+    def __init__(self):
+        """
+        Serial compute class.
+        """
+        super().__init__()
+    
+    def _subset_domain(self,):
+        #TODO Define subsetting method for serial
+        self._reaches_ordered_bytw = {}
+    
+    def _route(self,):
+        #TODO Define routing compute method for serial
+        self._results = []
+    
+    
+class by_network(serial):
+    def __init__(self):
+        """
+        By Network compute class.
+        
+        #NOTE I think this can be a subclass of serial. It
+        # just needs to route networks in parallel. -shorvath.
+        """
+        super().__init__()
+    
+    def _subset_domain(self,):
+        #TODO Define subsetting method for by-network
+        self._reaches_ordered_bytw = {}
+    
+    def _route(self,):
+        #TODO Define routing compute method for by-network
+        self._results = []
+    
+    
+class by_subnetwork_jit(by_network):
+    def __init__(self):
+        """
+        By Network JIT compute class.
+        
+        #NOTE I think this can be a subclass of by_network. It
+        # just needs a couple extra steps to handle 'order',
+        # e.g., 'flowveldepth_interorder'. -shorvath.
+        """
+        super().__init__()
+    
+    def _subset_domain(self,):
+        #TODO Define subsetting method for by-network-jit
+        self._reaches_ordered_bytw = {}
+    
+    def _route(self,):
+        #TODO Define routing compute method for by-network-jit
+        self._results = []
+    
+    
+class by_subnetwork_jit_clustered(by_subnetwork_jit):
+    def __init__(self):
+        """
+        By Network JIT Clustered compute class.
+        
+        #NOTE I think this can be a subclass of by_subnetwork_jit. It
+        # just needs a couple extra steps to cluster subnetworks. -shorvath.
+        """
+        super().__init__()
+    
+    def _subset_domain(self,):
+        #TODO Define subsetting method for by-network-jit-clustered
+        self._reaches_ordered_bytw = {}
+    
+    def _route(self,):
+        #TODO Define routing compute method for by-network-jit-clustered
+        self._results = []


### PR DESCRIPTION
Creating an abstract class to replace the functionality of compute.py. The four current compute methods (serial, by_network, by_subnetwork_jit, and by_subnetwork_jit_clustered) share a lot of common methods. This PR merges those into an abstract class that builds from the simplest compute method (serial) to the most complex (by_subnetwork_jit_clustered). This eliminates the excess, repetitive code and groups functionality in logical places.

## Additions
**AbstractCompute.py**
- Abstract classes for compute methods

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
