### PR TITLE
fix for diffusive to run with synthetic and topo on NHD

### DIFF
--- a/src/troute-network/troute/AbstractNetwork.py
+++ b/src/troute-network/troute/AbstractNetwork.py
@@ -474,10 +474,10 @@ class AbstractNetwork(ABC):
         routing_type = [run_hybrid, use_topobathy, run_refactored]
 
         _routing_scheme_map = {
-            MCOnly: [False, False, False],
-            MCwithDiffusive: [True, False, False],
-            MCwithDiffusiveNatlXSectionNonRefactored: [True, True, False],
-            MCwithDiffusiveNatlXSectionRefactored: [True, True, True],
+            MCOnly: [[False, False, False]],
+            MCwithDiffusive: [[True, False, False],[True, True, False]],
+            MCwithDiffusiveNatlXSectionNonRefactored: [[True, True, False]],
+            MCwithDiffusiveNatlXSectionRefactored: [[True, True, True]],
             }
         
         # Default to MCOnly routing
@@ -485,9 +485,9 @@ class AbstractNetwork(ABC):
 
         # Check user input to determine the routing scheme
         for key, value in _routing_scheme_map.items():
-            if value==routing_type:
+            if routing_type in value:
                 routing_scheme = key
-        
+
         routing = routing_scheme(self.hybrid_parameters)
 
         (

--- a/src/troute-network/troute/AbstractNetwork.py
+++ b/src/troute-network/troute/AbstractNetwork.py
@@ -474,10 +474,10 @@ class AbstractNetwork(ABC):
         routing_type = [run_hybrid, use_topobathy, run_refactored]
 
         _routing_scheme_map = {
-            MCOnly: [[False, False, False]],
-            MCwithDiffusive: [[True, False, False],[True, True, False]],
-            MCwithDiffusiveNatlXSectionNonRefactored: [[True, True, False]],
-            MCwithDiffusiveNatlXSectionRefactored: [[True, True, True]],
+            MCOnly: [False, False, False],
+            MCwithDiffusive: [True, False, False],
+            MCwithDiffusiveNatlXSectionNonRefactored: [True, True, False],
+            MCwithDiffusiveNatlXSectionRefactored: [True, True, True],
             }
         
         # Default to MCOnly routing
@@ -485,7 +485,8 @@ class AbstractNetwork(ABC):
 
         # Check user input to determine the routing scheme
         for key, value in _routing_scheme_map.items():
-            if routing_type in value:
+            #if routing_type in value:
+            if value==routing_type:
                 routing_scheme = key
 
         routing = routing_scheme(self.hybrid_parameters)

--- a/src/troute-network/troute/AbstractRouting.py
+++ b/src/troute-network/troute/AbstractRouting.py
@@ -213,32 +213,34 @@ class MCwithDiffusive(AbstractRouting):
         self._diffusive_domain = diffusive_domain_all
         
         # Load topobathy data and remove any links for which topo data cannot be obtained
-        topobathy_df = self.topobathy_df
-        missing_topo_ids = list(set(all_links).difference(set(topobathy_df.index)))
-        topo_df_list = []
-        
-        for key in missing_topo_ids:
-            topo_df_list.append(_fill_in_missing_topo_data(key, dataframe, topobathy_df))
-        
-        if len(topo_df_list)==0: 
-            new_topo_df = pd.DataFrame() 
-        else:
-            new_topo_df = pd.concat(topo_df_list)
-
-        bad_links = list(set(missing_topo_ids).difference(set(new_topo_df.index)))
-        self._topobathy_df = pd.concat([self.topobathy_df,new_topo_df])
-        
-        # select topo data with minimum value of cs_id for each segment
-        df =  self._topobathy_df
-        min_cs_id=df.reset_index().groupby('hy_id')['cs_id'].transform('min')
-        mask = df.reset_index()['cs_id'] == min_cs_id
-        single_topo_df = df.reset_index()[mask]
-        single_topo_df.set_index('hy_id', inplace=True)
-        self._topobathy_df= single_topo_df
-           
-        for tw in self._diffusive_domain:
-            #mainstem_segs = self._diffusive_domain[tw]['links']
+        if self.hybrid_params['use_natl_xsections']:
+            topobathy_df = self.topobathy_df
+            missing_topo_ids = list(set(all_links).difference(set(topobathy_df.index)))
+            topo_df_list = []
             
+            for key in missing_topo_ids:
+                topo_df_list.append(_fill_in_missing_topo_data(key, dataframe, topobathy_df))
+            
+            if len(topo_df_list)==0: 
+                new_topo_df = pd.DataFrame() 
+            else:
+                new_topo_df = pd.concat(topo_df_list)
+
+            bad_links = list(set(missing_topo_ids).difference(set(new_topo_df.index)))
+            self._topobathy_df = pd.concat([self.topobathy_df,new_topo_df])
+            
+            # select topo data with minimum value of cs_id for each segment
+            df =  self._topobathy_df
+            min_cs_id=df.reset_index().groupby('hy_id')['cs_id'].transform('min')
+            mask = df.reset_index()['cs_id'] == min_cs_id
+            single_topo_df = df.reset_index()[mask]
+            single_topo_df.set_index('hy_id', inplace=True)
+            self._topobathy_df= single_topo_df
+        else:
+            # Use synthetic channel cross section data instead.
+            bad_links = []
+           
+        for tw in self._diffusive_domain:          
             wbody_ids = waterbody_dataframe.index.tolist()
             targets = self._diffusive_domain[tw]['targets'] + bad_links
             links = list(reachable(rconn_diff0, sources=[tw], targets=targets).get(tw))


### PR DESCRIPTION
routing_scheme_map in AbtractNetwork.py was updated to run diffusive when using channel topobathy data was turned off in the config yaml file.  Now when "run_hybrid_routing" and "use_natl_xsections" are True and False, respectively, t-route run MC+diffusive both with synthetic xsec data provided by RouteLink file.

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
