### PR TITLE
Added functionality to output to parquet 

### DIFF
--- a/src/troute-config/troute/config/output_parameters.py
+++ b/src/troute-config/troute/config/output_parameters.py
@@ -49,7 +49,7 @@ class CsvOutput(BaseModel):
     csv_output_segments: Optional[List[str]] = None
 
 
-class ParquetOutput(BaseModel, extra='forbid'):
+class ParquetOutput(BaseModel):
     # NOTE: required if writing results to parquet
     parquet_output_folder: Optional[DirectoryPath] = None
     parquet_output_segments: Optional[List[str]] = None
@@ -57,7 +57,7 @@ class ParquetOutput(BaseModel, extra='forbid'):
     prefix_ids: Optional[str] = None
 
 
-class ChrtoutOutput(BaseModel, extra='forbid'):
+class ChrtoutOutput(BaseModel):
     # NOTE: mandatory if writing results to CHRTOUT.
     wrf_hydro_channel_output_source_folder: Optional[DirectoryPath] = None
 

--- a/src/troute-config/troute/config/output_parameters.py
+++ b/src/troute-config/troute/config/output_parameters.py
@@ -5,13 +5,16 @@ from typing import Optional, List
 from typing_extensions import Annotated, Literal
 from .types import FilePath, DirectoryPath
 
-streamOutput_allowedTypes = Literal['.csv', '.nc', '.pkl']
+streamOutput_allowedTypes = Literal['.csv', '.nc', '.pkl', '.parquet']
+
 
 class OutputParameters(BaseModel):
     chanobs_output: Optional["ChanobsOutput"] = None
     # NOTE: this appears to be optional. See nwm_routing/input.py ~:477
     csv_output: Optional["CsvOutput"] = None
     # NOTE: this appears to be optional. See nwm_routing/input.py ~:496
+    parquet_output: Optional["ParquetOutput"] = None
+    # NOTE: this appears to be optional. See nwm_routing/input.py ~:563
     chrtout_output: Optional["ChrtoutOutput"] = None
     lite_restart: Optional["LiteRestart"] = None
     # NOTE: this appears to be optional. See nwm_routing/input.py ~:520
@@ -46,7 +49,13 @@ class CsvOutput(BaseModel):
     csv_output_segments: Optional[List[str]] = None
 
 
-class ChrtoutOutput(BaseModel):
+class ParquetOutput(BaseModel, extra='forbid'):
+    # NOTE: required if writing results to parquet
+    parquet_output_folder: Optional[DirectoryPath] = None
+    parquet_output_segments: Optional[List[str]] = None
+
+
+class ChrtoutOutput(BaseModel, extra='forbid'):
     # NOTE: mandatory if writing results to CHRTOUT.
     wrf_hydro_channel_output_source_folder: Optional[DirectoryPath] = None
 
@@ -79,6 +88,7 @@ class WrfHydroParityCheck(BaseModel):
 class ParityCheckCompareFileSet(BaseModel):
     validation_files: List[FilePath]
 
+
 class StreamOutput(BaseModel):
     # NOTE: required if writing StreamOutput files
     stream_output_directory: Optional[DirectoryPath] = None
@@ -93,7 +103,7 @@ class StreamOutput(BaseModel):
             if values.get('stream_output_time') != -1 and value / 60 > values['stream_output_time']:
                 raise ValueError("stream_output_internal_frequency should be less than or equal to stream_output_time in minutes.")
         return value
- 
+
 
 OutputParameters.update_forward_refs()
 WrfHydroParityCheck.update_forward_refs()

--- a/src/troute-config/troute/config/output_parameters.py
+++ b/src/troute-config/troute/config/output_parameters.py
@@ -105,7 +105,7 @@ class StreamOutput(BaseModel):
             if values.get('stream_output_time') != -1 and value / 60 > values['stream_output_time']:
                 raise ValueError("stream_output_internal_frequency should be less than or equal to stream_output_time in minutes.")
         return value
-  
+ 
 
 OutputParameters.update_forward_refs()
 WrfHydroParityCheck.update_forward_refs()

--- a/src/troute-config/troute/config/output_parameters.py
+++ b/src/troute-config/troute/config/output_parameters.py
@@ -54,6 +54,7 @@ class ParquetOutput(BaseModel, extra='forbid'):
     parquet_output_folder: Optional[DirectoryPath] = None
     parquet_output_segments: Optional[List[str]] = None
     configuration: Optional[str] = None
+    prefix_ids: Optional[str] = None
 
 
 class ChrtoutOutput(BaseModel, extra='forbid'):

--- a/src/troute-config/troute/config/output_parameters.py
+++ b/src/troute-config/troute/config/output_parameters.py
@@ -53,6 +53,7 @@ class ParquetOutput(BaseModel, extra='forbid'):
     # NOTE: required if writing results to parquet
     parquet_output_folder: Optional[DirectoryPath] = None
     parquet_output_segments: Optional[List[str]] = None
+    configuration: Optional[str] = None
 
 
 class ChrtoutOutput(BaseModel, extra='forbid'):

--- a/src/troute-config/troute/config/output_parameters.py
+++ b/src/troute-config/troute/config/output_parameters.py
@@ -105,7 +105,7 @@ class StreamOutput(BaseModel):
             if values.get('stream_output_time') != -1 and value / 60 > values['stream_output_time']:
                 raise ValueError("stream_output_internal_frequency should be less than or equal to stream_output_time in minutes.")
         return value
-
+  
 
 OutputParameters.update_forward_refs()
 WrfHydroParityCheck.update_forward_refs()

--- a/src/troute-config/troute/config/output_parameters.py
+++ b/src/troute-config/troute/config/output_parameters.py
@@ -5,7 +5,7 @@ from typing import Optional, List
 from typing_extensions import Annotated, Literal
 from .types import FilePath, DirectoryPath
 
-streamOutput_allowedTypes = Literal['.csv', '.nc', '.pkl', '.parquet']
+streamOutput_allowedTypes = Literal['.csv', '.nc', '.pkl']
 
 
 class OutputParameters(BaseModel):

--- a/src/troute-nwm/src/nwm_routing/input.py
+++ b/src/troute-nwm/src/nwm_routing/input.py
@@ -559,6 +559,25 @@ def check_inputs(
 
     else:
         LOG.debug('No csv output folder specified. Results will NOT be written to csv')
+
+    if output_parameters.get('parquet_output', None):
+
+        if output_parameters['parquet_output'].get('parquet_output_folder', None):
+
+            _does_path_exist(
+                'parquet_output_folder',
+                output_parameters['parquet_output']['parquet_output_folder']
+            )
+
+            output_segs = output_parameters['parquet_output'].get('parquet_output_segments', None)
+            if not output_segs:
+                LOG.debug('No parquet output segments specified. Results for all domain segments will be written')
+
+        else:
+            LOG.debug('No parquet output folder specified. Results will NOT be written in parquet format')
+
+    else:
+        LOG.debug('No parquet output folder specified. Results will NOT be written in parquet format')
         
     if output_parameters.get('chrtout_output', None):
         

--- a/src/troute-nwm/src/nwm_routing/output.py
+++ b/src/troute-nwm/src/nwm_routing/output.py
@@ -46,31 +46,8 @@ def _reindex_lake_to_link_id(target_df, crosswalk):
 
     return target_df
 
-<<<<<<< HEAD
-def nwm_output_generator(
-    run,
-    results,
-    supernetwork_parameters,
-    output_parameters,
-    parity_parameters,
-    restart_parameters,
-    parity_set,
-    qts_subdivisions,
-    return_courant,
-    cpu_pool,
-    waterbodies_df,
-    waterbody_types_df,
-    duplicate_ids_df,
-    data_assimilation_parameters=False,
-    lastobs_df = None,
-    link_gage_df = None,
-    link_lake_crosswalk = None,
-    logFileName='NONE' 
-):
-=======
->>>>>>> 184493d (Added functionality to write flow, velocity and depth to parquet)
 
-def _parquet_output_format_converter(df, start_datetime, dt, configuration):
+def _parquet_output_format_converter(df, start_datetime, dt, configuration, prefix_ids):
     '''
     Utility function for convert flowveldepth dataframe
     to a timeseries and to match parquet input format
@@ -104,7 +81,7 @@ def _parquet_output_format_converter(df, start_datetime, dt, configuration):
     timeseries_df['units'] = timeseries_df['variable_name'].map(variable_to_units_map)
     timeseries_df['reference_time'] = start_datetime.date()
     timeseries_df['location_id'] = timeseries_df['location_id'].astype('string')
-    timeseries_df['location_id'] = 'nex-' + timeseries_df['location_id']
+    timeseries_df['location_id'] = prefix_ids + '-' + timeseries_df['location_id']
     timeseries_df['value'] = timeseries_df['value'].astype('double')
     timeseries_df['reference_time'] = timeseries_df['reference_time'].astype('datetime64[us]')
     timeseries_df['value_time'] = timeseries_df['value_time'].astype('datetime64[us]')
@@ -129,6 +106,7 @@ def nwm_output_generator(
         lastobs_df=None,
         link_gage_df=None,
         link_lake_crosswalk=None,
+        logFileName='NONE'
 ):
     dt = run.get("dt")
     nts = run.get("nts")
@@ -190,10 +168,6 @@ def nwm_output_generator(
         )
         csv_output_segments = csv_output.get("csv_output_segments", None)
 
-<<<<<<< HEAD
-    if csv_output_folder or rsrto or chrto or chano or test or wbdyo or stream_output:
-        
-=======
     if parquet_output:
         parquet_output_folder = output_parameters["parquet_output"].get(
             "parquet_output_folder", None
@@ -202,7 +176,6 @@ def nwm_output_generator(
 
     if csv_output_folder or parquet_output_folder or rsrto or chrto or chano or test or wbdyo or stream_output:
 
->>>>>>> 184493d (Added functionality to write flow, velocity and depth to parquet)
         start = time.time()
         qvd_columns = pd.MultiIndex.from_product(
             [range(nts), ["q", "v", "d"]]
@@ -283,7 +256,7 @@ def nwm_output_generator(
 
         nudge = np.concatenate([r[8] for r in results])
         usgs_positions_id = np.concatenate([r[3][0] for r in results])
-<<<<<<< HEAD
+
         nhd_io.write_flowveldepth(
             Path(stream_output_directory), 
             flowveldepth, 
@@ -309,23 +282,11 @@ def nwm_output_generator(
                 preRunLog.write("Output of FVD data every "+str(fCalc)+" minutes\n")
                 preRunLog.write("Writing "+str(nTimeBins)+" time bins for "+str(len(flowveldepth.index))+" segments per FVD output file\n")               
             preRunLog.close()      
-=======
-        nhd_io.write_flowveldepth_netcdf(Path(stream_output_directory),
-                                         flowveldepth,
-                                         nudge,
-                                         usgs_positions_id,
-                                         t0,
-                                         int(stream_output_timediff),
-                                         stream_output_type,
-                                         stream_output_internal_frequency,
-                                         cpu_pool=cpu_pool)
->>>>>>> 184493d (Added functionality to write flow, velocity and depth to parquet)
-
+            
     if test:
         flowveldepth.to_pickle(Path(test))
 
     if wbdyo and not waterbodies_df.empty:
-<<<<<<< HEAD
         
         time_index, tmp_variable = map(list,zip(*i_df.columns.tolist()))
         if not duplicate_ids_df.empty:
@@ -334,15 +295,11 @@ def nwm_output_generator(
         else:
             output_waterbodies_df = waterbodies_df
             output_waterbody_types_df = waterbody_types_df
-=======
 
-        time_index, tmp_variable = map(list, zip(*i_df.columns.tolist()))
->>>>>>> 184493d (Added functionality to write flow, velocity and depth to parquet)
         LOG.info("- writing t-route flow results to LAKEOUT files")
         start = time.time()
         for i in range(i_df.shape[1]):
             nhd_io.write_waterbody_netcdf(
-<<<<<<< HEAD
                 wbdyo, 
                 i_df.iloc[:,[i]],
                 q_df.iloc[:,[i]],
@@ -362,21 +319,7 @@ def nwm_output_generator(
                 preRunLog.write("Output of waterbody files into folder: "+str(wbdyo)+"\n") 
                 preRunLog.write("-----\n") 
             preRunLog.close()  
-         
-=======
-                wbdyo,
-                i_df.iloc[:, [i]],
-                q_df.iloc[:, [i]],
-                d_df.iloc[:, [i]],
-                waterbodies_df,
-                waterbody_types_df,
-                t0,
-                dt,
-                nts,
-                time_index[i],
-            )
 
->>>>>>> 184493d (Added functionality to write flow, velocity and depth to parquet)
         LOG.debug("writing LAKEOUT files took a total time of %s seconds." % (time.time() - start))
 
     if rsrto:
@@ -450,7 +393,6 @@ def nwm_output_generator(
                 qts_subdivisions,
                 cpu_pool,
             )
-<<<<<<< HEAD
         
             if (not logFileName == 'NONE'):
                 with open(logFileName, 'a') as preRunLog:
@@ -459,8 +401,6 @@ def nwm_output_generator(
                     preRunLog.write("Output of FVD files into folder: "+str(chrtout_read_folder)+"\n") 
                     preRunLog.write("-----\n") 
                 preRunLog.close()  
-=======
->>>>>>> 184493d (Added functionality to write flow, velocity and depth to parquet)
 
         LOG.debug("writing CHRTOUT files took a total time of %s seconds." % (time.time() - start))
 
@@ -526,17 +466,19 @@ def nwm_output_generator(
             parquet_output_segments = flowveldepth.index
 
         flowveldepth = flowveldepth.sort_index()
+        configuration = output_parameters["parquet_output"].get("configuration")
+        prefix_ids = output_parameters["parquet_output"].get("prefix_ids")
         timeseries_df = _parquet_output_format_converter(flowveldepth, restart_parameters.get("start_datetime"), dt,
-                                                         output_parameters["parquet_output"].get("configuration"))
+                                                         configuration, prefix_ids)
 
-        parquet_output_segments_str = ['nex-' + str(segment) for segment in parquet_output_segments]
+        parquet_output_segments_str = [prefix_ids + '-' + str(segment) for segment in parquet_output_segments]
         timeseries_df.loc[timeseries_df['location_id'].isin(parquet_output_segments_str)].to_parquet(
             output_path.joinpath(filename_fvd), allow_truncated_timestamps=True)
 
         if return_courant:
             courant = courant.sort_index()
             timeseries_courant = _parquet_output_format_converter(courant, restart_parameters.get("start_datetime"), dt,
-                                                         output_parameters["parquet_output"].get("configuration"))
+                                                                  configuration, prefix_ids)
             timeseries_courant.loc[timeseries_courant['location_id'].isin(parquet_output_segments_str)].to_parquet(
                 output_path.joinpath(filename_courant), allow_truncated_timestamps=True)
 
@@ -565,8 +507,7 @@ def nwm_output_generator(
             # TODO allow user to pass a list of segments at which they would like to print results
             # rather than just printing at gages. 
         )
-<<<<<<< HEAD
-
+        
         if (not logFileName == 'NONE'):
             with open(logFileName, 'a') as preRunLog:
                 preRunLog.write("\n") 
@@ -576,10 +517,6 @@ def nwm_output_generator(
             preRunLog.close()  
 
         LOG.debug("writing flow data to CHANOBS took %s seconds." % (time.time() - start))       
-=======
->>>>>>> 184493d (Added functionality to write flow, velocity and depth to parquet)
-
-        LOG.debug("writing flow data to CHANOBS took %s seconds." % (time.time() - start))
 
     if lastobso:
         # Write out LastObs as netcdf when using main_v04 or troute_model with HYfeature.
@@ -594,12 +531,8 @@ def nwm_output_generator(
 
             nudging_true = streamflow_da.get('streamflow_nudging', None)
 
-<<<<<<< HEAD
         if nudging_true and lastobs_output_folder and not lastobs_df.empty:
 
-=======
-        if nudging_true and lastobs_output_folder:
->>>>>>> 184493d (Added functionality to write flow, velocity and depth to parquet)
             LOG.info("- writing lastobs files")
             start = time.time()
 
@@ -622,14 +555,8 @@ def nwm_output_generator(
 
             LOG.debug("writing lastobs files took %s seconds." % (time.time() - start))
 
-<<<<<<< HEAD
-
-    # if 'flowveldepth' in locals():
-    #     LOG.debug(flowveldepth)
-=======
     if 'flowveldepth' in locals():
         LOG.debug(flowveldepth)
->>>>>>> 184493d (Added functionality to write flow, velocity and depth to parquet)
 
     LOG.debug("output complete in %s seconds." % (time.time() - start_time))
 

--- a/src/troute-nwm/src/nwm_routing/output.py
+++ b/src/troute-nwm/src/nwm_routing/output.py
@@ -572,5 +572,5 @@ def nwm_output_generator(
         parity_check(
             parity_set, results,
         )
-
+        
         LOG.debug("parity check complete in %s seconds." % (time.time() - start_time))

--- a/src/troute-nwm/src/nwm_routing/output.py
+++ b/src/troute-nwm/src/nwm_routing/output.py
@@ -521,7 +521,7 @@ def nwm_output_generator(
 
         output_path = Path(parquet_output_folder).resolve()
 
-        # no csv_output_segments are specified, then write results for all segments
+        # no parquet_output_segments are specified, then write results for all segments
         if not parquet_output_segments:
             parquet_output_segments = flowveldepth.index
 
@@ -532,7 +532,6 @@ def nwm_output_generator(
         parquet_output_segments_str = ['nex-' + str(segment) for segment in parquet_output_segments]
         timeseries_df.loc[timeseries_df['location_id'].isin(parquet_output_segments_str)].to_parquet(
             output_path.joinpath(filename_fvd), allow_truncated_timestamps=True)
-        # flowveldepth.loc[parquet_output_segments].to_parquet(output_path.joinpath(filename_fvd))
 
         if return_courant:
             courant = courant.sort_index()
@@ -540,7 +539,6 @@ def nwm_output_generator(
                                                          output_parameters["parquet_output"].get("configuration"))
             timeseries_courant.loc[timeseries_courant['location_id'].isin(parquet_output_segments_str)].to_parquet(
                 output_path.joinpath(filename_courant), allow_truncated_timestamps=True)
-            #courant.loc[parquet_output_segments].to_parquet(output_path.joinpath(filename_courant))
 
         LOG.debug("writing parquet file took %s seconds." % (time.time() - start))
 

--- a/src/troute-nwm/src/nwm_routing/output.py
+++ b/src/troute-nwm/src/nwm_routing/output.py
@@ -34,7 +34,7 @@ def _reindex_lake_to_link_id(target_df, crosswalk):
     lake_index_intersect = np.intersect1d(
         idxs,
         lakeids,
-        return_indices=True
+        return_indices = True
     )
 
     # replace lake ids with link IDs in the target_df index array
@@ -300,7 +300,7 @@ def nwm_output_generator(
         start = time.time()
         for i in range(i_df.shape[1]):
             nhd_io.write_waterbody_netcdf(
-                wbdyo, 
+                wbdyo,
                 i_df.iloc[:,[i]],
                 q_df.iloc[:,[i]],
                 d_df.iloc[:,[i]],

--- a/src/troute-nwm/src/nwm_routing/output.py
+++ b/src/troute-nwm/src/nwm_routing/output.py
@@ -528,26 +528,7 @@ def nwm_output_generator(
         flowveldepth = flowveldepth.sort_index()
         timeseries_df = _parquet_output_format_converter(flowveldepth, restart_parameters.get("start_datetime"), dt,
                                                          output_parameters["parquet_output"].get("configuration"))
-        """
-        flowveldepth.index.name = 'Location_ID'
-        flowveldepth.reset_index(inplace=True)
-        timeseries_df = flowveldepth.melt(id_vars=['Location_ID'], var_name='var')
-        timeseries_df['var'] = timeseries_df['var'].astype('string')
-        timeseries_df[['timestep', 'variable']] = timeseries_df['var'].str.strip("()").str.split(",", n=1, expand=True)
-        # timeseries_df[['timestep', 'variable_name']]= pd.DataFrame([x.strip("()").split(',') for x in list(
-        # timeseries_df['variable'])])
-        timeseries_df['variable'] = timeseries_df['variable'].str.strip().str.replace("'", "")
-        timeseries_df['timestep'] = timeseries_df['timestep'].astype('int')
-        timeseries_df['value_time'] = (restart_parameters.get("start_datetime") +
-                                       pd.to_timedelta(timeseries_df['timestep'] * dt, unit='s'))
-        variable_to_name_map = {"q": "streamflow", "d": "depth", "v": "velocity"}
-        timeseries_df["variable_name"] = timeseries_df["variable"].map(variable_to_name_map)
-        timeseries_df.drop(['var', 'timestep', 'variable'], axis=1, inplace=True)
-        timeseries_df['configuration'] = output_parameters["parquet_output"].get("configuration")
-        variable_to_units_map = {"streamflow": "m3/s", "velocity": "m/s", "depth": "m"}
-        timeseries_df['units'] = timeseries_df['variable_name'].map(variable_to_units_map)
-        timeseries_df['reference_time'] = restart_parameters.get("start_datetime").date()
-        """
+
         parquet_output_segments_str = ['nex-' + str(segment) for segment in parquet_output_segments]
         timeseries_df.loc[timeseries_df['location_id'].isin(parquet_output_segments_str)].to_parquet(
             output_path.joinpath(filename_fvd), allow_truncated_timestamps=True)

--- a/test/LowerColorado_TX/test_AnA_V4_NHD.yaml
+++ b/test/LowerColorado_TX/test_AnA_V4_NHD.yaml
@@ -128,5 +128,6 @@ output_parameters:
         #---------
         parquet_output_folder: output/
         configuration: short_range
+        prefix_ids: nex
 
     

--- a/test/LowerColorado_TX/test_AnA_V4_NHD.yaml
+++ b/test/LowerColorado_TX/test_AnA_V4_NHD.yaml
@@ -127,5 +127,6 @@ output_parameters:
     parquet_output:
         #---------
         parquet_output_folder: output/
+        configuration: short_range
 
     

--- a/test/LowerColorado_TX/test_AnA_V4_NHD.yaml
+++ b/test/LowerColorado_TX/test_AnA_V4_NHD.yaml
@@ -105,7 +105,7 @@ compute_parameters:
                 reservoir_rfc_forecasts_lookback_hours  : 48
             
 #--------------------------------------------------------------------------------
-# output_parameters:
+output_parameters:
 #     #----------
 #     test_output: output/lcr_flowveldepth.pkl
 #     lite_restart:
@@ -124,5 +124,8 @@ compute_parameters:
 #         stream_output_time: 1 #[hr]
 #         stream_output_type: '.nc' #please select only between netcdf '.nc' or '.csv' or '.pkl'
 #         stream_output_internal_frequency: 30 #[min] it should be order of 5 minutes. For instance if you want to output every hour put 60
+    parquet_output:
+        #---------
+        parquet_output_folder: output/
 
     


### PR DESCRIPTION
PR to add functionality to output flow, velocity and depth to parquet file. The output parquet is a timeseries data(details in Notes). It is required for the [TEEHR](https://github.com/RTIInternational/teehr) input. TEEHR comprises of set of tools for hydrologic model and forecast evaluation. Storing the t-route output in parquet format will lead to efficient query of the data. Also, it will help in automation by connecting TEEHR with NextGen water model. [CIROH](https://ciroh.ua.edu) along with Lynker has developed a containerized version of NextGen National Water Model [NextGen In A Box (NGIAB)](https://github.com/CIROH-UA/NGIAB-CloudInfra). TEEHR uses DuckDB to query the parquet output from NGIAB stored on cloud.  

## Additions

- Added functionality to output write flow, velocity and depth to parquet format.

## Changes

- Changed yaml input file to include parquet output format
```    
parquet_output:
    #---------
    parquet_output_folder: output/
    configuration: short_range
    prefix_ids: nex
```

## Testing

1. The modified code is tested by executing LowerColorado_TX demonstration test. 
<img width="1197" alt="LowerColorado_TX" src="https://github.com/NOAA-OWP/t-route/assets/22774612/c4a3d218-7cac-4058-a7b0-eae59b4bd81a">

## Screenshots
- Here is a screenshot of successful compilation.
<img width="1195" alt="compile" src="https://github.com/NOAA-OWP/t-route/assets/22774612/4f9ddbcc-8742-4943-8a36-0065e3c391bf">

- Parquet output timeserie data from LowerColorado_TX demonstration test.
<img width="826" alt="parquet" src="https://github.com/NOAA-OWP/t-route/assets/22774612/cfde82a1-4cd3-4e16-bd48-a994b3e27bae">


## Notes

- The `flowveldepth` dateframe is modified to create a timeseries containing following variables: 
```
location_id: string
value: double
value_time: timestamp[us]
variable_name: string
configuration: string
units: string
reference_time: timestamp[us]
```
- Location_id variable contains nexus IDs and has 'nex-' prepended to it. 
- Configuration (short range, medium range, long range etc.) has to be entered by the user in the input yaml file. 

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser
