### PR TITLE
update csv to parquet to use multiprocessing

### DIFF
--- a/src/troute-network/troute/AbstractNetwork.py
+++ b/src/troute-network/troute/AbstractNetwork.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from functools import partial
 import pandas as pd
 import numpy as np
+import multiprocessing
 from datetime import datetime, timedelta
 
 import os
@@ -927,14 +928,16 @@ def get_timesteps_from_nex(nexus_files):
     return output_file_timestamps
 
 
-def split_csv_file(nexus_file, catchment_id, binary_folder):
+def split_csv_file(nexus_file, binary_folder):
+    catchment_id = get_id_from_filename(nexus_file)
     # Split the csv file into multiple csv files
     # Unescaped command: awk -F ', ' '{ filename="test/tempfile_"$1".csv"; print "114085, "$NF >> filename; close(filename)}' nex-114085_output.csv
     cmd = f'awk -F \', \' \'{{ filename="{binary_folder}/tempfile_"$1".csv"; print "{catchment_id}, "$NF >> filename; close(filename) }}\' {nexus_file}'
     os.system(cmd)
 
 
-def rewrite_to_parquet(tempfile_id, output_file_id, binary_folder):
+def rewrite_to_parquet(file_args, binary_folder):
+    tempfile_id, output_file_id = file_args
     # Rewrite the csv file to parquet
     df = pd.read_csv(f'{binary_folder}/tempfile_{tempfile_id}.csv', names=['feature_id', output_file_id])
     df.set_index('feature_id', inplace=True)  # Set feature_id as the index
@@ -948,15 +951,19 @@ def rewrite_to_parquet(tempfile_id, output_file_id, binary_folder):
 def nex_files_to_binary(nexus_files, binary_folder):
     # Get the output files
     output_timesteps = get_timesteps_from_nex(nexus_files)
-    
+    partial_split_csv_file = partial(split_csv_file, binary_folder=binary_folder)
     # Split the csv file into multiple csv files
-    for nexus_file in nexus_files:
-        catchment_id = get_id_from_filename(nexus_file)
-        split_csv_file(nexus_file, catchment_id, binary_folder)
+    with multiprocessing.Pool() as pool:
+        pool.map(partial_split_csv_file, nexus_files)
+
+    # create a list of tuples to simplify pool.map call
+    temp_to_timestep_list = list(enumerate(output_timesteps))
     
+    partial_rewrite_to_parquet = partial(rewrite_to_parquet, binary_folder=binary_folder)
     # Rewrite the temp csv files to parquet
-    for tempfile_id, nexus_file in enumerate(output_timesteps):
-        rewrite_to_parquet(tempfile_id, nexus_file, binary_folder)
+    with multiprocessing.Pool() as pool:
+        pool.map(partial_rewrite_to_parquet, temp_to_timestep_list)
+
     
     # Clean up the temp files
     os.system(f'rm -rf {binary_folder}/tempfile_*.csv')


### PR DESCRIPTION
# Multiprocessing for Faster Input Reformatting

When testing routing for 6500 catchments and 24 timesteps, a large portion of the troute execution time is still spent on reformatting ngen output. PR #714 partially addressed this issue with an awk command. This PR adds multiprocessing to speed it up even more.

## Performance Comparison

### Without Multiprocessing

```
************ TIMING SUMMARY ************
----------------------------------------
Network graph construction: 0.8 secs,  7.27%
Forcing array construction: 7.7 secs, 69.93%
Routing computations:      1.89 secs, 17.20%
Output writing:            0.61 secs,  5.56%
----------------------------------------
```

### With Multiprocessing (56 cores - default to CPU core count)

```
************ TIMING SUMMARY ************
----------------------------------------
Network graph construction: 0.84 secs, 19.68%
Forcing array construction: 0.98 secs, 22.94%
Routing computations:      1.82 secs, 42.92%
Output writing:            0.61 secs, 14.36%
----------------------------------------
```

### With Multiprocessing (4 cores - hardcoded example)

```
************ TIMING SUMMARY ************
----------------------------------------
Network graph construction: 0.79 secs, 14.09%
Forcing array construction: 2.36 secs, 42.39%
Routing computations:       1.8 secs, 32.29%
Output writing:            0.62 secs, 11.15%
----------------------------------------
```


## Notes
- This works in ngiab with ngen run serially, 
- Testing this via ngen with MPI will actually reduce performance due to an issue being worked on in [NOAA-OWP/ngen#846](https://github.com/NOAA-OWP/ngen/pull/846).
- Building ngen from that PR should work.
- An ngiab image for x86 with both the MPI patch and this troute patch applied is available at `joshcu/ngiab_dev`.
