### PR TITLE
Updates to handle problematic waterbody data

### DIFF
--- a/src/troute-network/troute/AbstractRouting.py
+++ b/src/troute-network/troute/AbstractRouting.py
@@ -4,6 +4,7 @@ import yaml
 import json
 import xarray as xr
 import pandas as pd
+from itertools import chain
 
 from troute.nhd_network import reverse_network, reachable
 from troute.nhd_network_utilities_v02 import organize_independent_networks, build_refac_connections
@@ -189,7 +190,8 @@ class MCwithDiffusive(AbstractRouting):
                 wbody_ids = waterbody_dataframe.index.tolist()
                 targets = targets + wbody_ids
                 links = list(reachable(rconn_diff0, sources=[tw], targets=targets).get(tw))
-                outlet_ids = [connections.get(id)[0] for id in wbody_ids]
+                outlet_ids = [connections.get(id) for id in wbody_ids]
+                outlet_ids = list(chain.from_iterable(outlet_ids))
                 wbody_and_outlet_ids = wbody_ids + outlet_ids
                 links = list(set(links).difference(set(wbody_and_outlet_ids)))
                 
@@ -241,7 +243,8 @@ class MCwithDiffusive(AbstractRouting):
             targets = self._diffusive_domain[tw]['targets'] + bad_links
             links = list(reachable(rconn_diff0, sources=[tw], targets=targets).get(tw))
             links = list(set(self._diffusive_domain[tw]['links']).intersection(set(links)))
-            outlet_ids = [connections.get(id)[0] for id in wbody_ids]
+            outlet_ids = [connections.get(id) for id in wbody_ids]
+            outlet_ids = list(chain.from_iterable(outlet_ids))
             wbody_and_outlet_ids = wbody_ids + outlet_ids + bad_links
             mainstem_segs = list(set(links).difference(set(wbody_and_outlet_ids)))
             

--- a/src/troute-nwm/src/nwm_routing/__main__.py
+++ b/src/troute-nwm/src/nwm_routing/__main__.py
@@ -259,6 +259,7 @@ def main_v04(argv):
             cpu_pool,
             network.waterbody_dataframe,
             network.waterbody_types_dataframe,
+            network._duplicate_ids_df,
             data_assimilation_parameters,
             data_assimilation.lastobs_df,
             network.link_gage_df,

--- a/src/troute-nwm/src/nwm_routing/__main__.py
+++ b/src/troute-nwm/src/nwm_routing/__main__.py
@@ -86,7 +86,8 @@ def main_v04(argv):
                                     hybrid_parameters,
                                     preprocessing_parameters,
                                     output_parameters,
-                                    verbose=True, showtiming=showtiming) 
+                                    verbose=True, showtiming=showtiming)
+        duplicate_ids_df = network._duplicate_ids_df
         
     elif supernetwork_parameters["network_type"] == 'NHDNetwork':
         network = NHDNetwork(supernetwork_parameters,
@@ -99,6 +100,7 @@ def main_v04(argv):
                              verbose=True,
                              showtiming=showtiming,          
                             )
+        duplicate_ids_df = pd.DataFrame()
     
     if showtiming:
         network_end_time = time.time()
@@ -259,7 +261,7 @@ def main_v04(argv):
             cpu_pool,
             network.waterbody_dataframe,
             network.waterbody_types_dataframe,
-            network._duplicate_ids_df,
+            duplicate_ids_df,
             data_assimilation_parameters,
             data_assimilation.lastobs_df,
             network.link_gage_df,

--- a/src/troute-nwm/src/nwm_routing/output.py
+++ b/src/troute-nwm/src/nwm_routing/output.py
@@ -154,9 +154,10 @@ def nwm_output_generator(
             wbdy = wbdy.loc[wbdy_id_list]
             
             # Replace synthetic waterbody IDs (made from duplicate IDs) with
-            # original waterbody IDs:
-            flow_df = flow_df.rename(index=dict(duplicate_ids_df[['synthetic_ids','lake_id']].values))
-            wbdy = wbdy.rename(index=dict(duplicate_ids_df[['synthetic_ids','lake_id']].values))
+            # original waterbody IDs (if duplicates exist):
+            if not duplicate_ids_df.empty:
+                flow_df = flow_df.rename(index=dict(duplicate_ids_df[['synthetic_ids','lake_id']].values))
+                wbdy = wbdy.rename(index=dict(duplicate_ids_df[['synthetic_ids','lake_id']].values))
 
             timestep, variable = zip(*flow_df.columns.tolist())
             timestep_index = np.where(((np.array(list(set(list(timestep)))) + 1) * dt) % (dt * qts_subdivisions) == 0)
@@ -227,8 +228,12 @@ def nwm_output_generator(
     if wbdyo and not waterbodies_df.empty:
         
         time_index, tmp_variable = map(list,zip(*i_df.columns.tolist()))
-        output_waterbodies_df = waterbodies_df.rename(index=dict(duplicate_ids_df[['synthetic_ids','lake_id']].values))
-        output_waterbody_types_df = waterbody_types_df.rename(index=dict(duplicate_ids_df[['synthetic_ids','lake_id']].values))
+        if not duplicate_ids_df.empty:
+            output_waterbodies_df = waterbodies_df.rename(index=dict(duplicate_ids_df[['synthetic_ids','lake_id']].values))
+            output_waterbody_types_df = waterbody_types_df.rename(index=dict(duplicate_ids_df[['synthetic_ids','lake_id']].values))
+        else:
+            output_waterbodies_df = waterbodies_df
+            output_waterbody_types_df = waterbody_types_df
         LOG.info("- writing t-route flow results to LAKEOUT files")
         start = time.time()
         for i in range(i_df.shape[1]):            

--- a/src/troute-nwm/src/nwm_routing/output.py
+++ b/src/troute-nwm/src/nwm_routing/output.py
@@ -59,6 +59,7 @@ def nwm_output_generator(
     cpu_pool,
     waterbodies_df,
     waterbody_types_df,
+    duplicate_ids_df,
     data_assimilation_parameters=False,
     lastobs_df = None,
     link_gage_df = None,
@@ -151,6 +152,11 @@ def nwm_output_generator(
             wbdy_id_list = waterbodies_df.index.values.tolist()
             flow_df = flowveldepth.loc[wbdy_id_list]
             wbdy = wbdy.loc[wbdy_id_list]
+            
+            # Replace synthetic waterbody IDs (made from duplicate IDs) with
+            # original waterbody IDs:
+            flow_df = flow_df.rename(index=dict(duplicate_ids_df[['synthetic_ids','lake_id']].values))
+            wbdy = wbdy.rename(index=dict(duplicate_ids_df[['synthetic_ids','lake_id']].values))
 
             timestep, variable = zip(*flow_df.columns.tolist())
             timestep_index = np.where(((np.array(list(set(list(timestep)))) + 1) * dt) % (dt * qts_subdivisions) == 0)
@@ -221,6 +227,8 @@ def nwm_output_generator(
     if wbdyo and not waterbodies_df.empty:
         
         time_index, tmp_variable = map(list,zip(*i_df.columns.tolist()))
+        output_waterbodies_df = waterbodies_df.rename(index=dict(duplicate_ids_df[['synthetic_ids','lake_id']].values))
+        output_waterbody_types_df = waterbody_types_df.rename(index=dict(duplicate_ids_df[['synthetic_ids','lake_id']].values))
         LOG.info("- writing t-route flow results to LAKEOUT files")
         start = time.time()
         for i in range(i_df.shape[1]):            
@@ -229,8 +237,8 @@ def nwm_output_generator(
                 i_df.iloc[:,[i]],
                 q_df.iloc[:,[i]],
                 d_df.iloc[:,[i]],
-                waterbodies_df,
-                waterbody_types_df,
+                output_waterbodies_df,
+                output_waterbody_types_df,
                 t0, 
                 dt, 
                 nts,


### PR DESCRIPTION
Two major updates:

1. Fix issue of duplicate integer IDs between some waterbodies and stream segments. We now add a large number to any duplicate waterbody ID initially, then revert back to the original ID before writing output files.
2. Some waterbodies have flowpaths that physically lie within them, but are not referenced to the waterbody ID. This causes issues when collapsing segment IDs into a single waterbody ID in our connections dictionary (multiple "downstream" IDs which violates the DAG). These waterbodies are simply "dropped" as waterbodies, meaning the underlying segments are used for MC routing.

## Additions

-

## Removals

-

## Changes
**AbstractRouting.py**
- Updates to finding outlet IDs of waterbodies. The old method became an issue for a waterbody in Florida that directly flows into the ocean.

**HYFeaturesNetwork.py**
- Update to `bandaid()` function to simply drop problematic waterbody IDs.
- Change fix for duplicate IDs. Old method added a large value to flowpath IDs, now it adds to waterbody IDs.
- Saves the duplicate_ids crosswalk dictionary to revert changes before producing output.

**output.py**
- Reverts duplicate ID changes.

**__main__.py**
- Passes `duplicate_ids` dictionary to output generator function.

## Testing

1. Successfully ran a dummy (unrealistic forcing inputs) CONUS run with waterbodies enabled.
2. Verified output files contain original IDs.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
