### PR TITLE
update for csv_output

### DIFF
--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -2070,12 +2070,11 @@ def write_flowveldepth_csv_pkl(stream_output_directory, file_name,
             'velocity': velocity.iloc[:, i],
             'depth': depth.iloc[:, i],
             'nudge': nudge_df.iloc[:, i]  
-        })
+        }, index=flow.index)
         df_list.append(df_temp)
 
     # Concatenate all temporary DataFrames vertically
     df = pd.concat(df_list)
-    df.index.name = 'feature_id'
     
     df['current_time'] = pd.to_datetime(df['t0']) + pd.to_timedelta(df['time'])
     df = df[['current_time', 'flow', 'velocity', 'depth', 'nudge']]
@@ -2269,6 +2268,7 @@ def mask_find_seg(mask_list, nexus_dict, poi_crosswalk):
     return nex_id, seg_id
 
 def updated_flowveldepth(flowveldepth, nex_id, seg_id, mask_list):
+    flowveldepth = flowveldepth.copy(deep=True)
     flowveldepth.index.name = 'featureID'
     flowveldepth['Type'] = 'wb'
     flowveldepth.set_index('Type', append=True, inplace=True)


### PR DESCRIPTION
if a user has both `csv_output` and `stream_output` activated, the `csv_output` has extra columns (`feature_id` and `Type`). This PR change it so `flowveldepth` is untouched without extra column, and `stream_output` just works like before.

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
