### PR TITLE
if the folder doesn't exist

### DIFF
--- a/src/troute-config/troute/config/output_parameters.py
+++ b/src/troute-config/troute/config/output_parameters.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from pydantic import BaseModel, Field, validator
-import os
+
 from typing import Optional, List
 from typing_extensions import Annotated, Literal
 from .types import FilePath, DirectoryPath
@@ -93,17 +93,25 @@ class ParityCheckCompareFileSet(BaseModel):
 
 class StreamOutput(BaseModel):
     # NOTE: required if writing StreamOutput files
-    stream_output_directory: Optional[str] = None
+    stream_output_directory: Optional[Path] = None
     mask_output: Optional[FilePath] = None
     stream_output_time: int = 1
     stream_output_type:streamOutput_allowedTypes = ".nc"
     stream_output_internal_frequency: Annotated[int, Field(strict=True, ge=5)] = 5
     
-    @validator('stream_output_directory', pre=True, always=True)
+    @validator('stream_output_directory')
     def validate_stream_output_directory(cls, value):
-        if value:
-            if not os.path.exists(value):
-                os.makedirs(value) 
+        if value is None:
+            return None
+            
+        # expand ~/output/dir -> /home/user/output/dir
+        value = value.expanduser()
+        
+        if value.exists() and not value.is_dir():
+            raise ValueError(f"'stream_output_directory'={value!s} is a file, expected directory.")
+
+        # make directory (and intermediates) if they don't exist
+        value.mkdir(parents=True, exist_ok=True)
         return value
     
     @validator('stream_output_internal_frequency')

--- a/src/troute-config/troute/config/output_parameters.py
+++ b/src/troute-config/troute/config/output_parameters.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from pydantic import BaseModel, Field, validator
-
+import os
 from typing import Optional, List
 from typing_extensions import Annotated, Literal
 from .types import FilePath, DirectoryPath
@@ -93,11 +93,19 @@ class ParityCheckCompareFileSet(BaseModel):
 
 class StreamOutput(BaseModel):
     # NOTE: required if writing StreamOutput files
-    stream_output_directory: Optional[DirectoryPath] = None
+    stream_output_directory: Optional[str] = None
     mask_output: Optional[FilePath] = None
     stream_output_time: int = 1
     stream_output_type:streamOutput_allowedTypes = ".nc"
     stream_output_internal_frequency: Annotated[int, Field(strict=True, ge=5)] = 5
+    
+    @validator('stream_output_directory', pre=True, always=True)
+    def validate_stream_output_directory(cls, value):
+        if value:
+            if not os.path.exists(value):
+                os.makedirs(value) 
+        return value
+    
     @validator('stream_output_internal_frequency')
     def validate_stream_output_internal_frequency(cls, value, values):
         if value is not None:


### PR DESCRIPTION
In the current implementation, if the user specifies a directory for `stream_output_directory` (e.g., `output/`) that doesn't exist, it results in an error. With the new PR, the code automatically creates the specified directory if it doesn't exist, allowing the output to be saved in that folder without any issues.

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
