### PR TITLE
Fix #793: `chanobs_filepath` does not need to exist at startup

### DIFF
--- a/src/troute-config/troute/config/__init__.py
+++ b/src/troute-config/troute/config/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.0.1"
+__version__ = "0.0.2"
 
 from .config import Config

--- a/src/troute-config/troute/config/output_parameters.py
+++ b/src/troute-config/troute/config/output_parameters.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field, conint, validator, confloat
+from pydantic import BaseModel, Field, validator
 
 from typing import Optional, List
 from typing_extensions import Annotated, Literal

--- a/src/troute-config/troute/config/output_parameters.py
+++ b/src/troute-config/troute/config/output_parameters.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from pydantic import BaseModel, Field, validator
 
 from typing import Optional, List
@@ -35,7 +36,8 @@ class ChanobsOutput(BaseModel):
     # NOTE: required if writing chanobs files
     chanobs_output_directory: Optional[DirectoryPath] = None
     # NOTE: required if writing chanobs files
-    chanobs_filepath: Optional[FilePath] = None
+    # NOTE: is `Path` b.c. is output file
+    chanobs_filepath: Optional[Path] = None
 
 
 class CsvOutput(BaseModel):


### PR DESCRIPTION
See #793 for greater detail.

## `troute.config` -- `0.0.2`

### Changes

- `ChanobsOutput` field, `chanobs_filepath` does not need to exist at startup. (fixes #794; thanks @program-- :tada:!)