### PR TITLE
remove geopandas and fiona + bugfixes

### DIFF
--- a/.github/workflows/ubuntu-latest.yml
+++ b/.github/workflows/ubuntu-latest.yml
@@ -40,7 +40,7 @@ jobs:
         sudo apt-get install libstdc++-10-dev libgfortran-10-dev glibc-source openmpi-bin openmpi-common libopenmpi-dev libopenmpi3 libgtk-3-bin libgtk-3-common libgtk-3-dev -y
         sudo apt-get install netcdf-bin libnetcdf-dev libnetcdff-dev libnetcdf-c++4 libnetcdf-c++4-dev -y
         python -m pip install --upgrade pip
-        pip3 install wheel dask pyproj fiona bmipy opencv-contrib-python-headless
+        pip3 install wheel dask pyproj bmipy opencv-contrib-python-headless
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         
     - name: Install t-route

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ __pycache__/
 .env
 .python-version
 .ipynb_checkpoints/
+build/
 
 # pyenv #
 #########

--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,6 @@ joblib
 toolz
 Cython
 pyyaml
-geopandas
 pyarrow
 deprecated
 ```
@@ -84,7 +83,7 @@ To get a sense of the operation of the routing scheme, follow this sequence of c
 
 ```shell
 # install required python modules
-pip3 install numpy pandas xarray netcdf4 joblib toolz pyyaml Cython>3,!=3.0.4 geopandas pyarrow deprecated wheel
+pip3 install numpy pandas xarray netcdf4 joblib toolz pyyaml Cython>3,!=3.0.4 pyarrow deprecated wheel
 
 # clone t-toute
 git clone --progress --single-branch --branch master http://github.com/NOAA-OWP/t-route.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,3 @@ toolz
 joblib
 deprecated
 pyarrow<12.0
-geopandas

--- a/src/troute-network/pyproject.toml
+++ b/src/troute-network/pyproject.toml
@@ -7,8 +7,6 @@ name = "troute.network"
 version = "0.0.0"
 dependencies = [
     "deprecated",
-    "geopandas",
-    "fiona",
     "joblib",
     "netcdf4",
     "numpy",

--- a/src/troute-network/tests/make_test_network.py
+++ b/src/troute-network/tests/make_test_network.py
@@ -1,5 +1,5 @@
-import geopandas as gpd
 import pandas as pd
+import sqlite3
 from pathlib import Path
 import sys
 
@@ -45,9 +45,11 @@ def make_network_from_segment(flowpaths, edges, attributes, depth, segment):
     sub_edges.drop('geometry', axis=1).to_json("flowpath_edge_list.json", orient='records', indent=2)
 
 def make_network_from_geopkg(file_path, depth, segment=None):
-    flowpaths = gpd.read_file(file_path, layer="flowpaths")
-    attributes = gpd.read_file(file_path, layer="flowpath_attributes")
-    edges = gpd.read_file(file_path, layer="flowpath_edge_list")
+    with sqlite3.connect(file_path) as conn:
+        flowpaths = pd.read_sql_query("SELECT * FROM flowpaths", file_path)
+        attributes = pd.read_sql_query("SELECT * FROM flowpath_attributes", file_path)
+        edges = pd.read_sql_query("SELECT * FROM flowpath_edge_list", file_path)
+
     if segment is None:
         segment = flowpaths[flowpaths['toid'].str.startswith('tnex')].iloc[0]['id']
     make_network_from_segment(flowpaths, edges, attributes, depth, segment)

--- a/src/troute-network/troute/AbstractNetwork.py
+++ b/src/troute-network/troute/AbstractNetwork.py
@@ -926,13 +926,7 @@ class AbstractNetwork(ABC):
         diff_tw_ids = ['nex-' + str(s) for s in diff_tw_ids]
         nexus_latlon = nexus_latlon[nexus_latlon['id'].isin(diff_tw_ids)]
         nexus_latlon['id'] = nexus_latlon['id'].str.split('-',expand=True).loc[:,1].astype(float).astype(int)
-        lat_lon_crs = nexus_latlon[['id','geometry']]
-        lat_lon_crs = lat_lon_crs.to_crs(crs=4326)
-        lat_lon_crs['lon'] = lat_lon_crs.geometry.x
-        lat_lon_crs['lat'] = lat_lon_crs.geometry.y
-        lat_lon_crs['crs'] = str(lat_lon_crs.crs)
-        lat_lon_crs = lat_lon_crs[['lon','lat','crs']]
-        self._nexus_latlon = nexus_latlon[['id']].join(lat_lon_crs)
+        self._nexus_latlon = nexus_latlon[['id','lon','lat', 'crs']]
 
 def get_timesteps_from_nex(nexus_files):
     # Return a list of output files

--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -28,7 +28,7 @@ def find_layer_name(layers, pattern):
         if re.search(pattern, layer, re.IGNORECASE):
             return layer
     return None
-  
+
 def read_geopkg(file_path, compute_parameters, waterbody_parameters, cpu_pool):
     # Retrieve available layers from the GeoPackage 
     with sqlite3.connect(file_path) as conn:
@@ -76,7 +76,7 @@ def read_geopkg(file_path, compute_parameters, waterbody_parameters, cpu_pool):
         try:
             with sqlite3.connect(file_path) as conn:
                 has_spatial_metadata = False
-                # try and get the name of the geometry column and it's crs
+                # try and get the name of the geometry column and its crs
                 geometry_columns = conn.execute(f"""
                 SELECT c.column_name,g.definition
                 FROM gpkg_geometry_columns AS c
@@ -89,7 +89,9 @@ def read_geopkg(file_path, compute_parameters, waterbody_parameters, cpu_pool):
                     crs = geometry_columns[0][1]
 
                 if has_spatial_metadata:
-                    # select everything from the layer, + the midpoint of it's bounding box
+                    # select everything from the layer, + the midpoint of its bounding box
+                    # decoding the geometry blob can be done as it's just gpkg header + WKB
+                    # the rtree table calculation is much faster
                     sql_query = f"""SELECT d.*,
                         (r.minx + r.maxx) / 2.0 AS lon,
                         (r.miny + r.maxy) / 2.0 AS lat
@@ -170,8 +172,7 @@ def read_geojson(file_path):
     df = pd.json_normalize(data,max_level=1)
     df.columns = df.columns.str.replace('properties.','')
     df = df.drop(columns=['type'])
-    # Geometry seems to be unused or dropped, in case it is needed:
-    # geometry type e.g. MULTIPOLYGON, is stored in geometry.type
+    # Geometry type e.g. MULTIPOLYGON, is stored in geometry.type
     # and the coordinates are stored in geometry.coordinates
     # crs stored in data['crs'] e.g.
     # data['crs'] = { "type": "name", "properties": { "name": "urn:ogc:def:crs:EPSG::5070" } }

--- a/test/LowerColorado_TX_v4/run_BMI_Coastal.py
+++ b/test/LowerColorado_TX_v4/run_BMI_Coastal.py
@@ -3,8 +3,6 @@ import glob
 import os
 import numpy as np
 import pandas as pd
-import geopandas as gpd
-import pickle
 from datetime import datetime, timedelta
 import time
 
@@ -20,7 +18,7 @@ import bmi_DAforcing
 #import troute_model
 
 from troute.HYFeaturesNetwork import HYFeaturesNetwork
-from troute.AbstractNetwork import *
+from troute.AbstractNetwork import read_coastal_output
 
 import bmi_df2array as df2a
 

--- a/test/LowerColorado_TX_v4/run_with_BMI.py
+++ b/test/LowerColorado_TX_v4/run_with_BMI.py
@@ -3,8 +3,6 @@ import glob
 import os
 import numpy as np
 import pandas as pd
-import geopandas as gpd
-import pickle
 from datetime import datetime, timedelta
 import time
 


### PR DESCRIPTION
# Geopandas
geopandas (more specifically it's fiona dependency) causes issues when wheels aren't available and it attempts to build from source on arm64/aarch64. building fiona is currently preventing NGIAB from building and has caused issues with arm NGIAB in the past.
As far as I can tell it's just used to read non-geometric data from geopackages and non-geometric data from geojson files.

```python
#this
gdf = gpd.open_file("conus.gpkg", layer="divides")
# can be done like this
with sqlite3.connect("conus.gpkg") as conn:
    df = pd.read_sql_query("SELECT * FROM divides", conn)
``` 
The geometry is an unpleasant blob that would need to be decoded [something like this](https://github.com/CIROH-UA/NGIAB_data_preprocess/blob/9809b532629e2ce6cd93b37ce0c6790dd6dea102/modules/data_processing/gpkg_utils.py#L70), but it doesn't appear to be used anywhere so we could probably not bother select it from the geopackage in the first place to save some time and memory

Similarly, geojson is read into a normal pandas df, the geometry is less mangled than the geopackage but still not a proper geometry object. The geometry doesn't seem to be used anywhere, so I just left some comments explaining the format if anyone in the future does need to use it.

I haven't done performance tests on this, but it should also be faster than geopandas. 

### Some similar work
https://github.com/NOAA-OWP/t-route/issues/604
https://github.com/NOAA-OWP/t-route/pull/568

## Removals

- All imports and use of geopandas and fiona

## Changes

- Geopackages now open with pandas + sqlite3 and are **normal dataframes**
- Geojson now opens by reading the raw json and reformatting the contents into a normal pandas dataframe

## Testing & Screenshots

It worked on a small simulation generated with ngiab_data_preprocess, running inside NGIAB
![image](https://github.com/user-attachments/assets/eeacd7c1-0375-4369-ac9d-8b2dfe06326b)


# Additional Bugfixes
In order to test this using geopackages generated by ngiab_data_preprocess (v20.1 of the hydrofabric) I had to modify the regex and pandas table merging. 

## Regex
The original regex would match both flowpaths and flowpath_attributes as flowpaths.
![image](https://github.com/user-attachments/assets/bf2f0fc4-161c-4190-9ca5-3248eae92d7d)
`matched_layers: {'flowpaths': 'flowpath_attributes', 'flowpath_attributes': 'flowpath_attributes', 'lakes': None, 'nexus': 'nexus', 'network': None}`
adding $ to check for the end of line fixed this.

## table merging
I noticed this while debugging the regex issue; trying to merge two dataframes when either one of them didn't have the "id" column was causing errors. Now it checks to see what combination of the flowpaths and flowpath_attributes exist and merge accordingly.



