### PR TITLE
Diffusive fortran kernel correctly executes diffusive wave on stream segments defined by Python preprocessing

### DIFF
--- a/src/kernel/diffusive/diffusive.f90
+++ b/src/kernel/diffusive/diffusive.f90
@@ -133,7 +133,7 @@ contains
     integer, dimension(nrch_g, frnw_col),  intent(in) :: frnw_ar_g
     integer, dimension(mxncomp_g, nrch_g), intent(in) :: size_bathy_g
     double precision, dimension(paradim ), intent(in) :: para_ar_g
-    double precision, dimension(:)       , intent(in) :: timestep_ar_g(9)
+    double precision, dimension(:)       , intent(in) :: timestep_ar_g(10)
     double precision, dimension(nts_db_g), intent(in) :: dbcd_g    
     double precision, dimension(mxncomp_g,   nrch_g),            intent(in) :: z_ar_g
     double precision, dimension(mxncomp_g,   nrch_g),            intent(in) :: bo_ar_g
@@ -184,7 +184,7 @@ contains
     double precision :: x
     double precision :: saveInterval, width
     !double precision :: maxCourant
-    double precision :: dtini_given
+    double precision :: dtini_given, dtini_divisor
     double precision :: timesDepth
     double precision :: t
     double precision :: tfin
@@ -224,17 +224,18 @@ contains
 
   !-----------------------------------------------------------------------------
   ! Time domain parameters
-    dtini        = timestep_ar_g(1) ! initial timestep duration [sec]
-    t0           = timestep_ar_g(2) ! simulation start time [hr]
-    tfin         = timestep_ar_g(3) ! simulation end time [hr]
-    saveInterval = timestep_ar_g(4) ! output recording interval [sec]
-    dt_ql        = timestep_ar_g(5) ! lateral inflow data time step [sec]
-    dt_ub        = timestep_ar_g(6) ! upstream boundary time step [sec]
-    dt_db        = timestep_ar_g(7) ! downstream boundary time step [sec]
-    dt_qtrib     = timestep_ar_g(8) ! tributary data time step [sec]
-    dt_da        = timestep_ar_g(9) ! data assimilation data time step [sec]
-    dtini_given  = dtini            ! preserve user-input timestep duration
-    dtini_min    = dtini/10.0       ! minimum increment in internal time step (user-selected value at the denominator)
+    dtini         = timestep_ar_g(1)    ! initial timestep duration [sec]
+    t0            = timestep_ar_g(2)    ! simulation start time [hr]
+    tfin          = timestep_ar_g(3)    ! simulation end time [hr]
+    saveInterval  = timestep_ar_g(4)    ! output recording interval [sec]
+    dt_ql         = timestep_ar_g(5)    ! lateral inflow data time step [sec]
+    dt_ub         = timestep_ar_g(6)    ! upstream boundary time step [sec]
+    dt_db         = timestep_ar_g(7)    ! downstream boundary time step [sec]
+    dt_qtrib      = timestep_ar_g(8)    ! tributary data time step [sec]
+    dt_da         = timestep_ar_g(9)    ! data assimilation data time step [sec]
+    dtini_given   = dtini               ! preserve user-input timestep duration
+    dtini_divisor = timestep_ar_g(10)   ! numeric value that divide dtini in the next line
+    dtini_min     = dtini/dtini_divisor ! minimum increment in internal time step 
 
   !-----------------------------------------------------------------------------
   ! miscellaneous parameters

--- a/src/kernel/diffusive/pydiffusive.f90
+++ b/src/kernel/diffusive/pydiffusive.f90
@@ -26,7 +26,7 @@ subroutine c_diffnw(timestep_ar_g, nts_ql_g, nts_ub_g, nts_db_g, ntss_ev_g, nts_
     integer(c_int), dimension(mxncomp_g, nrch_g),   intent(in) :: size_bathy_g 
     real(c_double), dimension(nts_db_g),            intent(in) :: dbcd_g
     real(c_double), dimension(paradim),             intent(in) :: para_ar_g
-    real(c_double), dimension(:),                   intent(in) :: timestep_ar_g(9)
+    real(c_double), dimension(:),                   intent(in) :: timestep_ar_g(10)
     real(c_double), dimension(mxncomp_g, nrch_g),   intent(in) :: z_ar_g, bo_ar_g, traps_ar_g
     real(c_double), dimension(mxncomp_g, nrch_g),   intent(in) :: tw_ar_g, twcc_ar_g
     real(c_double), dimension(mxncomp_g, nrch_g),   intent(in) :: mann_ar_g, manncc_ar_g

--- a/src/troute-network/troute/AbstractRouting.py
+++ b/src/troute-network/troute/AbstractRouting.py
@@ -180,7 +180,7 @@ class MCwithDiffusive(AbstractRouting):
         diffusive_domain_all = {}
         rconn_diff0 = reverse_network(connections)
         all_links = []
-        
+
         for tw in diffusive_domain:
             headlink_mainstem, rfc_val, rpu_val = list(diffusive_domain.get(tw).values())
             if 999999 in headlink_mainstem:
@@ -212,11 +212,15 @@ class MCwithDiffusive(AbstractRouting):
         topobathy_df = self.topobathy_df
         missing_topo_ids = list(set(all_links).difference(set(topobathy_df.index)))
         topo_df_list = []
-
+   
         for key in missing_topo_ids:
             topo_df_list.append(_fill_in_missing_topo_data(key, dataframe, topobathy_df))
+        
+        if len(topo_df_list)==0: 
+            new_topo_df = pd.DataFrame() 
+        else:
+            new_topo_df = pd.concat(topo_df_list)
 
-        new_topo_df = pd.concat(topo_df_list)
         bad_links = list(set(missing_topo_ids).difference(set(new_topo_df.index)))
         self._topobathy_df = pd.concat([self.topobathy_df,new_topo_df])
         
@@ -233,7 +237,6 @@ class MCwithDiffusive(AbstractRouting):
             
             wbody_ids = waterbody_dataframe.index.tolist()
             targets = self._diffusive_domain[tw]['targets'] + bad_links
-            
             links = list(reachable(rconn_diff0, sources=[tw], targets=targets).get(tw))
             outlet_ids = [connections.get(id)[0] for id in wbody_ids]
             wbody_and_outlet_ids = wbody_ids + outlet_ids + bad_links
@@ -260,7 +263,7 @@ class MCwithDiffusive(AbstractRouting):
                 for u in us_list:
                     if u not in mainstem_segs:
                         trib_segs.append(u) 
-
+ 
             self._diffusive_network_data[tw]['tributary_segments'] = trib_segs
             # diffusive domain connections object
             self._diffusive_network_data[tw]['connections'] = {k: connections[k] for k in (mainstem_segs + trib_segs)}       

--- a/src/troute-routing/troute/routing/diffusive_utils_v02.py
+++ b/src/troute-routing/troute/routing/diffusive_utils_v02.py
@@ -725,7 +725,7 @@ def diffusive_input_data_v02(
     tfin_g = (dt * nsteps)/60/60
     
     # package timestep variables into single array
-    timestep_ar_g    = np.zeros(9)
+    timestep_ar_g    = np.zeros(10)
     timestep_ar_g[0] = dtini_g
     timestep_ar_g[1] = t0_g
     timestep_ar_g[2] = tfin_g
@@ -735,6 +735,7 @@ def diffusive_input_data_v02(
     # timestep_ar_g[6] =  dt_db_g <- defined after calling fp_coastal_boundary_input_map
     timestep_ar_g[7] = dt_qtrib_g
     timestep_ar_g[8] = dt_da_g
+    timestep_ar_g[9] = 10.0 # dtini_g/this_number = the min.sim.time interval internally executed within diffusive.f90 
 
     # CN-mod parameters
     paradim       = 11


### PR DESCRIPTION
When defining diffusive domain including not only mainstem but also connected tributaries by [this config file](https://github.com/NOAA-OWP/t-route/blob/master/test/LowerColorado_TX_v4/domain/coastal_domain_tw.yaml), diffusive.f90 hasn't been executed diffusive wave routing on all the reaches where the config file defines to run diffusive wave on. That's because diffusive.f90 assumes a reach without any its upstream reach to not run diffusive wave on but instead to  already have given flow and depth data computed from other routing model, in this case MC.  By defining a reach of index j in frnw_g with specified value, for example, 555 for diffusive reach while -555 for already-computed reach,  diffusive.f90 now correctly route on all reaches told to run diffusive wave. 

## Additions
AbstractRouting.py:  Select a single cross section topo data with minimum value of cs_id for each stream segment
diffusive_utils_v02.py:  Decide a stream reach of index j whether to run diffusive wave or not to run diffusive but have already-computed flow value by MC instead.
diffusive.90: Implement diffusive wave on all the reaches that are told to run diffusive on.

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
