### PR TITLE
Update for usace issue

### DIFF
--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -1059,27 +1059,30 @@ def _read_timeslice_file(f):
         stns      = ds.variables['stationId'][:].filled(fill_value = np.nan)
         t         = ds.variables['time'][:].filled(fill_value = np.nan)
         qual      = ds.variables['discharge_quality'][:].filled(fill_value = np.nan)
+   
+    if discharge.size != 0 and stns.size != 0 and t.size != 0:        
+        stationId = np.apply_along_axis(''.join, 1, stns.astype(str))
+        time_str = np.apply_along_axis(''.join, 1, t.astype(str))
+        stationId = np.char.strip(stationId)
         
-    stationId = np.apply_along_axis(''.join, 1, stns.astype(str))
-    time_str = np.apply_along_axis(''.join, 1, t.astype(str))
-    stationId = np.char.strip(stationId)
-    
-    timeslice_observations = (pd.DataFrame({
-                                'stationId' : stationId,
-                                'datetime'  : time_str,
-                                'discharge' : discharge
-                            }).
-                             set_index(['stationId', 'datetime']).
-                             unstack(1, fill_value = np.nan)['discharge'])
-    
-    observation_quality = (pd.DataFrame({
-                                'stationId' : stationId,
-                                'datetime'  : time_str,
-                                'quality'   : qual/100
-                            }).
-                             set_index(['stationId', 'datetime']).
-                             unstack(1, fill_value = np.nan)['quality'])
-    
+        timeslice_observations = (pd.DataFrame({
+                                    'stationId' : stationId,
+                                    'datetime'  : time_str,
+                                    'discharge' : discharge
+                                }).
+                                set_index(['stationId', 'datetime']).
+                                unstack(1, fill_value = np.nan)['discharge'])
+        
+        observation_quality = (pd.DataFrame({
+                                    'stationId' : stationId,
+                                    'datetime'  : time_str,
+                                    'quality'   : qual/100
+                                }).
+                                set_index(['stationId', 'datetime']).
+                                unstack(1, fill_value = np.nan)['quality'])
+    else:
+        timeslice_observations = pd.DataFrame()
+        observation_quality = pd.DataFrame()
     return timeslice_observations, observation_quality
 
 def _interpolate_one(df, interpolation_limit, frequency):
@@ -1157,7 +1160,12 @@ def get_obs_from_timeslices(
         for f in timeslice_files:
             jobs.append(delayed(_read_timeslice_file)(f))
         timeslice_dataframes = parallel(jobs)
-        
+
+    all_empty = all(df.empty for tuple in timeslice_dataframes for df in tuple)
+    if all_empty:
+        LOG.debug(f'DataFrames in the list are empty.')
+        return pd.DataFrame()
+       
     # create lists of observations and obs quality dataframes returned 
     # from _read_timeslice_file
     timeslice_obs_frames = []

--- a/test/LowerColorado_TX_v4/test_AnA_V4_HYFeature.yaml
+++ b/test/LowerColorado_TX_v4/test_AnA_V4_HYFeature.yaml
@@ -98,7 +98,7 @@ compute_parameters:
     data_assimilation_parameters:
         #----------
         usgs_timeslices_folder   : usgs_timeslices/
-        usace_timeslices_folder  : usace_timelices/
+        usace_timeslices_folder  : usace_timeslices/
         streamflow_da:
             #----------
             streamflow_nudging            : True


### PR DESCRIPTION
in the config file `usace_timeslices_folder  : usace_timeslices/` the letter 's' was missing and that was causing the t-rout skip usace_timeslices folder. By adding 's' it would go through the folder but since the usace files are all empty it throw an error and couldn't process it. So the update in `nhd_io.py` checks if the size is zero then return empty dataframe

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
