### PR TITLE
fix: `DataFrame` merge error on `id` field for HF >= 2.2

### DIFF
--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -88,8 +88,11 @@ def read_geopkg(file_path, compute_parameters, waterbody_parameters, cpu_pool):
     flowpaths_df = table_dict.get('flowpaths', pd.DataFrame())
     flowpath_attributes_df = table_dict.get('flowpath_attributes', pd.DataFrame())
 
-    # Check if 'link' column exists and rename it to 'id'
+    # Check if 'link' column exists; drop existing 'id' col; rename 'link' to 'id'
     if 'link' in flowpath_attributes_df.columns:
+        # In HF 2.2, a 'link' field was introduced. The field is identical to
+        # previous version's 'id' field, but it preferred moving forwards.
+        flowpath_attributes_df.drop(columns=['id'], errors='ignore', inplace=True)
         flowpath_attributes_df.rename(columns={'link': 'id'}, inplace=True) 
      
     # Merge flowpaths and flowpath_attributes 

--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -95,12 +95,19 @@ def read_geopkg(file_path, compute_parameters, waterbody_parameters, cpu_pool):
         flowpath_attributes_df.drop(columns=['id'], errors='ignore', inplace=True)
         flowpath_attributes_df.rename(columns={'link': 'id'}, inplace=True) 
      
+    # NOTE: aaraney: `flowpaths_df` and `flowpath_attributes_df` can share
+    # column names but this is not accounted for elsewhere. im not sure if it
+    # is okay to assume that if the left and right df have the same `id` field
+    # that the other shared columns will match and thus it is safe to set, for
+    # example, the left suffix to "".
     # Merge flowpaths and flowpath_attributes 
     flowpaths = pd.merge(
         flowpaths_df, 
         flowpath_attributes_df, 
         on='id', 
-        how='inner'
+        how='inner',
+        # NOTE: aaraney: not sure if this is safe
+        suffixes=("", "_flowpath_attributes"),
     )
 
     lakes = table_dict.get('lakes', pd.DataFrame())


### PR DESCRIPTION
## Problem:

t-route tries to join two dataframes where one dataframe has two columns with the same name, `id`. A `ValueError` is raised b.c. the column labels are not unique. This seemingly only affects running t-route with HF 2.2.

HF 2.2 introduced a `link` field to the `flowpath-attributes` table. Per the [HF schema docs](https://lynker-spatial.s3-us-west-2.amazonaws.com/hydrofabric/v2.2/hfv2.2-data_model.html), this field is a duplication of the existing `id` field needed for t-route (@shorvath-noaa can you provide background on this?). If t-route detects the `link` field, t-route will rename it from `link` -> `id` causing a column name duplication. Later code joins this dataframe using the `id` field and this causes the aforementioned exception.

## Proposed Solution:

If `link` field is present, drop `id` field _then_ rename `link` to `id`.

This seems to have been addressed in #847 however the change is so minor IMO a smaller PR will be easier to review and resolve issues in using `t-route` with HF 2.2.