### PR TITLE
fix: parquet `prefix_ids` defaults to `wb`

### DIFF
--- a/src/troute-config/troute/config/output_parameters.py
+++ b/src/troute-config/troute/config/output_parameters.py
@@ -54,7 +54,7 @@ class ParquetOutput(BaseModel):
     parquet_output_folder: Optional[DirectoryPath] = None
     parquet_output_segments: Optional[List[str]] = None
     configuration: str = 'None'
-    prefix_ids: str = 'wb-'
+    prefix_ids: str = 'wb'
 
 
 class ChrtoutOutput(BaseModel):


### PR DESCRIPTION
Remove unnecessary `-` suffix from `prefix_ids` (I should have caught this when reviewing #821).

#821 changed the default `prefix_ids` to `wb-`. The parquet output handling code sets the feature location to `{prefix_ids}-{location_id}`. So, the default would now be `wb--{location_id}`. We want `wb-{location_id}`. This fixes that.

related to #821