### PR TITLE
`pip>23.1` compliance

### DIFF
--- a/compiler.sh
+++ b/compiler.sh
@@ -87,8 +87,8 @@ if [[ "$build_framework" == true ]]; then
   rm -rf build
   ##python setup.py --use-cython install
   ##python setup.py --use-cython develop
-  CC=${CC} python setup.py build_ext --inplace --use-cython || exit
-  pip install $E . || exit
+  python setup.py build_ext --inplace --use-cython || exit
+  pip install --no-build-isolation $E . || exit
 fi
 
 if [[ "$build_routing" == true ]]; then
@@ -97,8 +97,8 @@ if [[ "$build_routing" == true ]]; then
   rm -rf build
   #python setup.py --use-cython install
   #python setup.py --use-cython develop
-  CC=${CC} python setup.py build_ext --inplace --use-cython || exit
-  pip install $E . || exit
+  python setup.py build_ext --inplace --use-cython || exit
+  pip install --no-build-isolation $E . || exit
 fi
 
 if [[ "$build_config" == true ]]; then

--- a/readme.md
+++ b/readme.md
@@ -84,7 +84,7 @@ To get a sense of the operation of the routing scheme, follow this sequence of c
 
 ```
 # install required python modules
-$ pip3 install numpy pandas xarray netcdf4 joblib toolz pyyaml Cython geopandas pyarrow deprecated
+$ pip3 install numpy pandas xarray netcdf4 joblib toolz pyyaml Cython geopandas pyarrow deprecated wheel
 
 # clone t-toute
 $ git clone --progress --single-branch --branch master http://github.com/NOAA-OWP/t-route.git

--- a/src/troute-network/pyproject.toml
+++ b/src/troute-network/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools", "numpy", "Cython<3.0.4", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "troute.network"
+version = "0.0.0"
+dependencies = [
+    "deprecated",
+    "geopandas",
+    "joblib",
+    "netcdf4",
+    "numpy",
+    "pandas",
+    "pyarrow",
+    "pyyaml",
+    "toolz",
+    "typing_extensions",
+    "xarray",
+]

--- a/src/troute-nwm/pyproject.toml
+++ b/src/troute-nwm/pyproject.toml
@@ -3,6 +3,6 @@ requires = [
     "setuptools>=42",
     "wheel",
     "pip",
-    "Cython"
+    "Cython<3.0.4"
 ]
 build-backend = "setuptools.build_meta"

--- a/src/troute-routing/pyproject.toml
+++ b/src/troute-routing/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = ["setuptools", "numpy", "Cython<3.0.4", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "troute.routing"
+version = "0.0.0"
+dependencies = ["hydrotools.nwis_client", "joblib", "numpy", "pandas", "xarray"]

--- a/src/troute-routing/troute/routing/compute.py
+++ b/src/troute-routing/troute/routing/compute.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
 from itertools import chain
 from functools import partial
-from tlz import concat
 from joblib import delayed, Parallel
 from datetime import datetime, timedelta
 import time


### PR DESCRIPTION
[`pip` `23.1`](https://pip.pypa.io/en/stable/news/#id80) changed the default behavior when the `wheel` package is not installed. `troute.network` and `troute.routing` both require `wheel` at build time and previously did not contain `pyproject.toml` files.

> When the `wheel` package is not installed, `pip` now uses the default build backend instead of `setup.py install` and `setup.py develop` for project without `pyproject.toml`. ([#8559](https://github.com/pypa/pip/issues/8559))

The PR addresses these issues and makes it possible to install `troute` using the latest `pip` version (`24.0`).

Fixes #621.