### PR TITLE
save in one file

### DIFF
--- a/src/troute-config/troute/config/output_parameters.py
+++ b/src/troute-config/troute/config/output_parameters.py
@@ -27,7 +27,7 @@ class OutputParameters(BaseModel):
     # NOTE: assuming this should be removed
     # TODO: missing from `v3_doc.yaml`
     # see nwm_routing/output.py :114
-    test_output: Optional[FilePath] = None
+    test_output: Optional[Path] = None
     stream_output: Optional["StreamOutput"] = None
     # NOTE: mandatory if writing results to lastobs
     lastobs_output: Optional[DirectoryPath] = None

--- a/src/troute-config/troute/config/output_parameters.py
+++ b/src/troute-config/troute/config/output_parameters.py
@@ -90,7 +90,7 @@ class StreamOutput(BaseModel):
         if value is not None:
             if value % 5 != 0:
                 raise ValueError("stream_output_internal_frequency must be a multiple of 5.")
-            if value / 60 > values['stream_output_time']:
+            if values.get('stream_output_time') != -1 and value / 60 > values['stream_output_time']:
                 raise ValueError("stream_output_internal_frequency should be less than or equal to stream_output_time in minutes.")
         return value
  

--- a/src/troute-network/troute/AbstractNetwork.py
+++ b/src/troute-network/troute/AbstractNetwork.py
@@ -833,7 +833,7 @@ class AbstractNetwork(ABC):
             if stream_output:
                 stream_output_time = stream_output.get('stream_output_time', None)
                 if stream_output_time and stream_output_time > max_loop_size:
-                    nfiles = stream_output_time // (nts // 12)
+                    max_loop_size = stream_output_time
             # list of forcing file datetimes
             #datetime_list = [t0 + dt_qlat_timedelta * (n + 1) for n in
             #                 range(nfiles)]

--- a/src/troute-network/troute/AbstractNetwork.py
+++ b/src/troute-network/troute/AbstractNetwork.py
@@ -725,7 +725,7 @@ class AbstractNetwork(ABC):
 
         forcing_parameters = self.forcing_parameters
         supernetwork_parameters = self.supernetwork_parameters
-
+        stream_output = self.output_parameters.get('stream_output', None)
         run_sets           = forcing_parameters.get("qlat_forcing_sets", None)
         qlat_input_folder  = forcing_parameters.get("qlat_input_folder", None)
         nts                = forcing_parameters.get("nts", None)
@@ -830,7 +830,10 @@ class AbstractNetwork(ABC):
 
             # the number of files required for the simulation
             nfiles = int(np.ceil(nts / qts_subdivisions))
-            
+            if stream_output:
+                stream_output_time = stream_output.get('stream_output_time', None)
+                if stream_output_time and stream_output_time > max_loop_size:
+                    nfiles = stream_output_time // (nts // 12)
             # list of forcing file datetimes
             #datetime_list = [t0 + dt_qlat_timedelta * (n + 1) for n in
             #                 range(nfiles)]

--- a/src/troute-network/troute/NHDNetwork.py
+++ b/src/troute-network/troute/NHDNetwork.py
@@ -27,7 +27,8 @@ class NHDNetwork(AbstractNetwork):
                 forcing_parameters, 
                 compute_parameters, 
                 data_assimilation_parameters, 
-                hybrid_parameters, 
+                hybrid_parameters,
+                output_parameters, 
                 verbose=False, 
                 showtiming=False,
                 ):
@@ -41,6 +42,7 @@ class NHDNetwork(AbstractNetwork):
         self.compute_parameters = compute_parameters
         self.forcing_parameters = forcing_parameters
         self.hybrid_parameters = hybrid_parameters
+        self.output_parameters = output_parameters
         self.verbose = verbose
         self.showtiming = showtiming
 

--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -2171,7 +2171,7 @@ def write_flowveldepth(
     nudge_df = pd.concat([nudge_df, empty_df]).loc[flowveldepth.index]
     file_name_time = t0
     jobs = []
-    import pdb;pdb.set_trace()
+    
     if stream_output_timediff > 0:
         ts_per_file = stream_output_timediff*60//stream_output_internal_frequency
         
@@ -2209,10 +2209,10 @@ def write_flowveldepth(
      
         filename = 'troute_output_' + file_name_time.strftime('%Y%m%d%H%M') + stream_output_type
         args = (stream_output_directory,filename,
-                flow.iloc,
-                velocity.iloc,
-                depth.iloc,
-                nudge_df.iloc,
+                flow,
+                velocity,
+                depth,
+                nudge_df,
                 timestamps_sec,
                 t0)
         if stream_output_type == '.nc':

--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -2169,42 +2169,64 @@ def write_flowveldepth(
     empty_ids = list(set(flowveldepth.index).difference(set(nudge_df.index)))
     empty_df = pd.DataFrame(index=empty_ids, columns=nudge_df.columns).fillna(-9999.0)
     nudge_df = pd.concat([nudge_df, empty_df]).loc[flowveldepth.index]
-    
-    ts_per_file = stream_output_timediff*60//stream_output_internal_frequency
-    
-    num_files = flowveldepth.shape[1]//3*dt//(stream_output_timediff*60*60)
-    if num_files==0:
-        num_files=1
-
     file_name_time = t0
     jobs = []
-    for _ in range(num_files):
+    import pdb;pdb.set_trace()
+    if stream_output_timediff > 0:
+        ts_per_file = stream_output_timediff*60//stream_output_internal_frequency
+        
+        num_files = flowveldepth.shape[1]//3*dt//(stream_output_timediff*60*60)
+        if num_files==0:
+            num_files=1
+        
+        for _ in range(num_files):
+            filename = 'troute_output_' + file_name_time.strftime('%Y%m%d%H%M') + stream_output_type
+            args = (stream_output_directory,filename,
+                    flow.iloc[:,0:ts_per_file],
+                    velocity.iloc[:,0:ts_per_file],
+                    depth.iloc[:,0:ts_per_file],
+                    nudge_df.iloc[:,0:ts_per_file],
+                    timestamps_sec[0:ts_per_file],t0)
+            if stream_output_type == '.nc':
+                if cpu_pool > 1 & num_files > 1:
+                    jobs.append(delayed(write_flowveldepth_netcdf)(*args))
+                else:
+                    write_flowveldepth_netcdf(*args)
+            else:
+                if cpu_pool > 1 & num_files > 1:
+                    jobs.append(delayed(write_flowveldepth_csv_pkl)(*args))
+                else:
+                    write_flowveldepth_csv_pkl(*args)
+
+            flow = flow.iloc[:,ts_per_file:]
+            velocity = velocity.iloc[:,ts_per_file:]
+            depth = depth.iloc[:,ts_per_file:]
+            nudge_df = nudge_df.iloc[:,ts_per_file:]
+            timestamps_sec = timestamps_sec[ts_per_file:]
+            file_name_time = file_name_time + timedelta(hours=stream_output_timediff)
+    
+    elif stream_output_timediff == -1:
+     
         filename = 'troute_output_' + file_name_time.strftime('%Y%m%d%H%M') + stream_output_type
         args = (stream_output_directory,filename,
-                flow.iloc[:,0:ts_per_file],
-                velocity.iloc[:,0:ts_per_file],
-                depth.iloc[:,0:ts_per_file],
-                nudge_df.iloc[:,0:ts_per_file],
-                timestamps_sec[0:ts_per_file],t0)
+                flow.iloc,
+                velocity.iloc,
+                depth.iloc,
+                nudge_df.iloc,
+                timestamps_sec,
+                t0)
         if stream_output_type == '.nc':
-            if cpu_pool > 1 & num_files > 1:
+            if cpu_pool > 1:
                 jobs.append(delayed(write_flowveldepth_netcdf)(*args))
             else:
                 write_flowveldepth_netcdf(*args)
         else:
-            if cpu_pool > 1 & num_files > 1:
+            if cpu_pool > 1:
                 jobs.append(delayed(write_flowveldepth_csv_pkl)(*args))
             else:
                 write_flowveldepth_csv_pkl(*args)
 
-        flow = flow.iloc[:,ts_per_file:]
-        velocity = velocity.iloc[:,ts_per_file:]
-        depth = depth.iloc[:,ts_per_file:]
-        nudge_df = nudge_df.iloc[:,ts_per_file:]
-        timestamps_sec = timestamps_sec[ts_per_file:]
-        file_name_time = file_name_time + timedelta(hours=stream_output_timediff)
-    
-    if cpu_pool > 1 & num_files > 1:
+    if cpu_pool > 1:
         try:
             # Execute all jobs in parallel
             with Parallel(n_jobs=cpu_pool) as parallel:

--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -2013,7 +2013,7 @@ def write_flowveldepth_netcdf(stream_output_directory, file_name,
         # =========== time VARIABLE ===============
         TIME = ncfile.createVariable(
             varname = "time",
-            datatype = 'int32',
+            datatype = 'float64',
             dimensions = ("time",),
             fill_value = -9999.0
         )
@@ -2022,7 +2022,7 @@ def write_flowveldepth_netcdf(stream_output_directory, file_name,
             {
                 'long_name': 'valid output time',
                 'standard_name': 'time',
-                'units': 'seconds',
+                'units': f'seconds since {t0.strftime("%Y-%m-%d %H:%M:%S")}',
                 'missing_value': -9999.0
                 #'calendar': 'proleptic_gregorian'
             }

--- a/src/troute-nwm/src/nwm_routing/__main__.py
+++ b/src/troute-nwm/src/nwm_routing/__main__.py
@@ -100,6 +100,7 @@ def main_v04(argv):
                              compute_parameters,
                              data_assimilation_parameters,
                              hybrid_parameters,
+                             output_parameters,
                              verbose=True,
                              showtiming=showtiming,          
                             )

--- a/src/troute-nwm/src/nwm_routing/output.py
+++ b/src/troute-nwm/src/nwm_routing/output.py
@@ -462,8 +462,8 @@ def nwm_output_generator(
             LOG.debug("writing lastobs files took %s seconds." % (time.time() - start))
 
 
-    if 'flowveldepth' in locals():
-        LOG.debug(flowveldepth)
+    # if 'flowveldepth' in locals():
+    #     LOG.debug(flowveldepth)
 
     LOG.debug("output complete in %s seconds." % (time.time() - start_time))
 

--- a/test/LowerColorado_TX_v4/test_AnA_V4_HYFeature.yaml
+++ b/test/LowerColorado_TX_v4/test_AnA_V4_HYFeature.yaml
@@ -123,12 +123,12 @@ compute_parameters:
 #--------------------------------------------------------------------------------
 # output_parameters:
 #     #----------
-#      test_output : output/lcr_flowveldepth.pkl
-#      lite_restart:
+#     test_output : output/lcr_flowveldepth.pkl
+#     lite_restart:
 #         #----------
 #         lite_restart_output_directory: restart/
-#      lakeout_output: lakeout/
-#      lastobs_output: lastobs/
+#     lakeout_output: lakeout/
+#     lastobs_output: lastobs/
 #     stream_output : 
 #         stream_output_directory: output/
 #         stream_output_time: 1 #[hr] ** Consider `stream_output_time = -1` means save everything in one file **

--- a/test/LowerColorado_TX_v4/test_AnA_V4_HYFeature.yaml
+++ b/test/LowerColorado_TX_v4/test_AnA_V4_HYFeature.yaml
@@ -131,7 +131,7 @@ compute_parameters:
 #      lastobs_output: lastobs/
 #     stream_output : 
 #         stream_output_directory: output/
-#         stream_output_time: 1 #[hr]
+#         stream_output_time: 1 #[hr] ** Consider `stream_output_time = -1` means save everything in one file **
 #         stream_output_type: '.nc' #please select only between netcdf '.nc' or '.csv' or '.pkl'
 #         stream_output_internal_frequency: 60 #[min] it should be order of 5 minutes. For instance if you want to output every hour put 60    
 


### PR DESCRIPTION
1- By putting `stream_output_time : -1` means it will save all data in one file without considering `max_loop_size`.

2- Also there was a bug in the code that when `max_loop_size` is less than `nts` in the second loop it was giving error that some lake_id can't be found. There was an error in `DataAssimilation` that fixed.

3- If the `stream_output_time` is greater than `max_loop_size` the code was not making correct output, the issue fixed.

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
