### PR TITLE
troute.network: handle `fiona` dependency for `geopandas>=1.0.0`

### DIFF
--- a/src/troute-network/pyproject.toml
+++ b/src/troute-network/pyproject.toml
@@ -8,6 +8,7 @@ version = "0.0.0"
 dependencies = [
     "deprecated",
     "geopandas",
+    "fiona",
     "joblib",
     "netcdf4",
     "numpy",


### PR DESCRIPTION
This PR adds `fiona` to the `troute.network` dependencies to handle the case when consumers have `geopandas>=1.0.0` without explicitly installing `fiona`. This change shouldn't impact consumers with `geopandas<1.0.0`, since `fiona` will already be installed.

## Additions

- Adds `fiona` to troute.network's pyproject.toml dependencies

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: