### PR TITLE
Remove check for existing parquet files

### DIFF
--- a/src/troute-network/troute/AbstractNetwork.py
+++ b/src/troute-network/troute/AbstractNetwork.py
@@ -751,9 +751,7 @@ class AbstractNetwork(ABC):
                 raise(RuntimeError("No output binary qlat folder supplied in config"))
             elif not os.path.exists(binary_folder):
                 raise(RuntimeError("Output binary qlat folder supplied in config does not exist"))
-            elif len(list(pathlib.Path(binary_folder).glob('*.parquet'))) != 0:
-                raise(RuntimeError("Output binary qlat folder supplied in config is not empty (already contains '.parquet' files)"))
-
+            
             #Add tnx for backwards compatability
             qlat_files_list = list(qlat_files) + list(qlat_input_folder.glob('tnx*.csv'))
             #Convert files to binary hourly files, reset nexus input information


### PR DESCRIPTION
Remove raising an error if parquet files already exist in the provided binary_folder.

## Additions

-

## Removals
**AbstractNetwork.py**
- `elif` check for existence of parquet files, which would then raise an error.

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
