### PR TITLE
Included pip & venv based instructions for WSL2 (#812)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -111,6 +111,79 @@ python3 -m nwm_routing -f -V4 test_AnA_V4_HYFeature.yaml
 
 **Note**: The following instructions are for setting up T-Route on a Linux environment (standalone, no MPI). If you are using Windows, please install WSL (Windows Subsystem for Linux) before proceeding.
 
+### T-Route Setup and Testing Guide for Windows Users WITHOUT conda [based on pip and venv - only widely available dependencies]
+
+1. **Install Recommended distro:**
+   - Download and install WSL2 for your Windows OS
+   - We recommend long-term stable (LTS) Ubuntu distribution 22.04 or 20.04 (24.04 not recommended yet)
+   - Open Windows Power Shell and issue
+     > wsl --install Ubuntu-22.04
+   - Enter (root) username and password (2x) of your choice
+     
+2. **Set up venv-based virtual environment:**
+   - From root (the username you created under 1):
+      - Update Linux distro:
+         > sudo apt update
+      - Install pip (package manager):
+         > sudo apt install python3-pip
+      - Install venv:
+         > sudo apt install python3.10-venv
+      - Create a virtual environment for T-route (named here 'troute-env1'):
+         > python3 -m venv troute_env1
+      - Activate your shiny new virtual environment:
+         > source troute_env1/bin/activate
+      - Now, the command prompts in the Shell window should start with (troute-env1)
+ 
+3. **Clone T-route:**
+   - Go to a folder of your choice (here, your home folder) and create a T-route directory
+      > mkdir troute1
+      > cd troute1
+   - Clone a T-route repository (the current main branch is used as an example):
+      > git clone https://github.com/NOAA-OWP/t-route.git
+      > cd troute1
+   - Install python packages per requirements file
+      > pip install -r requirements.txt
+
+4. **Download & build netcdf fortran libraries from UCAR:**
+   - Go to a folder of your choice (here, your home folder) and download the source code:
+      > cd ~
+      > wget https://downloads.unidata.ucar.edu/netcdf-fortran/4.6.1/netcdf-fortran-4.6.1.tar.gz
+   - Unzip it:
+      > tar xvf netcdf-fortran-4.6.1.tar.gz
+   - Enter the directory:
+      > cd netcdf-fortran-4.6.1/
+   - Install some prerequisites (Fortran compiler, build essentials, standard C-netcdf library):
+      > sudo apt install gfortran
+      > sudo apt install build-essential
+      > sudo apt-get install libnetcdf-dev
+   - Configure the fortran-netcdf libraries:
+      > ./configure
+   - There should be no error message, and the output log should end up with something like:
+     ![image](https://github.com/user-attachments/assets/48268212-0b74-4f75-9d52-97f68e6c80d0)
+   - Check the installation (running two sets of examples):
+      > make check
+   - Again, there should be no error message (expect some warnings, though), and output should end with "passing" of two sets:
+     ![image](https://github.com/user-attachments/assets/83745989-9f14-4c1b-a2a1-675aa94e5181)
+   - Finally, install the libraries:
+      > sudo make install
+   - Output should be something like:
+      ![image](https://github.com/user-attachments/assets/57e48501-18f4-4004-9b10-5a9245186e38)
+
+5. **Build and test T-route:**
+   - Go to your T-route folder:
+      > cd ~/troute1
+   - Compile T-route (may take a few minutes, depending on the machine):
+      > ./compiler.sh
+   - Set path to runtime netcdf-Fortran library [recommend including this in the .bashrc file or your equivalent]:
+      > export LD_LIBRARY_PATH=/usr/local/lib/
+   - Run one of the demo examples provided:
+      > cd test/LowerColorado_TX
+      > python -m nwm_routing -f -V3 test_AnA.yaml
+   - The latter is a hybrid (MC + diffusive) routing example that should run within a few minutes at most
+
+
+### T-Route Setup Instructions and Troubleshooting Guide for Windows Users - Legacy Conda Version [requires  may have to be built with compiler.sh no-e option]
+
 1. **Install Required Components:**
    - Open the WSL terminal.
    - Install Miniconda, Python, Pip, and Git.


### PR DESCRIPTION
Possible Cython compile errors in T-route caused by PR784 (https://github.com/NOAA-OWP/t-route/pull/784) have resulted in a recommendation to compile in "no-editable' mode (PR 801, https://github.com/NOAA-OWP/t-route/pull/801). The no-e option, in turn, has resulted in the necessity to recompile T-route after each edit of python code. 

The instructions provided here showcase how T-route can be installed in a manner compatible with PR 784 while avoiding the non-editable compile option. It is based on pip and venv, avoiding conda altogether. It has been implemented on WSL, but should be readily adaptable to the same recent long-term stable Ubuntu distros (22.04 and 20.04).

[Short description explaining the high-level reason for the pull request]

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
