### PR TITLE
remove fiona dep, require non-dev geopandas

### DIFF
--- a/.github/workflows/ubuntu-latest.yml
+++ b/.github/workflows/ubuntu-latest.yml
@@ -40,7 +40,7 @@ jobs:
         sudo apt-get install libstdc++-10-dev libgfortran-10-dev glibc-source openmpi-bin openmpi-common libopenmpi-dev libopenmpi3 libgtk-3-bin libgtk-3-common libgtk-3-dev -y
         sudo apt-get install netcdf-bin libnetcdf-dev libnetcdff-dev libnetcdf-c++4 libnetcdf-c++4-dev -y
         python -m pip install --upgrade pip
-        pip3 install wheel dask pyproj fiona bmipy opencv-contrib-python-headless
+        pip3 install wheel dask pyproj bmipy opencv-contrib-python-headless
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         
     - name: Install t-route

--- a/src/troute-network/pyproject.toml
+++ b/src/troute-network/pyproject.toml
@@ -7,8 +7,7 @@ name = "troute.network"
 version = "0.0.0"
 dependencies = [
     "deprecated",
-    "geopandas",
-    "fiona",
+    "geopandas>=1.0.0",
     "joblib",
     "netcdf4",
     "numpy",

--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -10,10 +10,8 @@ from itertools import chain
 from joblib import delayed, Parallel
 from collections import defaultdict
 import xarray as xr
-from datetime import datetime
 from pprint import pformat
 import os
-import fiona
 import troute.nhd_io as nhd_io #FIXME
 from troute.nhd_network import reverse_dict, extract_connections, reverse_network, reachable
 from .rfc_lake_gage_crosswalk import get_rfc_lake_gage_crosswalk, get_great_lakes_climatology
@@ -32,7 +30,7 @@ def find_layer_name(layers, pattern):
 
 def read_geopkg(file_path, compute_parameters, waterbody_parameters, cpu_pool):
     # Retrieve available layers from the GeoPackage
-    available_layers = fiona.listlayers(file_path)
+    available_layers = gpd.list_layers(file_path)
 
     # patterns for the layers we want to find
     layer_patterns = {

--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -30,7 +30,7 @@ def find_layer_name(layers, pattern):
 
 def read_geopkg(file_path, compute_parameters, waterbody_parameters, cpu_pool):
     # Retrieve available layers from the GeoPackage
-    available_layers = gpd.list_layers(file_path)
+    available_layers = list(gpd.list_layers(file_path)["name"])
 
     # patterns for the layers we want to find
     layer_patterns = {


### PR DESCRIPTION
Spin off from #833 
### Less intrusive change to remove the dependency on fiona
Until wheels for fiona become available on arm for rockylinux, NGIAB can't build with the explicit dependency. 

This change removes the explicit fiona dependency and substitutes it's use with geopandas.
Versions of geopandas prior to 1.0.0 require fiona so I added a version requirement to pyproject.toml. 
The version is there for completeness but not required for NGIAB as it uses the latest version of geopandas without fiona. The version requirement could be dropped to allow pip to install fiona if needed for installations where geopandas<1.0.0 .