### PR TITLE
fix: mask_output fvd aggregation

### DIFF
--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -2336,6 +2336,9 @@ def updated_flowveldepth(flowveldepth, nex_id, seg_id, mask_list):
         all_nex_data['Type'] = 'nex'        
         # Set the new 'Type' column as an index
         all_nex_data = all_nex_data.set_index('Type', append=True)
+
+        # Reindex to (n, f), (n, v), (n, d), ...
+        all_nex_data = all_nex_data.reindex(flowveldepth.columns, axis=1)
         
     else:
         all_nex_data = pd.DataFrame()


### PR DESCRIPTION
If a `output_parameters->stream_output->mask_output` file was configured, the flows, velocities, and depths written to disk are an erroneous mixture of flows, velocities, and depths. For example, the `flow` field for a given `feature_id` contains values for a mixture of aggregated flows, velocities, and depths. Not the expected flows.

This patch corrects this behavior so the expected aggregated flows _and_ depths are produced. However, I am not certain that velocities are correctly aggregated. I observed NAN values returned for aggregated velocities. The [`optimized_v_data`](https://github.com/NOAA-OWP/t-route/blob/aa320a24de48124c1e2fbdaca5fc34292fb061b1/src/troute-network/troute/nhd_io.py#L2293) subroutine needs to be checked to ensure velocity values are correctly aggregated.

## Technical Description

If a `output_parameters->stream_output->mask_output` file is included _and_ contains a `nex` section, `t-route` will aggregate contributions from flowpaths directly upstream of a `nex`us. The [aggregation subroutine](https://github.com/noaa-owp/t-route/blob/738f845055237b5561cb22eeb8c0b792dddff723/src/troute-network/troute/nhd_io.py#L2347) contained an error which changed the output column ordering of the flow velocity depth dataframe changes from `(0, q), (0, v), (0, d), ...` to `(0, q), (1, q), (0, v), (1, v), (0, d), (1, d), ...`. [The subroutine](https://github.com/noaa-owp/t-route/blob/738f845055237b5561cb22eeb8c0b792dddff723/src/troute-network/troute/nhd_io.py#L2401) that operated on the potentially aggregated flow, velocity, and depth dataframe expects the `(0, q), (0, v), (0, d), ...` column ordering. The mismatching expectations resulted in erroneous flow velocity and depth values written to disk. For example, the `flow` field for a given `feature_id` would contain values for a mixture of aggregated flows, velocities, and depths. Not the expected flows.

Reindexing the flow velocity depth dataframe returned from the aggregation subroutine resolves this issue.