### PR TITLE
Fix all_links object when running diffusive on just the mainstem

### DIFF
--- a/src/troute-network/troute/AbstractRouting.py
+++ b/src/troute-network/troute/AbstractRouting.py
@@ -205,6 +205,8 @@ class MCwithDiffusive(AbstractRouting):
                 headlink_mainstem = headlink_mainstem[0]
                 twlink_mainstem = tw
                 diffusive_domain_all[twlink_mainstem] = self.diffusive_domain_by_both_ends_streamid(connections, headlink_mainstem, twlink_mainstem, rfc_val, rpu_val)
+                diffusive_domain_all[twlink_mainstem]['targets'] = [headlink_mainstem]
+                all_links = all_links + diffusive_domain_all[twlink_mainstem]['links']
 
         self._diffusive_domain = diffusive_domain_all
         
@@ -212,7 +214,7 @@ class MCwithDiffusive(AbstractRouting):
         topobathy_df = self.topobathy_df
         missing_topo_ids = list(set(all_links).difference(set(topobathy_df.index)))
         topo_df_list = []
-   
+        
         for key in missing_topo_ids:
             topo_df_list.append(_fill_in_missing_topo_data(key, dataframe, topobathy_df))
         
@@ -238,6 +240,7 @@ class MCwithDiffusive(AbstractRouting):
             wbody_ids = waterbody_dataframe.index.tolist()
             targets = self._diffusive_domain[tw]['targets'] + bad_links
             links = list(reachable(rconn_diff0, sources=[tw], targets=targets).get(tw))
+            links = list(set(self._diffusive_domain[tw]['links']).intersection(set(links)))
             outlet_ids = [connections.get(id)[0] for id in wbody_ids]
             wbody_and_outlet_ids = wbody_ids + outlet_ids + bad_links
             mainstem_segs = list(set(links).difference(set(wbody_and_outlet_ids)))


### PR DESCRIPTION
`all_links` object was causing errors when diffusive was run not using the `999999` flag (so just on a mainstem). This fixes those issues.

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
