### PR TITLE
chore(build): fix editable builds

### DIFF
--- a/compiler.sh
+++ b/compiler.sh
@@ -24,10 +24,10 @@ then
 fi
 
 #preserve old/default behavior of installing packages with -e
-E="-e"
+WITH_EDITABLE=true
 if [ "$1" == 'no-e' ]
 then
-E=""
+WITH_EDITABLE=false
 fi
 
 #if you have custom static library paths, uncomment below and export them
@@ -87,30 +87,42 @@ if [[ "$build_framework" == true ]]; then
   #creates troute package
   cd $REPOROOT/src/troute-network
   rm -rf build
-  ##python setup.py --use-cython install
-  ##python setup.py --use-cython develop
-  python setup.py build_ext --inplace --use-cython || exit
-  pip install --no-build-isolation $E . || exit
+
+  if [[ ${WITH_EDITABLE} == true ]]; then
+    pip install --no-build-isolation --config-setting='--build-option=--use-cython' --editable . --config-setting='editable_mode=compat' || exit
+  else
+    pip install --no-build-isolation --config-setting='--build-option=--use-cython' . || exit
+  fi
 fi
 
 if [[ "$build_routing" == true ]]; then
   #updates troute package with the execution script
   cd $REPOROOT/src/troute-routing
   rm -rf build
-  #python setup.py --use-cython install
-  #python setup.py --use-cython develop
-  python setup.py build_ext --inplace --use-cython || exit
-  pip install --no-build-isolation $E . || exit
+
+  if [[ ${WITH_EDITABLE} == true ]]; then
+    pip install --no-build-isolation --config-setting='--build-option=--use-cython' --editable . --config-setting='editable_mode=compat' || exit
+  else
+    pip install --no-build-isolation --config-setting='--build-option=--use-cython' . || exit
+  fi
 fi
 
 if [[ "$build_config" == true ]]; then
   #updates troute package with the execution script
   cd $REPOROOT/src/troute-config
-  pip install $E . || exit
+  if [[ ${WITH_EDITABLE} == true ]]; then
+    pip install --editable . || exit
+  else
+    pip install . || exit
+  fi
 fi
 
 if [[ "$build_nwm" == true ]]; then
   #updates troute package with the execution script
   cd $REPOROOT/src/troute-nwm
-  pip install $E . || exit
+  if [[ ${WITH_EDITABLE} == true ]]; then
+    pip install --editable . || exit
+  else
+    pip install . || exit
+  fi
 fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+pip>=22.1.0
+setuptools>=64.0,<69.0
 wheel
 numpy
 Cython>3,!=3.0.4


### PR DESCRIPTION
See #783 for some detail. Ensure that you install `t-route`'s python dependencies with `pip install -r requirements.txt` **before** running `compiler.sh`.

closes #783

@shorvath-noaa, can you give this a try?