### PR TITLE
Don't validate `ReservoirRfcParameters` paths if reservoir forecasts are disabled

### DIFF
--- a/src/troute-config/troute/config/__init__.py
+++ b/src/troute-config/troute/config/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.0.2"
+__version__ = "0.0.3"
 
 from .config import Config

--- a/src/troute-config/troute/config/compute_parameters.py
+++ b/src/troute-config/troute/config/compute_parameters.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel, Field, validator
 from datetime import datetime
 
-from typing import Optional, List
+from typing import Optional, List, Union
 from typing_extensions import Literal
 
 from .types import FilePath, DirectoryPath
@@ -141,16 +141,22 @@ class ReservoirPersistenceDA(BaseModel, extra='ignore'):
 
 
 class ReservoirRfcParameters(BaseModel):
-    reservoir_rfc_forecasts: bool = False
+    reservoir_rfc_forecasts: Literal[True] = True
     reservoir_rfc_forecasts_time_series_path: Optional[DirectoryPath] = None
     reservoir_rfc_forecasts_lookback_hours: int = 28
     reservoir_rfc_forecasts_offset_hours: int = 28
     reservoir_rfc_forecast_persist_days: int = 11
 
 
+class ReservoirRfcParametersDisabled(BaseModel):
+    reservoir_rfc_forecasts: Literal[False] = False
+
+
 class ReservoirDA(BaseModel):
     reservoir_persistence_da: Optional[ReservoirPersistenceDA] = None
-    reservoir_rfc_da: Optional[ReservoirRfcParameters] = None
+    reservoir_rfc_da: Optional[
+        Union[ReservoirRfcParameters, ReservoirRfcParametersDisabled]
+    ] = Field(None, discriminator="reservoir_rfc_forecasts")
     reservoir_parameter_file: Optional[FilePath] = None
 
 

--- a/src/troute-config/troute/config/config.py
+++ b/src/troute-config/troute/config/config.py
@@ -128,7 +128,7 @@ class Config(BaseModel):
             if reservoir_da:
                 reservoir_rfc_da = reservoir_da.reservoir_rfc_da
                 reservoir_rfc_forecasts = False
-                if reservoir_rfc_da:
+                if reservoir_rfc_da and reservoir_rfc_da.reservoir_rfc_forecasts:
                     reservoir_rfc_forecasts = reservoir_rfc_da.reservoir_rfc_forecasts
                     reservoir_rfc_forecasts_time_series_path = reservoir_rfc_da.reservoir_rfc_forecasts_time_series_path
                 if reservoir_rfc_forecasts:


### PR DESCRIPTION
fixes #799

## `troute.config` -- `0.0.3`

## Changes

- If `reservoir_rfc_forecasts` is disabled, the `reservoir_rfc_forecasts_time_series_path` directory will not be validated to exist in strict mode (fixes #799).


@shorvath-noaa, are there other fields that I use this same kind of pattern on? The idea being, that in strict mode, we only _need_ to validate the paths that `troute` will use.