### PR TITLE
Add tests for `troute.config.FilePath` and `troute.config.DirectoryPath`

### DIFF
--- a/src/troute-config/test/test_types.py
+++ b/src/troute-config/test/test_types.py
@@ -1,0 +1,99 @@
+from pathlib import Path
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from troute.config._utils import use_strict
+from troute.config.types import DirectoryPath, FilePath
+
+
+@pytest.mark.parametrize(
+    "file,expected",
+    (
+        ("some_file", Path("some_file")),
+        (Path("some_file"), Path("some_file")),
+    ),
+)
+def test_file_path(file, expected):
+    class Foo(BaseModel):
+        file: FilePath
+
+    o = Foo(file=file)
+    assert o.file == expected
+
+
+@pytest.mark.parametrize("file", (__file__, Path(__file__)))
+def test_file_path_use_strict(file):
+    class Foo(BaseModel):
+        file: FilePath
+
+    with use_strict():
+        o = Foo(file=file)
+        assert isinstance(o.file, Path)
+
+
+@pytest.mark.parametrize("file", ("some_fake_file", Path("some_fake_file")))
+def test_file_path_use_strict_raises(file):
+    assert not Path(file).exists(), "test expects file not to exist"
+
+    class Foo(BaseModel):
+        file: FilePath
+
+    with pytest.raises(ValidationError):
+        with use_strict():
+            Foo(file=file)
+
+
+@pytest.mark.parametrize(
+    "directory,expected",
+    (
+        ("some_dir", Path("some_dir")),
+        (Path("some_dir"), Path("some_dir")),
+    ),
+)
+def test_directory_path(directory, expected):
+    class Foo(BaseModel):
+        dir: DirectoryPath
+
+    o = Foo(dir=directory)
+    assert o.dir == expected
+
+
+MOD_DIR = Path(__file__).parent
+
+
+@pytest.mark.parametrize(
+    "directory",
+    (
+        str(MOD_DIR),
+        MOD_DIR,
+    ),
+)
+def test_directory_path_use_strict(directory):
+    assert Path(directory).is_dir(), "test expects dir to exist"
+
+    class Foo(BaseModel):
+        dir: DirectoryPath
+
+    with use_strict():
+        Foo(dir=directory)
+
+
+@pytest.mark.parametrize(
+    "directory",
+    (
+        "some_fake_dir",
+        Path("some_fake_dir"),
+    ),
+)
+def test_directory_path_use_strict_raises(directory):
+    assert (
+        not Path(directory).exists() and not Path(directory).is_dir()
+    ), "test expects dir not to exist"
+
+    class Foo(BaseModel):
+        dir: DirectoryPath
+
+    with pytest.raises(ValidationError):
+        with use_strict():
+            Foo(dir=directory)


### PR DESCRIPTION
`FilePath` and `DirectoryPath` build on pydantic's `FilePath` and `DirectoryPath` classes. Specifically, `troute.config`'s version of these classes unable using a "strict" mode (see committed tests for usage). The idea of strict mode is that in some contexts it is desirable to verify if a file or directory path exists. Likewise, in other contexts that is not desirable. "strict" mode enables the best of both worlds by effectively toggling if existence is verified.

To run the tests (assuming you've cloned the repo and you are in the repo root):

```shell
pip install 'src/troute-config[test]'
pytest src/troute-config
```
