### PR TITLE
update default values for parquet output

### DIFF
--- a/src/troute-config/troute/config/output_parameters.py
+++ b/src/troute-config/troute/config/output_parameters.py
@@ -53,8 +53,8 @@ class ParquetOutput(BaseModel):
     # NOTE: required if writing results to parquet
     parquet_output_folder: Optional[DirectoryPath] = None
     parquet_output_segments: Optional[List[str]] = None
-    configuration: Optional[str] = 'None'
-    prefix_ids: Optional[str] = 'wb-'
+    configuration: str = 'None'
+    prefix_ids: str = 'wb-'
 
 
 class ChrtoutOutput(BaseModel):

--- a/src/troute-config/troute/config/output_parameters.py
+++ b/src/troute-config/troute/config/output_parameters.py
@@ -53,8 +53,8 @@ class ParquetOutput(BaseModel):
     # NOTE: required if writing results to parquet
     parquet_output_folder: Optional[DirectoryPath] = None
     parquet_output_segments: Optional[List[str]] = None
-    configuration: Optional[str] = None
-    prefix_ids: Optional[str] = None
+    configuration: Optional[str] = 'None'
+    prefix_ids: Optional[str] = 'wb-'
 
 
 class ChrtoutOutput(BaseModel):


### PR DESCRIPTION
Add default values for `prefix_ids` and `configurations`.

## Additions

-

## Removals

-

## Changes
**output_parameters.py**
- `configuration: Optional[str] = 'None'`
- `prefix_ids: Optional[str] = 'wb-'`

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
