### PR TITLE
Add build dep `wheel` to `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+wheel
 numpy
 Cython<3.0.4
 pandas >=1.1.5, <=2.2.0


### PR DESCRIPTION
Should have added this in #780. This should fix [the CI docker image build failures](https://github.com/NOAA-OWP/t-route/actions/runs/9457679519/job/26051934655). 