### PR TITLE
More time-efficient order in timeslice file creation

### DIFF
--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -1224,7 +1224,13 @@ def get_obs_from_timeslices(
         t = [out[2] for out in result]
         qual = [out[3] for out in result]
 
-    if len(discharge) != 0 and len(stns) != 0 and len(t) != 0:     
+    all_empty = all(len(s)==0 for s in stns)
+
+    if (all_empty):
+        LOG.debug(f'{crosswalk_gage_field} DataFrames is empty, check timeslice files.')
+        return pd.DataFrame() 
+
+    if (not all_empty):
 
         stationIds = [np.apply_along_axis(''.join, 1, stn.astype(str)) for stn in stns]
         stationIds = [np.char.strip(stn) for stn in stationIds]

--- a/test/LowerColorado_TX/test_AnA.yaml
+++ b/test/LowerColorado_TX/test_AnA.yaml
@@ -31,7 +31,7 @@ compute_parameters:
     compute_kernel         : V02-structured
     assume_short_ts        : True
     subnetwork_target_size : 10000
-    cpu_pool               : 1
+    cpu_pool               : 36
     restart_parameters:
         #----------
         start_datetime: 2021-08-23_13:00

--- a/test/LowerColorado_TX/test_AnA.yaml
+++ b/test/LowerColorado_TX/test_AnA.yaml
@@ -31,7 +31,7 @@ compute_parameters:
     compute_kernel         : V02-structured
     assume_short_ts        : True
     subnetwork_target_size : 10000
-    cpu_pool               : 36
+    cpu_pool               : 1
     restart_parameters:
         #----------
         start_datetime: 2021-08-23_13:00


### PR DESCRIPTION
Changed the order of timeslice file import and creation of dataframes. Previously, a pandas dataframe was created for each timeslice, and then the dataframes were concatenated into a combined dataframe for 15-minute resampling. Now, only numpy arrays are imported, which are then combined into one large dataframe. 

## Additions

-

## Removals

-

## Changes

- For reading individual timeslices, added a routine _read_timeslice_file_numpy in nhd_io that only returns numpy arrays
- Rewrote get_obs_from_timeslices: streamlined creation of the observation_df in one step

## Testing

1. Running any example that reads usgs timeslice files
2. If you want to benchmark the time, the pyinstruments profiler is suggested, which will create a report with 1 millisecond time resolution:

from pyinstrument import Profiler
profiler = Profiler()
profiler.start()

     [CODE YOU WANT TO BENCHMARK]

profiler.stop()
profiler.print()

## Screenshots

For Lower Colorado example [test_AnA.yaml]: benchmark for get_obs_from_timeslices shows 2-fold speedup:

BEFORE:

![image](https://github.com/user-attachments/assets/cb858312-8364-484a-ad19-2491dc393010)

AFTER:

![image](https://github.com/user-attachments/assets/119f3612-53cc-4663-bdab-2b1aa7d0b1fd)


## Notes

-

## Todos

- Suggest considering to delete the "quality" dataframe, which will result in further speedup

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
