### PR TITLE
feat(docs): add CLI tool for generating troute config documentation from source

### DIFF
--- a/doc/util/gen_config_docs.py
+++ b/doc/util/gen_config_docs.py
@@ -1,0 +1,336 @@
+'''
+Generate documentation from a pydantic model's type hints and field docstrings
+in yaml or json format. Requires 'pydantic'.
+
+Example:
+    # foo.py
+    from pydantic import BaseModel
+
+    class Bar(BaseModel):
+        baz: int
+        """
+        The baz field holds the number of quox in the observable universe.
+        """
+
+    # from command line
+    python gen_config_docs.py foo.Bar
+    # The baz field holds the number of quox in the observable universe.
+    baz: int
+'''
+
+from __future__ import annotations
+
+import argparse
+import ast
+import dataclasses
+import inspect
+import itertools
+import typing
+
+import pydantic
+
+
+@dataclasses.dataclass
+class Field:
+    name: str
+    annotation: str
+    default: str | None = None
+    docstring: str | None = None
+
+
+@dataclasses.dataclass
+class PydanticField:
+    field: Field
+    fields: list[Field | PydanticField] = dataclasses.field(default_factory=list)
+
+
+def assert_never(arg: typing.Never):
+    raise AssertionError(f"Expected code to be unreachable, but got: {arg}")
+
+
+def format_attribute(attr: ast.Attribute) -> str:
+    if type(attr.value) == ast.Name:
+        return f"{attr.value.id}.{attr.attr}"
+    return attr.attr
+
+
+def format_fn(fn: ast.Call) -> str:
+    name = format_annotation(fn.func)
+    args = [format_annotation(arg) for arg in fn.args]
+    kwargs = [f"{kw.arg}={format_annotation(kw.value)}" for kw in fn.keywords]
+    return f"{name}({', '.join(itertools.chain(args, kwargs))})"
+
+
+def format_unary(val: ast.UnaryOp) -> str:
+    if type(val.op) == ast.UAdd:
+        op = "+"
+    elif type(val.op) == ast.USub:
+        op = "-"
+    else:
+        assert_never(type(val))
+    assert type(val.operand) == ast.Constant
+    return f"{op}{val.operand.value}"
+
+
+def format_annotation(
+    sub: (
+        ast.Name
+        | ast.Attribute
+        | ast.Constant
+        | ast.Tuple
+        | ast.Call
+        | ast.UnaryOp
+        | ast.Lambda
+    ),
+) -> str:
+    if type(sub) == ast.Name:
+        return sub.id
+    elif type(sub) == ast.Attribute:
+        return format_attribute(sub)
+    elif type(sub) == ast.Constant:
+        return repr(sub.value)
+    elif type(sub) == ast.UnaryOp:
+        return format_unary(sub)
+    elif type(sub) == ast.Subscript:
+        return format_subscript(sub)
+    elif type(sub) == ast.Call:
+        return format_fn(sub)
+    if type(sub) == ast.Lambda:
+        # TODO: this could be improved
+        return "lambda"
+    elif type(sub) == ast.Tuple:
+        return f"{', '.join([format_annotation(el) for el in sub.elts])}"
+
+    import astpretty
+
+    astpretty.pprint(sub)
+    assert_never(type(sub))
+
+
+def format_subscript(sub: ast.Subscript) -> str:
+    if type(sub.value) == ast.Name:
+        attr = sub.value.id
+    elif type(sub.value) == ast.Attribute:
+        attr = format_attribute(sub.value)
+    elif type(sub.value) == ast.Constant:
+        attr = sub.value
+    else:
+        assert_never(sub.value)
+    return f"{attr}[{format_annotation(sub.slice)}]"
+
+
+def is_pydantic_subtype(node: ast.ClassDef) -> bool:
+    def predicate(node: ast.Name | ast.Attribute | ast.expr) -> bool:
+        if type(node) == ast.Name and "BaseModel" in node.id:
+            return True
+        elif type(node) == ast.Attribute and "BaseModel" in node.attr:
+            return True
+        return False
+
+    return any([b for b in node.bases if predicate(b)])
+
+
+class NodeVisitor(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.models: dict[str, list[Field]] = {}
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> typing.Any:
+        if is_pydantic_subtype(node):
+            fields = []
+            for i, item in enumerate(node.body):
+                item = node.body[i]
+                if type(item) != ast.AnnAssign:
+                    continue
+                name = item.target.id
+                ann = format_annotation(item.annotation)
+                default = format_annotation(item.value) if item.value else None
+                if i + 1 < len(node.body) and type(node.body[i + 1]) == ast.Expr:
+                    doc = node.body[i + 1].value.value
+                else:
+                    doc = None
+                fields.append(Field(name, ann, default, doc))
+            self.models[node.name] = fields
+
+        self.generic_visit(node)
+
+
+T = typing.TypeVar("T", covariant=True)
+
+
+def first(l: list[T], pred: typing.Callable[[T], bool]) -> int:
+    for i, item in enumerate(l):
+        if pred(item):
+            return i
+    return -1
+
+
+def get_model_fields(
+    model: pydantic.BaseModel,
+) -> list[Field | PydanticField]:
+    nv = NodeVisitor()
+    try:
+        nv.visit(ast.parse(inspect.getsource(model)))
+    except AssertionError as e:
+        print(f"model: {model.__module__}.{model.__name__}")
+        raise e
+    fields = nv.models[model.__name__]
+    for field in model.__fields__.values():
+        # TODO: test with future annotations
+        type_ = field.type_ if hasattr(field, "type_") else field.annotation
+        if inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
+            idx = first(fields, lambda f: isinstance(f, Field) and f.name == field.name)
+            assert idx != -1
+            subfields = get_model_fields(field.type_)
+            fields[idx] = PydanticField(fields[idx], subfields)
+    return fields
+
+
+def pretty_print(l: list[Field | PydanticField], indent: str = ""):
+    for item in l:
+        if isinstance(item, Field):
+            print(f"{indent}{item}")
+        else:
+            print(f"{indent}{item.field.name}: {item.field.annotation}")
+            pretty_print(item.fields, indent + " " * 2)
+
+
+def json_print(l: list[Field | PydanticField], indent: str = ""):
+    for item in l:
+        if isinstance(item, Field):
+            if item.docstring is not None:
+                docstring = item.docstring.strip().replace("\n", "\n# ")
+                print(f"{indent}# {docstring}")
+            print(f"{indent}{item.name}: {item.annotation}")
+        else:
+            if item.field.docstring is not None:
+                docstring = item.field.docstring.strip().replace("\n", "\n# ")
+                print(f"{indent}# {docstring}")
+            print(f"{indent}{item.field.name}: {item.field.annotation}")
+            json_print(item.fields, indent + " " * 2)
+
+
+class DictField(typing.TypedDict):
+    type: str
+    docs: str | None
+
+
+class DictFields(typing.TypedDict):
+    type: str
+    docs: str | None
+    fields: dict[str, DictField | DictFields]
+
+
+def field_as_dict(field: Field) -> dict[str, DictField]:
+    return {
+        field.name: {
+            "type": field.annotation,
+            "docs": field.docstring,
+        }
+    }
+
+
+def pydantic_field_as_dict(field: PydanticField) -> dict[str, DictFields]:
+    fields = {}
+    for f in field.fields:
+        fields.update(as_dict(f))
+
+    return {
+        field.field.name: {
+            "type": field.field.annotation,
+            "docs": field.field.docstring,
+            "fields": fields,
+        }
+    }
+
+
+def as_dict(
+    field: Field | PydanticField,
+) -> dict[str, DictField] | dict[str, DictFields]:
+    if type(field) == Field:
+        return field_as_dict(field)
+    elif type(field) == PydanticField:
+        return pydantic_field_as_dict(field)
+
+    assert_never(type(field))
+
+
+def print_json(fields: list[PydanticField | Field]):
+    dict_fields = {}
+    for f in fields:
+        dict_fields.update(as_dict(f))
+
+    import json
+
+    print(json.dumps(dict_fields, indent=2))
+
+
+def print_ast(o: object) -> None:
+    tree = ast.parse(inspect.getsource(o))
+    import astpretty
+
+    astpretty.pprint(tree)
+
+
+def _print_yaml_docstring(docstring: str, indent: str):
+    docstring = docstring.strip().replace("\n", "\n# ")
+    print(f"{indent}# {docstring}")
+
+
+def _print_yaml_field(field: Field, indent: str):
+    default = f" = {field.default}" if field.default else ""
+    print(f"{indent}{field.name}: {field.annotation}{default}")
+
+
+def print_yaml(l: list[Field | PydanticField], indent: str = ""):
+    for item in l:
+        if isinstance(item, Field):
+            if item.docstring is not None:
+                _print_yaml_docstring(item.docstring, indent)
+            _print_yaml_field(item, indent)
+        else:
+            if item.field.docstring is not None:
+                _print_yaml_docstring(item.field.docstring, indent)
+            _print_yaml_field(item.field, indent)
+            print_yaml(item.fields, indent + " " * 2)
+
+
+def import_model(model_name: str) -> pydantic.BaseModel:
+    import importlib
+
+    module, model = model_name.rsplit(".", 1)
+    mod = importlib.import_module(module)
+    model: pydantic.BaseModel = getattr(mod, model)
+
+    assert issubclass(model, pydantic.BaseModel)
+    return model
+
+
+def main() -> int:
+    description = "Generate a pydantic model's documentation using its type hints and field docstrings"
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument(
+        "model", nargs=1, help="python formatted import path to pydantic model"
+    )
+    parser.add_argument(
+        "--ast",
+        action="store_true",
+        help="output abstract syntax tree (requires 'astpretty' library)",
+    )
+    parser.add_argument("--json", action="store_true", help="use json format")
+    args = parser.parse_args()
+
+    model = import_model(args.model[0])
+    if args.ast:
+        print_ast(model)
+        return 0
+
+    fields = get_model_fields(model)
+    if args.json:
+        print_json(fields)
+    else:
+        print_yaml(fields)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds a CLI script that generates documentation in yaml format from a `pydantic` model (e.g. `troute.config.Config`). A field's name, type annotation, and "docstring" will be used to generate the documentation. Example:

```python
# foo.py
from pydantic import BaseModel

class Bar(BaseModel):
    baz: int
    """
    The baz field holds the number of quox in the observable universe.
    """
```

```shell
python gen_config_docs.py foo.Bar

# The baz field holds the number of quox in the observable universe.
baz: int
```

I've verified that this tool works to generate documentation for `troute.config.Config`. Hopefully, this will remove some of the burden in writing up documentation 😃!


<details><summary><code>python gen_config_docs.py troute.config.Config</code> output</summary>

Note, at the moment there are not doc strings on fields, so no rich documentation is generated.


```shell
log_parameters: LoggingParameters = Field(default_factory=LoggingParameters)
  showtiming: Optional[bool] = None
  log_level: Optional[str] = None
  log_directory: Optional[str] = None
network_topology_parameters: Optional[NetworkTopologyParameters] = None
  preprocessing_parameters: 'PreprocessingParameters' = Field(default_factory=dict)
    preprocess_only: bool = False
    preprocess_output_folder: Optional[DirectoryPath] = None
    preprocess_output_filename: str = 'preprocess_output'
    use_preprocessed_data: bool = False
    preprocess_source_file: Optional[FilePath] = None
  supernetwork_parameters: 'SupernetworkParameters'
    title_string: Optional[str] = None
    geo_file_path: FilePath
    network_type: Literal['HYFeaturesNetwork', 'NHDNetwork'] = 'HYFeaturesNetwork'
    flowpath_edge_list: Optional[str] = None
    mask_file_path: Optional[FilePath] = None
    mask_layer_string: str = ''
    mask_driver_string: Optional[str] = None
    mask_key: int = 0
    columns: Optional['Columns'] = None
      key: str
      downstream: str
      dx: str
      n: str
      ncc: str
      s0: str
      bw: str
      waterbody: Optional[str]
      tw: str
      twcc: str
      alt: Optional[str]
      musk: str
      musx: str
      cs: str
      gages: Optional[str]
      mainstem: Optional[str]
    synthetic_wb_segments: Optional[List[int]] = Field(default_factory=lambda)
    synthetic_wb_id_offset: float = 999000000000.0
    terminal_code: int = 0
    driver_string: Union[str, Literal['NetCDF']] = 'NetCDF'
    layer_string: int = 0
  waterbody_parameters: 'WaterbodyParameters' = Field(default_factory=dict)
    break_network_at_waterbodies: bool = False
    level_pool: Optional['LevelPool'] = None
      level_pool_waterbody_parameter_file_path: Optional[FilePath] = None
      level_pool_waterbody_id: Union[str, Literal['lake_id']] = 'lake_id'
    waterbody_null_code: int = -9999
compute_parameters: ComputeParameters = Field(default_factory=dict)
  parallel_compute_method: ParallelComputeMethod = 'by-network'
  compute_kernel: ComputeKernel = 'V02-structured'
  assume_short_ts: bool = False
  subnetwork_target_size: int = 10000
  cpu_pool: Optional[int] = 1
  return_courant: bool = False
  restart_parameters: 'RestartParameters' = Field(default_factory=dict)
    start_datetime: Optional[datetime] = None
    lite_channel_restart_file: Optional[FilePath] = None
    lite_waterbody_restart_file: Optional[FilePath] = None
    wrf_hydro_channel_restart_file: Optional[FilePath] = None
    wrf_hydro_channel_ID_crosswalk_file: Optional[FilePath] = None
    wrf_hydro_channel_ID_crosswalk_file_field_name: Optional[str] = None
    wrf_hydro_channel_restart_upstream_flow_field_name: Optional[str] = None
    wrf_hydro_channel_restart_downstream_flow_field_name: Optional[str] = None
    wrf_hydro_channel_restart_depth_flow_field_name: Optional[str] = None
    wrf_hydro_waterbody_restart_file: Optional[FilePath] = None
    wrf_hydro_waterbody_ID_crosswalk_file: Optional[FilePath] = None
    wrf_hydro_waterbody_ID_crosswalk_file_field_name: Optional[str] = None
    wrf_hydro_waterbody_crosswalk_filter_file: Optional[FilePath] = None
    wrf_hydro_waterbody_crosswalk_filter_file_field_name: Optional[str] = None
    hyfeature_channel_restart_file: Optional[FilePath] = None
  hybrid_parameters: 'HybridParameters' = Field(default_factory=dict)
    run_hybrid_routing: bool = False
    diffusive_domain: Optional[FilePath] = None
    use_natl_xsections: bool = False
    topobathy_domain: Optional[FilePath] = None
    run_refactored_network: bool = False
    refactored_domain: Optional[FilePath] = None
    refactored_topobathy_domain: Optional[FilePath] = None
    coastal_boundary_domain: Optional[FilePath] = None
  forcing_parameters: 'ForcingParameters' = Field(default_factory=dict)
    qts_subdivisions: int = 12
    dt: int = 300
    qlat_input_folder: Optional[DirectoryPath] = None
    nts: Optional[int] = 288
    max_loop_size: int = 24
    qlat_file_index_col: str = 'feature_id'
    qlat_file_value_col: str = 'q_lateral'
    qlat_file_gw_bucket_flux_col: str = 'qBucket'
    qlat_file_terrain_runoff_col: str = 'qSfcLatRunoff'
    qlat_file_pattern_filter: Optional[str] = '*NEXOUT'
    qlat_forcing_sets: Optional[List[QLateralForcingSet]] = None
      nts: 'QLateralFiles'
        qlat_files: List[FilePath]
    binary_nexus_file_folder: Optional[DirectoryPath] = None
    coastal_boundary_input_file: Optional[FilePath] = None
  data_assimilation_parameters: 'DataAssimilationParameters' = Field(default_factory=dict)
    usgs_timeslices_folder: Optional[DirectoryPath] = None
    usace_timeslices_folder: Optional[DirectoryPath] = None
    canada_timeslices_folder: Optional[DirectoryPath] = None
    LakeOntario_outflow: Optional[FilePath] = None
    timeslice_lookback_hours: int = 24
    interpolation_limit_min: int = 59
    wrf_hydro_lastobs_lead_time_relative_to_simulation_start_time: int = 0
    wrf_lastobs_type: str = 'obs-based'
    streamflow_da: StreamflowDA = None
      streamflow_nudging: bool = False
      gage_segID_crosswalk_file: Optional[FilePath] = None
      crosswalk_gage_field: Optional[str] = 'gages'
      crosswalk_segID_field: Optional[str] = 'link'
      lastobs_file: Optional[FilePath] = None
      diffusive_streamflow_nudging: bool = False
    reservoir_da: Optional[ReservoirDA] = None
      reservoir_persistence_da: Optional[ReservoirPersistenceDA] = None
        reservoir_persistence_usgs: bool = False
        reservoir_persistence_usace: bool = False
        reservoir_persistence_greatLake: bool = False
        crosswalk_usgs_gage_field: str = 'usgs_gage_id'
        crosswalk_usace_gage_field: str = 'usace_gage_id'
        crosswalk_usgs_lakeID_field: str = 'usgs_lake_id'
        crosswalk_usace_lakeID_field: str = 'usace_lake_id'
      reservoir_rfc_da: Optional[ReservoirRfcParameters] = None
        reservoir_rfc_forecasts: bool = False
        reservoir_rfc_forecasts_time_series_path: Optional[DirectoryPath] = None
        reservoir_rfc_forecasts_lookback_hours: int = 28
        reservoir_rfc_forecasts_offset_hours: int = 28
        reservoir_rfc_forecast_persist_days: int = 11
      reservoir_parameter_file: Optional[FilePath] = None
    qc_threshold: float = Field(1, ge=0, le=1)
output_parameters: OutputParameters = Field(default_factory=dict)
  chanobs_output: Optional['ChanobsOutput'] = None
    chanobs_output_directory: Optional[DirectoryPath] = None
    chanobs_filepath: Optional[FilePath] = None
  csv_output: Optional['CsvOutput'] = None
    csv_output_folder: Optional[DirectoryPath] = None
    csv_output_segments: Optional[List[str]] = None
  chrtout_output: Optional['ChrtoutOutput'] = None
    wrf_hydro_channel_output_source_folder: Optional[DirectoryPath] = None
  lite_restart: Optional['LiteRestart'] = None
    lite_restart_output_directory: Optional[DirectoryPath] = None
  hydro_rst_output: Optional['HydroRstOutput'] = None
    wrf_hydro_restart_dir: Optional[DirectoryPath] = None
    wrf_hydro_channel_restart_pattern_filter: str = 'HYDRO_RST.*'
    wrf_hydro_channel_restart_source_directory: Optional[DirectoryPath] = None
    wrf_hydro_channel_output_source_folder: Optional[DirectoryPath] = None
  wrf_hydro_parity_check: Optional['WrfHydroParityCheck'] = None
    parity_check_input_folder: Optional[DirectoryPath] = None
    parity_check_file_index_col: str
    parity_check_file_value_col: str
    parity_check_compare_node: str
    parity_check_compare_file_sets: Optional[List['ParityCheckCompareFileSet']] = None
      validation_files: List[FilePath]
  lakeout_output: Optional[DirectoryPath] = None
  test_output: Optional[FilePath] = None
  stream_output: Optional['StreamOutput'] = None
    stream_output_directory: Optional[DirectoryPath] = None
    stream_output_time: int = 1
    stream_output_type: streamOutput_allowedTypes = '.nc'
    stream_output_internal_frequency: Annotated[int, Field(strict=True, ge=5)] = 5
  lastobs_output: Optional[DirectoryPath] = None
bmi_parameters: Optional[BMIParameters] = None
  flowpath_columns: Optional[List[str]] = Field(default_factory=lambda)
  attributes_columns: Optional[List[str]] = Field(default_factory=lambda)
  waterbody_columns: Optional[List[str]] = Field(default_factory=lambda)
  network_columns: Optional[List[str]] = Field(default_factory=lambda)
```

</details>