### PR TITLE
style: improve `InvalidIndexError` error message

### DIFF
--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -11,6 +11,7 @@ from joblib import delayed, Parallel
 from collections import defaultdict
 import xarray as xr
 from datetime import datetime
+from pprint import pformat
 import os
 
 import troute.nhd_io as nhd_io #FIXME
@@ -688,6 +689,9 @@ class HYFeaturesNetwork(AbstractNetwork):
                 for f in qlat_files:
                     df = read_file(f)
                     df['feature_id'] = df['feature_id'].map(lambda x: int(str(x).removeprefix('nex-')) if str(x).startswith('nex') else int(x))
+                    assert df[
+                        "feature_id"
+                    ].is_unique, f"'feature_id's must be unique. '{f!s}' contains duplicate 'feature_id's: {pformat(df.loc[df['feature_id'].duplicated(), 'feature_id'].to_list())}"
                     df = df.set_index('feature_id')
                     dfs.append(df)
             


### PR DESCRIPTION
Assert a known unrecoverable condition and provide a more informative user error message. See #721 for more information.

Fixes #721

## `troute.network`

## Changes

- `troute.network` now raises an assertion error and provides an informative user error message when duplicate `feature_id`s are present in a NextGen catchment or nexus output file. (see #721).
