### PR TITLE
update to save other formats

### DIFF
--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -1955,6 +1955,37 @@ def write_waterbody_netcdf(
             )
 
 
+def write_flowveldepth_csv_pkl(stream_output_directory, file_name,
+                              flow, velocity, depth, nudge_df, timestamps,
+                              t0):
+    
+    formatted_times = [str(timedelta(seconds=t)) for t in timestamps]
+    column_names = ['flow','velocity', 'depth', 'nudge', 'time']
+    
+    df_list = []
+    
+    for i in range(len(formatted_times)):
+        # Construct a temporary DataFrame for each column set
+        df_temp = pd.DataFrame({
+            'time': formatted_times[i],
+            'flow': flow.iloc[:, i],
+            'velocity': velocity.iloc[:, i],
+            'depth': depth.iloc[:, i],
+            'nudge': nudge_df.iloc[:, i]  
+        })
+        df_list.append(df_temp)
+
+    # Concatenate all temporary DataFrames vertically
+    df = pd.concat(df_list)
+    df.index.name = 'feature_id'
+
+    # File format handling
+    file_format = file_name.split('.')[-1]
+    if file_format == 'csv':
+        df.to_csv(f"{stream_output_directory}/{file_name}", index=True)
+    elif file_format == 'pkl':
+        df.to_pickle(f"{stream_output_directory}/{file_name}")
+
 def write_flowveldepth_netcdf(stream_output_directory, file_name,
                               flow, velocity, depth, nudge_df, timestamps,
                               t0):
@@ -2116,8 +2147,8 @@ def write_flowveldepth(
     n_timesteps = flowveldepth.shape[1]//3
     ts = stream_output_internal_frequency//5
     ind = [i for i in range(ts-1,n_timesteps+1,ts)]
-    timestamps_sec =  [(i+1)*300 for i in ind]
-
+    timestamps_sec =  [(i+1)*dt for i in ind]
+    
     flow = flowveldepth.iloc[:,0::3].iloc[:,ind]
     velocity = flowveldepth.iloc[:,1::3].iloc[:,ind]
     depth = flowveldepth.iloc[:,2::3].iloc[:,ind]
@@ -2140,18 +2171,24 @@ def write_flowveldepth(
     file_name_time = t0
     jobs = []
     for _ in range(num_files):
-        filename = 'troute_output_' + file_name_time.strftime('%Y%m%d%H%M') + '.nc'
+        filename = 'troute_output_' + file_name_time.strftime('%Y%m%d%H%M') + stream_output_type
         args = (stream_output_directory,filename,
                 flow.iloc[:,0:ts_per_file],
                 velocity.iloc[:,0:ts_per_file],
                 depth.iloc[:,0:ts_per_file],
                 nudge_df.iloc[:,0:ts_per_file],
                 timestamps_sec[0:ts_per_file],t0)
-        if cpu_pool > 1 & num_files > 1:
-            jobs.append(delayed(write_flowveldepth_netcdf)(*args))
+        if stream_output_type == '.nc':
+            if cpu_pool > 1 & num_files > 1:
+                jobs.append(delayed(write_flowveldepth_netcdf)(*args))
+            else:
+                write_flowveldepth_netcdf(*args)
         else:
-            write_flowveldepth_netcdf(*args)
-            
+            if cpu_pool > 1 & num_files > 1:
+                jobs.append(delayed(write_flowveldepth_csv_pkl)(*args))
+            else:
+                write_flowveldepth_csv_pkl(*args)
+
         flow = flow.iloc[:,ts_per_file:]
         velocity = velocity.iloc[:,ts_per_file:]
         depth = depth.iloc[:,ts_per_file:]

--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -2145,7 +2145,7 @@ def write_flowveldepth(
     # timesteps, variable = zip(*flowveldepth.columns.tolist())
     # timesteps = list(timesteps)
     n_timesteps = flowveldepth.shape[1]//3
-    ts = stream_output_internal_frequency//5
+    ts = stream_output_internal_frequency//(dt//60)
     ind = [i for i in range(ts-1,n_timesteps,ts)]
     timestamps_sec =  [(i+1)*dt for i in ind]
     

--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -1960,13 +1960,13 @@ def write_flowveldepth_csv_pkl(stream_output_directory, file_name,
                               t0):
     
     formatted_times = [str(timedelta(seconds=t)) for t in timestamps]
-    column_names = ['flow','velocity', 'depth', 'nudge', 'time']
     
     df_list = []
     
     for i in range(len(formatted_times)):
         # Construct a temporary DataFrame for each column set
         df_temp = pd.DataFrame({
+            't0': str(t0),
             'time': formatted_times[i],
             'flow': flow.iloc[:, i],
             'velocity': velocity.iloc[:, i],
@@ -2146,7 +2146,7 @@ def write_flowveldepth(
     # timesteps = list(timesteps)
     n_timesteps = flowveldepth.shape[1]//3
     ts = stream_output_internal_frequency//5
-    ind = [i for i in range(ts-1,n_timesteps+1,ts)]
+    ind = [i for i in range(ts-1,n_timesteps,ts)]
     timestamps_sec =  [(i+1)*dt for i in ind]
     
     flow = flowveldepth.iloc[:,0::3].iloc[:,ind]

--- a/src/troute-routing/troute/routing/diffusive_utils_v02.py
+++ b/src/troute-routing/troute/routing/diffusive_utils_v02.py
@@ -709,9 +709,9 @@ def diffusive_input_data_v02(
     # lateral inflow timestep (sec). Currently, lateral flow in CHAROUT files at one hour time step
     dt_ql_g = 3600.0
     # upstream boundary condition timestep = MC simulation time step (sec)
-    dt_ub_g = 300.0 
+    dt_ub_g = dt
     # tributary inflow timestep (sec) - currently, MC simulation time step = 5 min
-    dt_qtrib_g = 300.0
+    dt_qtrib_g = dt
     # usgs_df time step used for data assimilation. The original timestep of USGS streamflow is 15 min but later interpolated at every dt in min.
     dt_da_g = dt # [sec]
     # time interval at which flow and depth simulations are written out by Tulane diffusive model


### PR DESCRIPTION
The function that save outputs updated to be able to save in csv and pickle format. User just need to make change in yaml file to select the format

## Additions

- a function named `write_flowveldepth_csv_pkl` added that saves in csv and pickle formats

## Removals

-

## Changes

-

## Testing

1. Tested with different time frequency and compared with netcdf file

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
