### PR TITLE
Updates for Coastal Runs

### DIFF
--- a/src/troute-network/troute/AbstractNetwork.py
+++ b/src/troute-network/troute/AbstractNetwork.py
@@ -35,7 +35,7 @@ class AbstractNetwork(ABC):
                 "supernetwork_parameters", "waterbody_parameters","data_assimilation_parameters",
                 "restart_parameters", "compute_parameters", "forcing_parameters",
                 "hybrid_parameters", "preprocessing_parameters", "output_parameters",
-                "verbose", "showtiming", "break_points", "_routing", "_gl_climatology_df", "_nexus_dict", "_poi_nex_dict"]
+                "verbose", "showtiming", "break_points", "_routing", "_gl_climatology_df", "_nexus_dict", "_poi_nex_df"]
 
     
     def __init__(self, from_files=True, value_dict={}):
@@ -379,8 +379,8 @@ class AbstractNetwork(ABC):
         return self._nexus_dict
     
     @property
-    def poi_nex_dict(self):
-        return self._poi_nex_dict
+    def poi_nex_df(self):
+        return self._poi_nex_df
 
     @property
     def terminal_codes(self):

--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -453,12 +453,12 @@ class HYFeaturesNetwork(AbstractNetwork):
 
     def crosswalk_nex_flowpath_poi(self, flowpaths, nexus):
         
-        mask_flowpaths = flowpaths['toid'].str.startswith(('nex-', 'tnex-'))
+        mask_flowpaths = flowpaths['toid'].str.startswith(('nex-', 'tnx-'))
         filtered_flowpaths = flowpaths[mask_flowpaths]
         self._nexus_dict = filtered_flowpaths.groupby('toid')['id'].apply(list).to_dict()  ##{id: toid}
         if 'poi_id' in nexus.columns:
             # self._poi_nex_dict = nexus.groupby('poi_id')['id'].apply(list).to_dict()
-            self._poi_nex_df = nexus[nexus['type']=='poi'][['id','poi_id']]
+            self._poi_nex_df = nexus[~nexus['poi_id'].isna()][['id','poi_id']]
         else:
             self._poi_nex_df = pd.DataFrame()
 

--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -2385,6 +2385,7 @@ def write_flowveldepth(
     # Create POI-nexus point crosswalk dataframe (if necessary)
     idx = flowveldepth.reset_index()[['featureID','Type']]
     poi_crosswalk[['Type', 'featureID']] = poi_crosswalk['id'].str.split('-', expand=True)
+    poi_crosswalk['Type'] = 'nex' # Types can be 'nex', 'tnx', etc. This just sets them all to generic 'nex'.
     poi_crosswalk['featureID'] = poi_crosswalk.featureID.astype(int)
     poi_crosswalk = idx.set_index(['featureID','Type']).join(poi_crosswalk[['featureID','Type','poi_id']].set_index(['featureID','Type']))
 

--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -2055,7 +2055,7 @@ def write_waterbody_netcdf(
 
 def write_flowveldepth_csv_pkl(stream_output_directory, file_name,
                               flow, velocity, depth, nudge_df, timestamps,
-                              t0):
+                              t0, poi_crosswalk):
     
     formatted_times = [str(timedelta(seconds=t)) for t in timestamps]
     
@@ -2088,7 +2088,12 @@ def write_flowveldepth_csv_pkl(stream_output_directory, file_name,
 
 def write_flowveldepth_netcdf(stream_output_directory, file_name,
                               flow, velocity, depth, nudge_df, timestamps,
-                              t0):
+                              t0, poi_crosswalk):
+   
+    # Find max lenght of string variables:
+    max_Type_str_len = max(len(str(x)) for x in flow.index.get_level_values('Type'))
+    max_poi_str_len = max(len(str(x)) for x in poi_crosswalk.poi_id)
+    
     # Open netCDF4 Dataset in write mode
     with netCDF4.Dataset(
         filename=f"{stream_output_directory}/{file_name}",
@@ -2099,8 +2104,7 @@ def write_flowveldepth_netcdf(stream_output_directory, file_name,
         # ============ DIMENSIONS ===================
         _ = ncfile.createDimension('feature_id', len(flow))
         _ = ncfile.createDimension('time', len(timestamps))
-        max_str_len = max(len(str(x)) for x in flow.index.get_level_values('Type'))
-        _ = ncfile.createDimension('type_strlen', max_str_len)
+        _ = ncfile.createDimension('type_strlen', max_Type_str_len)
         #_ = ncfile.createDimension('gage', gage)
         #_ = ncfile.createDimension('nudge_timestep', nudge_timesteps)  # Add dimension for nudge time steps
         
@@ -2151,10 +2155,10 @@ def write_flowveldepth_netcdf(stream_output_directory, file_name,
         # =========== type VARIABLE ===============
         TYPE = ncfile.createVariable(
             varname="type",
-            datatype=f'S{max_str_len}',
+            datatype=f'S{max_Type_str_len}',
             dimensions=("feature_id",),
         )
-        TYPE[:] = np.array(flow.index.get_level_values('Type').astype(str).tolist(), dtype=f'S{max_str_len}')
+        TYPE[:] = np.array(flow.index.get_level_values('Type').astype(str).tolist(), dtype=f'S{max_Type_str_len}')
         ncfile['type'].setncatts(
             {
                 'long_name': 'Type',
@@ -2226,6 +2230,19 @@ def write_flowveldepth_netcdf(stream_output_directory, file_name,
             }
         )
         
+        # ============= POI VARIABLE ===============
+        TYPE = ncfile.createVariable(
+            varname="POI",
+            datatype=f'S{max_poi_str_len}',
+            dimensions=("feature_id",),
+        )
+        TYPE[:] = np.array(poi_crosswalk.poi_id.astype(str).tolist(), dtype=f'S{max_poi_str_len}')
+        ncfile['type'].setncatts(
+            {
+                'long_name': 'POI ID',
+            }
+        )
+        
         # =========== GLOBAL ATTRIBUTES ===============
         ncfile.setncatts(
             {
@@ -2280,7 +2297,7 @@ def updated_flowveldepth(flowveldepth, nex_id, seg_id, mask_list):
         masked = (flowveldepth.index.get_level_values('featureID').isin(ids)) & (flowveldepth.index.get_level_values('Type') == 'wb')
         return masked
     
-    flowveldepth_seg = flowveldepth[create_mask(seg_id)] if seg_id else pd.DataFrame()
+    flowveldepth_seg = flowveldepth[create_mask(seg_id)] if seg_id else pd.DataFrame(columns=flowveldepth.reset_index().columns).set_index(['featureID','Type'])
 
     if nex_id:    
         nex_df = pd.DataFrame([(nex, wb) for nex, wbs in nex_id.items() for wb in wbs], columns=['nex', 'featureID'])
@@ -2353,7 +2370,7 @@ def write_flowveldepth(
     mask_list = stream_output_mask_reader(stream_output_mask)
     nex_id, seg_id = mask_find_seg(mask_list, nexus_dict, poi_crosswalk)
     flowveldepth = updated_flowveldepth(flowveldepth, nex_id, seg_id, mask_list)
-
+    
     # timesteps, variable = zip(*flowveldepth.columns.tolist())
     # timesteps = list(timesteps)
     n_timesteps = flowveldepth.shape[1]//3
@@ -2364,6 +2381,12 @@ def write_flowveldepth(
     flow = flowveldepth.iloc[:,0::3].iloc[:,ind]
     velocity = flowveldepth.iloc[:,1::3].iloc[:,ind]
     depth = flowveldepth.iloc[:,2::3].iloc[:,ind]
+
+    # Create POI-nexus point crosswalk dataframe (if necessary)
+    idx = flowveldepth.reset_index()[['featureID','Type']]
+    poi_crosswalk[['Type', 'featureID']] = poi_crosswalk['id'].str.split('-', expand=True)
+    poi_crosswalk['featureID'] = poi_crosswalk.featureID.astype(int)
+    poi_crosswalk = idx.set_index(['featureID','Type']).join(poi_crosswalk[['featureID','Type','poi_id']].set_index(['featureID','Type']))
 
     # Check if the first column of nudge is all zeros
     if np.all(nudge[:, 0] == 0):
@@ -2390,7 +2413,8 @@ def write_flowveldepth(
                     velocity.iloc[:,0:ts_per_file],
                     depth.iloc[:,0:ts_per_file],
                     nudge_df.iloc[:,0:ts_per_file],
-                    timestamps_sec[0:ts_per_file],t0)
+                    timestamps_sec[0:ts_per_file],t0,
+                    poi_crosswalk)
             if stream_output_type == '.nc':
                 if cpu_pool > 1 & num_files > 1:
                     jobs.append(delayed(write_flowveldepth_netcdf)(*args))

--- a/src/troute-nwm/src/nwm_routing/__main__.py
+++ b/src/troute-nwm/src/nwm_routing/__main__.py
@@ -296,7 +296,7 @@ def main_v04(argv):
         if not network.poi_nex_df.empty:
             poi_crosswalk = network.poi_nex_df
         else:
-            poi_crosswalk = dict()
+            poi_crosswalk = pd.DataFrame()
 
         output_start_time = time.time()  
         

--- a/src/troute-nwm/src/nwm_routing/__main__.py
+++ b/src/troute-nwm/src/nwm_routing/__main__.py
@@ -293,8 +293,8 @@ def main_v04(argv):
             forcing_end_time = time.time()
             task_times['forcing_time'] += forcing_end_time - route_end_time
 
-        if network.poi_nex_dict:
-            poi_crosswalk = network.poi_nex_dict
+        if not network.poi_nex_df.empty:
+            poi_crosswalk = network.poi_nex_df
         else:
             poi_crosswalk = dict()
 

--- a/src/troute-nwm/src/nwm_routing/input.py
+++ b/src/troute-nwm/src/nwm_routing/input.py
@@ -59,6 +59,13 @@ def _input_handler_v04(args):
     parity_parameters = output_parameters.get('wrf_hydro_parity_check')
     data_assimilation_parameters = compute_parameters.get('data_assimilation_parameters')
     
+    # read mask output info and add it to output_parameters
+    if output_parameters.get('stream_output'):
+        stream_output_mask = output_parameters.get('stream_output',{}).get('mask_output',{})
+        if stream_output_mask:
+            mask_list = nhd_io.stream_output_mask_reader(stream_output_mask)
+            output_parameters['stream_output']['mask'] = mask_list
+    
     # configure python logger
     log_level_set(log_parameters)
 


### PR DESCRIPTION
**NOT READY TO MERGE**
This contains a few updates to run on v2.2 of the hydrofabric. These edits have been focused on producing valid output for the inland/coastal coupling exercise. The main features are working with v2.2 of the hydrofabric, accessing gage crosswalk information for streamflow nudging, and accessing POI crosswalk information that is now included in the `stream_output` output files.

**TODO**
We will need to ensure backwards compatibility with older versions of the hydrofabric. This might not be necessary eventually, but for the time being I believe users are still running t-route on older versions, so we want to maintain that.

## Additions

- Retrieve and pass along `poi_crosswalk` info from the hydrofabric to output files.

## Removals

-

## Changes

- Access gage information from a new location in the hydrofabric.

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
