### PR TITLE
Update readme.md: removed obsolete no-e option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -92,10 +92,6 @@ git clone --progress --single-branch --branch master http://github.com/NOAA-OWP/
 # compile and install
 ./compiler.sh
 
-# In the event that compilation results does not complete and throws a Cython compile error, rerun with a non-editable flag:
-./compiler.sh no-e
-# [ this is a known issue, and may happen in fresh t-route clones; please see https://github.com/NOAA-OWP/t-route/issues/675 for details ]
-
 # execute a demonstration test with NHD network
 cd test/LowerColorado_TX
 python3 -m nwm_routing -f -V4 test_AnA_V4_NHD.yaml


### PR DESCRIPTION
The non-editable flag:
./compiler.sh no-e
is no longer necessary 

(see https://github.com/NOAA-OWP/t-route/issues/675 for details)

[Short description explaining the high-level reason for the pull request]

## Additions

-

## Removals

- non-editable flag from compiler.sh

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
