### PR TITLE
Single input forcing and output t-route files

### DIFF
--- a/compiler.sh
+++ b/compiler.sh
@@ -12,15 +12,21 @@ build_routing=true
 build_config=true
 build_nwm=true
 
-if [ -z "$F90" ]
+
+if [ -z "$FC" ]
 then
-    export F90="gfortran"
-    echo "using F90=${F90}"
+    FC=gfortran
+    echo "FC environmental variable not set. Defaulting to FC=${FC}"
+else
+    echo "Using environmental Fortran compiler: FC=${FC}"
 fi
+
 if [ -z "$CC" ]
 then
-    export CC="gcc"
-    echo "using CC=${CC}"
+    CC=gcc
+    echo "CC environmental variable not set. Defaulting to CC=${CC}"
+else
+    echo "Using environmental C compiler: CC=${CC}"
 fi
 
 #preserve old/default behavior of installing packages with -e

--- a/install.sh
+++ b/install.sh
@@ -6,15 +6,32 @@ set -e
 echo "--- Starting t-route Installation ---"
 
 # If on a cluster platform that requires module load
-# commands to load up python, cmake, netcdf, and/or gcc
-# then go ahead and insert those moudle commands here. 
-# Below are example moudle load commnads for the NOAA
-# RDHPCS Ursa cluster
+# commands to load up python, cmake, netcdf, and gcc 
+# or intel compilers and then go ahead and insert 
+# those module commands here. Below are example 
+# module load commands for the NOAA RDHPCS Ursa cluster
 module purge
-module load hpcx-mpi/2.18.1
+
+####### gcc/gfortran compilers ##############
+#module load hpcx-mpi/2.18.1
+#module load netcdf-fortran/4.6.1
+#module load cmake/3.30.2
+#module load python/3.11
+#export FC=gfortran
+#export CC=gcc
+#export CXX=g++
+############################################
+
+####### intel compilers ####################
+module load intel-oneapi-compilers/2025.1.1
+module load intel-oneapi-mpi/2021.15.0
 module load netcdf-fortran/4.6.1
 module load cmake/3.30.2
 module load python/3.11
+export FC=mpiifx
+export CC=mpiicx
+export CXX=mpiicpx
+############################################
 
 
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+echo "--- Starting t-route Installation ---"
+
+# If on a cluster platform that requires module load
+# commands to load up python, cmake, netcdf, and/or gcc
+# then go ahead and insert those moudle commands here. 
+# Below are example moudle load commnads for the NOAA
+# RDHPCS Ursa cluster
+module purge
+module load hpcx-mpi/2.18.1
+module load netcdf-fortran/4.6.1
+module load cmake/3.30.2
+module load python/3.11
+
+
+
+# User defined installation pathway to the virtual Python
+# for t-route needs to be set here! Otherwise, default is 
+# in the t-route root directory
+INSTALL_DIR=$(pwd)
+
+# System dependency check to ensure we have all the required
+# compilers and libraries for t-route
+dependencies=("gcc" "gfortran" "cmake" "python3" "nc-config" "nf-config")
+
+for tool in "${dependencies[@]}"; do
+    if ! command -v "$tool" &> /dev/null; then
+        echo "Error: $tool is not installed or not in PATH."
+        echo "Please install the missing dependency before running the t-route installation script."
+        exit 1
+    fi
+done
+
+# Set compiler definitions based on user defined environmental variables 
+# or defer to standard defaults
+export FC=${FC:-gfortran}
+export CC=${CC:-gcc}
+export CXX=${CXX:-g++}
+
+
+# Create virtual environment
+if [ ! -d "venv" ]; then
+    echo "Creating virtual Python environment for t-route..."
+    python3 -m venv venv
+fi
+
+
+# Automatically extract paths from the system's NetCDF installation
+NC_LIB_PATH=$(nc-config --prefix)/lib
+NF_LIB_PATH=$(nf-config --prefix)/lib
+NC_INC=$(nc-config --includedir)
+
+# Set Linker flags so the compiler knows where the NetCDF binaries live
+export LDFLAGS="-L${NC_LIB_PATH} -L${NF_LIB_PATH} -Wl,-rpath,${NC_LIB_PATH} -Wl,-rpath,${NF_LIB_PATH}"
+export NETCDF="${NC_INC}"
+
+
+echo "Installing t-route libraries and it's internal dependencies..."
+
+# Activate Python virtual environment, install baseline
+# Python dependencies for t-route libraries, and then 
+# install the t-route libraries for Python
+source $INSTALL_DIR/venv/bin/activate && \
+$INSTALL_DIR/venv/bin/pip install --upgrade pip~=24.0 && \
+$INSTALL_DIR/venv/bin/pip install -r requirements.txt && \
+env LDFLAGS="$(nc-config --libs) $(nf-config --flibs)" NETCDF=$(nc-config --includedir) ./compiler.sh no-e
+
+echo "--- Installation Complete! ---"
+

--- a/readme.md
+++ b/readme.md
@@ -53,7 +53,7 @@ T-Route represents streamflow channel routing and reservoir routing, assimilatin
 This program uses the following system packages:
 ```
 python3
-gcc-gfortran
+gcc-gfortran OR Intel compilers
 ```
 
 ... and the following non-default python modules:
@@ -89,8 +89,14 @@ pip3 install numpy pandas xarray netcdf4 joblib toolz pyyaml Cython>3,!=3.0.4 ge
 # clone t-toute
 git clone --progress --single-branch --branch master http://github.com/NOAA-OWP/T-Route.git
 
+## Installation Option 1 for direct installation using precompiled Python environment
 # compile and install
 ./compiler.sh
+
+## Installation Option 2 to install a virtual Python environment for t-route modules
+# compile and install
+./install.sh
+
 
 # execute a demonstration test with NHD network
 cd test/LowerColorado_TX

--- a/src/kernel/diffusive/makefile
+++ b/src/kernel/diffusive/makefile
@@ -1,15 +1,18 @@
 # compiler
-FC := ${F90}
+FC := ${FC}
 
 # compile flags
 F90FLAGSGFORTRAN = -g -c -O2 -fPIC -fbounds-check 
 F90FLAGSINTEL = -free -g -c -O2 -fPIC -I${NETCDF}/include 
-ifeq ($(notdir ${FC}), ifort)
-FCFLAGS = $(F90FLAGSINTEL)
-else ifeq ($(notdir ${FC}), mpiifort)
-FCFLAGS = $(F90FLAGSINTEL)
+
+FC_VERSION := $(shell $(FC) --version 2>&1 || true)
+
+IS_INTEL := $(findstring Intel,$(FC_VERSION))$(findstring ifx,$(FC_VERSION))$(findstring ifort,$(FC_VERSION))
+
+ifneq ($(strip $(IS_INTEL)),)
+    FCFLAGS = $(F90FLAGSINTEL)
 else
-FCFLAGS = $(F90FLAGSGFORTRAN)
+    FCFLAGS = $(F90FLAGSGFORTRAN)
 endif
 
 diffusive.o: diffusive.f90

--- a/src/kernel/muskingum/makefile
+++ b/src/kernel/muskingum/makefile
@@ -1,18 +1,20 @@
 # compiler
-FC := $(F90)
+FC := $(FC)
 
 # compile flags
 #FCFLAGS = -c -fdefault-real-8 -fno-align-commons -fbounds-check --free-form
 F90FLAGSGFORTRAN = -g -c -O2 -fPIC -lgfortran -lgcc -static-libgfortran -static-libgcc -nodefaultlibs
 F90FLAGSINTEL = -free -w -c -O2 -fPIC -fconvert=big-endian -frecord-marker=4
-ifeq ($(notdir ${FC}), ifort)
-F90FLAGS = $(F90FLAGSINTEL)
-else ifeq ($(notdir ${FC}), mpiifort)
-F90FLAGS = $(F90FLAGSINTEL)
-else
-F90FLAGS = $(F90FLAGSGFORTRAN)
-endif
 
+FC_VERSION := $(shell $(FC) --version 2>&1 || true)
+
+IS_INTEL := $(findstring Intel,$(FC_VERSION))$(findstring ifx,$(FC_VERSION))$(findstring ifort,$(FC_VERSION))
+
+ifneq ($(strip $(IS_INTEL)),)
+    F90FLAGS = $(F90FLAGSINTEL)
+else
+    F90FLAGS = $(F90FLAGSGFORTRAN)
+endif
 
 .PHONY: reach all install
 all: reach 

--- a/src/kernel/reservoir/makefile
+++ b/src/kernel/reservoir/makefile
@@ -13,17 +13,20 @@ endif
 NETCDFINC := -I$(NETCDFINC) $(NETCDFINC_FLAGS)
 NETCDFLIB := $(NETCDFLIB_FLAGS)
 
-COMPILER90 = $(F90)
+FC = $(FC)
 
 F90FLAGSGFORTRAN = -w -c -ffree-form -ffree-line-length-none -fconvert=big-endian -frecord-marker=4 -static-libgfortran -lgfortran -lgcc -static-libgcc 
 F90FLAGSINTEL = -free -w -c -O2 -fconvert=big-endian -frecord-marker=4
-ifeq ($(notdir ${FC}), ifort)
-F90FLAGS = $(F90FLAGSINTEL)
-else ifeq ($(notdir ${FC}), mpiifort)
-F90FLAGS = $(F90FLAGSINTEL)
-else
-F90FLAGS = $(F90FLAGSGFORTRAN)
-endif
+
+FC_VERSION := $(shell $(FC) --version 2>&1 || true)
+
+IS_INTEL := $(findstring Intel,$(FC_VERSION))$(findstring ifx,$(FC_VERSION))$(findstring ifort,$(FC_VERSION))
+
+ifneq ($(strip $(IS_INTEL)),) 
+    F90FLAGS = $(F90FLAGSINTEL)
+else     
+    F90FLAGS = $(F90FLAGSGFORTRAN)
+endif 
 
 F90FLAGS := -g $(F90FLAGS) $(NETCDFINC) $(NETCDFLIB)  -nodefaultlibs -fPIC
 ARFLAGS = rc
@@ -35,10 +38,10 @@ VPATH = ./Level_Pool ./Persistence_Level_Pool_Hybrid ./RFC_Forecasts
 all: binding_lp.a bind_hybrid.a bind_rfc.a
 
 test_main: test_main.o binding_lp.a bind_hybrid.a bind_rfc.a
-	$(COMPILER90) -g -o $@ $^
+	$(FC) -g -o $@ $^
 
 test_main.o: test_binding.c
-	$(COMPILER90) -g -c -o $@ $<
+	$(FC) -g -c -o $@ $<
 
 module_levelpool.o: module_reservoir.o module_levelpool_properties.o module_levelpool_state.o
 
@@ -62,10 +65,10 @@ bind_rfc.a: module_reservoir.o module_hydro_stop.o module_reservoir_utilities.o 
 	$(AR) $(ARFLAGS) $@ $^
 
 %.o: %.F
-	$(COMPILER90) $(F90FLAGS) $(NETCDFLIB) -c -o $@ $<
+	$(FC) $(F90FLAGS) $(NETCDFLIB) -c -o $@ $<
 
 %.o: %.f90
-	$(COMPILER90) $(F90FLAGS) $(NETCDFLIB) -c -o $@ $<
+	$(FC) $(F90FLAGS) $(NETCDFLIB) -c -o $@ $<
 
 #install: binding_lp.a bind_hybrid.a bind_rfc.a
 #install: binding_lp.a bind_rfc.a

--- a/src/kernel/reservoir/makefile
+++ b/src/kernel/reservoir/makefile
@@ -13,7 +13,7 @@ endif
 NETCDFINC := -I$(NETCDFINC) $(NETCDFINC_FLAGS)
 NETCDFLIB := $(NETCDFLIB_FLAGS)
 
-FC = $(FC)
+FC := $(FC)
 
 F90FLAGSGFORTRAN = -w -c -ffree-form -ffree-line-length-none -fconvert=big-endian -frecord-marker=4 -static-libgfortran -lgfortran -lgcc -static-libgcc 
 F90FLAGSINTEL = -free -w -c -O2 -fconvert=big-endian -frecord-marker=4

--- a/src/kernel/reservoir/makefile
+++ b/src/kernel/reservoir/makefile
@@ -1,5 +1,18 @@
-NETCDFINC := -I$(NETCDFINC) $(shell nc-config --fflags)
-NETCDFLIB := $(shell nc-config --flibs)
+NF_CONFIG := $(shell command -v nf-config 2> /dev/null)
+
+ifdef NF_CONFIG
+    # Modern approach (NetCDF-Fortran separated from NetCDF-C)
+    NETCDFINC_FLAGS := $(shell nf-config --fflags)
+    NETCDFLIB_FLAGS := $(shell nf-config --flibs)
+else
+    # Legacy fallback for older versions or monolithic installs
+    NETCDFINC_FLAGS := $(shell nc-config --fflags 2> /dev/null || nc-config --cflags)
+    NETCDFLIB_FLAGS := $(shell nc-config --flibs 2> /dev/null || nc-config --libs)
+endif
+
+NETCDFINC := -I$(NETCDFINC) $(NETCDFINC_FLAGS)
+NETCDFLIB := $(NETCDFLIB_FLAGS)
+
 COMPILER90 = $(F90)
 
 F90FLAGSGFORTRAN = -w -c -ffree-form -ffree-line-length-none -fconvert=big-endian -frecord-marker=4 -static-libgfortran -lgfortran -lgcc -static-libgcc 

--- a/src/troute-config/troute/config/compute_parameters.py
+++ b/src/troute-config/troute/config/compute_parameters.py
@@ -430,6 +430,10 @@ class ForcingParameters(BaseModel):
     Value is in hours. To handle memory issues, t-route can divvy it's simulation time into chunks, reducing the amount 
     of forcing and data assimilation files it reads into memory at once. This is the size of those time loops.
     """
+    qlat_input_file: Optional[str] = None
+    """
+    Single q_lateral forcing file. If this parameter is provided, 'qlat_file_pattern_filter' is ignored.
+    """
     qlat_file_index_col: str = "feature_id"
     """
     Name of column containing flowpath/nexus IDs

--- a/src/troute-config/troute/config/output_parameters.py
+++ b/src/troute-config/troute/config/output_parameters.py
@@ -25,6 +25,7 @@ class OutputParameters(BaseModel):
     test_output: Optional[Path] = None
     stream_output: Optional["StreamOutput"] = None
     lastobs_output: Optional[DirectoryPath] = None
+    netcdf_stream_output: Optional["NetcdfStreamOutput"] = None
 
 
 class ChanobsOutput(BaseModel):
@@ -189,7 +190,36 @@ class StreamOutput(BaseModel):
             if values.get('stream_output_time') != -1 and value / 60 > values['stream_output_time']:
                 raise ValueError("stream_output_internal_frequency should be less than or equal to stream_output_time in minutes.")
         return value
- 
+
+class NetcdfStreamOutput(BaseModel):
+    """
+    Configuration for a pre-allocated NetCDF output writer. This will output a single NetCDF file containing all locations and 
+    time steps for the full simulation.
+    """
+    output_path: str
+    """
+    Filepath to save output.
+    """
+    output_interval: int = 3600
+    """
+    Frequency of output in seconds.
+    """
+    subset_file: Optional[str] = None
+    """
+    Path to yaml file specifying flowpath IDs to include in output file.
+    """
+    variables: List[str] = ["streamflow", "velocity", "depth", "nudge"]
+    """
+    Variables to write. 
+    """
+    
+    # Validator to ensure variables are valid
+    @validator('variables')
+    def valid_variables(cls, v):
+        valid_set = {'streamflow', 'velocity', 'depth', 'nudge'}
+        if not set(v).issubset(valid_set):
+            raise ValueError(f"Variables must be a subset of {valid_set}")
+        return v
 
 OutputParameters.update_forward_refs()
 WrfHydroParityCheck.update_forward_refs()

--- a/src/troute-config/troute/config/output_parameters.py
+++ b/src/troute-config/troute/config/output_parameters.py
@@ -25,7 +25,7 @@ class OutputParameters(BaseModel):
     test_output: Optional[Path] = None
     stream_output: Optional["StreamOutput"] = None
     lastobs_output: Optional[DirectoryPath] = None
-    netcdf_stream_output: Optional["NetcdfStreamOutput"] = None
+    netcdf_output: Optional["NetcdfOutput"] = None
 
 
 class ChanobsOutput(BaseModel):
@@ -191,35 +191,84 @@ class StreamOutput(BaseModel):
                 raise ValueError("stream_output_internal_frequency should be less than or equal to stream_output_time in minutes.")
         return value
 
-class NetcdfStreamOutput(BaseModel):
+class NetcdfOutputVariables(BaseModel):
     """
-    Configuration for a pre-allocated NetCDF output writer. This will output a single NetCDF file containing all locations and 
-    time steps for the full simulation.
+    Controls which variables are written for each feature type.
+    
+    Omitting either sub-key falls back to its full default list.  Reservoir
+    output is skipped entirely if the simulation has no waterbodies, regardless
+    of what is listed under 'reservoir'.
+    """
+    stream: List[str] = ['streamflow', 'velocity', 'depth', 'nudge']
+    """
+    Variables to write for flowpath and nexus rows.
+    Valid options: streamflow, velocity, depth, nudge
+    NOTE: Only streamflow will be written for nexus rows.
+    """
+    reservoir: Optional[List[str]] = ['inflow', 'outflow', 'water_sfc_elev']
+    """
+    Variables to write for reservoir rows.
+    Valid options: inflow, outflow, water_sfc_elev
+    #TODO: add 'reservoir_assimilated_value' as an output variable?
+    """
+ 
+    @validator('stream')
+    def valid_stream_variables(cls, v):
+        valid = {'streamflow', 'velocity', 'depth', 'nudge'}
+        bad = set(v) - valid
+        if bad:
+            raise ValueError(
+                f"Invalid stream variable(s) {bad}. Must be a subset of {valid}.")
+        return v
+ 
+    @validator('reservoir')
+    def valid_reservoir_variables(cls, v):
+        if v is None:
+            return v
+        valid = {'inflow', 'outflow', 'water_sfc_elev'}
+        bad = set(v) - valid
+        if bad:
+            raise ValueError(...)
+        return v
+ 
+ 
+class NetcdfOutput(BaseModel):
+    """
+    Produces a single NetCDF file containing all requested locations and timesteps for
+    the full simulation.
+    
+    Stream and reservoir outputs are co-located in the same file under
+    separate dimensions (flowpath_id / lake_id). Reservoir variables are
+    only written when the simulation contains waterbodies.
     """
     output_path: str
-    """
-    Filepath to save output.
-    """
+    """Filepath to save output."""
+ 
     output_interval: int = 3600
-    """
-    Frequency of output in seconds.
-    """
+    """Frequency of output in seconds."""
+ 
     subset_file: Optional[str] = None
     """
-    Path to yaml file specifying flowpath IDs to include in output file.
+    Path to a YAML file specifying which IDs to include in the output.
+    Accepted keys: 'feature_ids' (wb flowpath integers or 'wb-NNNN' strings) 
+    and/or 'nexuses' (nexus IDs as integers or 'nex-NNNN' strings).
+    Both may be present in the same file to mix flowpath and nexus rows in the output.
     """
-    variables: List[str] = ["streamflow", "velocity", "depth", "nudge"]
+ 
+    variables: NetcdfOutputVariables = NetcdfOutputVariables()
     """
-    Variables to write. 
+    Variables to write, split by feature type.  Defaults to all available
+    variables for both streams and reservoirs.
     """
-    
-    # Validator to ensure variables are valid
-    @validator('variables')
-    def valid_variables(cls, v):
-        valid_set = {'streamflow', 'velocity', 'depth', 'nudge'}
-        if not set(v).issubset(valid_set):
-            raise ValueError(f"Variables must be a subset of {valid_set}")
+ 
+    @validator('variables', pre=True, always=True)
+    def coerce_variables(cls, v):
+        if v is None:
+            return NetcdfOutputVariables()
+        if isinstance(v, dict):
+            return NetcdfOutputVariables(**v)
         return v
 
+    
 OutputParameters.update_forward_refs()
 WrfHydroParityCheck.update_forward_refs()

--- a/src/troute-network/troute/AbstractNetwork.py
+++ b/src/troute-network/troute/AbstractNetwork.py
@@ -102,6 +102,7 @@ class AbstractNetwork(ABC):
         dt                           = self.forcing_parameters.get("dt", None)
         qts_subdivisions             = self.forcing_parameters.get("qts_subdivisions", None)
         qlat_input_folder            = self.forcing_parameters.get("qlat_input_folder", None)
+        qlat_input_file              = self.forcing_parameters.get("qlat_input_file", None)
         qlat_file_index_col          = self.forcing_parameters.get("qlat_file_index_col", "feature_id")
         qlat_file_value_col          = self.forcing_parameters.get("qlat_file_value_col", "q_lateral")
         qlat_file_gw_bucket_flux_col = self.forcing_parameters.get("qlat_file_gw_bucket_flux_col", "qBucket")
@@ -113,6 +114,7 @@ class AbstractNetwork(ABC):
         run["dt"]                           = run.get("dt", dt)
         run["qts_subdivisions"]             = run.get("qts_subdivisions", qts_subdivisions)
         run["qlat_input_folder"]            = run.get("qlat_input_folder", qlat_input_folder)
+        run["qlat_input_file"]              = run.get("qlat_input_file", qlat_input_file)
         run["qlat_file_index_col"]          = run.get("qlat_file_index_col", qlat_file_index_col)
         run["qlat_file_value_col"]          = run.get("qlat_file_value_col", qlat_file_value_col)
         run["qlat_file_gw_bucket_flux_col"] = run.get("qlat_file_gw_bucket_flux_col", qlat_file_gw_bucket_flux_col)
@@ -749,6 +751,7 @@ class AbstractNetwork(ABC):
         nts                = forcing_parameters.get("nts", None)
         max_loop_size      = forcing_parameters.get("max_loop_size", 12)
         dt                 = forcing_parameters.get("dt", None)
+        qlat_input_file    = forcing_parameters.get("qlat_input_file", None)
 
         try:
             qlat_input_folder = pathlib.Path(qlat_input_folder)
@@ -760,38 +763,65 @@ class AbstractNetwork(ABC):
 
         forcing_glob_filter = forcing_parameters["qlat_file_pattern_filter"]
         binary_folder = forcing_parameters.get('binary_nexus_file_folder', None)
-
-        if forcing_glob_filter=="nex-*" and binary_folder:
-            print("Reformating qlat nexus files as hourly binary files...")
-            qlat_files = qlat_input_folder.glob(forcing_glob_filter)
-
-            #Check that directory/files specified will work
-            if not binary_folder:
-                raise(RuntimeError("No output binary qlat folder supplied in config"))
-            elif not os.path.exists(binary_folder):
-                raise(RuntimeError("Output binary qlat folder supplied in config does not exist"))
-            
-            #Add tnx for backwards compatability
-            qlat_files_list = list(qlat_files) + list(qlat_input_folder.glob('tnx*.csv'))
-            #Convert files to binary hourly files, reset nexus input information
-            qlat_input_folder, forcing_glob_filter = nex_files_to_binary(qlat_files_list, binary_folder)
-            forcing_parameters["qlat_input_folder"] = qlat_input_folder
-            forcing_parameters["qlat_file_pattern_filter"] = forcing_glob_filter
         
-        if forcing_glob_filter=="nex-*":
-            all_files = sorted(qlat_input_folder.glob(forcing_glob_filter))
-            final_timestamp = pd.read_csv(all_files[0], header=None, index_col=[0]).tail(1).iloc[0,0]
-            final_timestamp = datetime.strptime(final_timestamp.strip(), "%Y-%m-%d %H:%M:%S")
-            
-            all_files = [os.path.basename(f) for f in all_files]
-            
-            run_sets = [
-                {
-                    'qlat_files': all_files,
-                    'nts': nts,
-                    'final_timestamp': final_timestamp
-                }
-            ]
+        if qlat_input_file:
+            filename, extension = os.path.splitext(qlat_input_file)
+            if extension=='.nc':
+                # Derive total duration strictly from steps
+                total_duration = pd.Timedelta(seconds=dt * nts)
+                end_time = self.t0 + total_duration
+
+                # Define the "Master Clock" broken into chunks
+                # freq=f"{max_loop_size_hours}h" creates strict hourly breaking points
+                # inclusive="left" ensures we don't create an empty zero-length chunk at the very end
+                chunk_starts = pd.date_range(start=self.t0, end=end_time, freq=f"{max_loop_size}h", inclusive="left")
+
+                run_sets = []
+
+                for i, start in enumerate(chunk_starts):
+                    run_sets.append({})
+                    
+                    # Calculate the theoretical end of this chunk (e.g., +1 hour)
+                    theoretical_end = start + pd.Timedelta(hours=max_loop_size)
+                    
+                    # Cap the end at the simulation's actual end time (handles partial last hours)
+                    actual_end = min(theoretical_end, end_time)
+
+                    run_sets[i]['timestamps'] = [start, actual_end]
+                    run_sets[i]['nts'] = int(round((actual_end - start).total_seconds() / dt))
+                
+        elif forcing_glob_filter=="nex-*":
+            if binary_folder:
+                print("Reformating qlat nexus files as hourly binary files...")
+                qlat_files = qlat_input_folder.glob(forcing_glob_filter)
+
+                #Check that directory/files specified will work
+                if not binary_folder:
+                    raise(RuntimeError("No output binary qlat folder supplied in config"))
+                elif not os.path.exists(binary_folder):
+                    raise(RuntimeError("Output binary qlat folder supplied in config does not exist"))
+                
+                #Add tnx for backwards compatability
+                qlat_files_list = list(qlat_files) + list(qlat_input_folder.glob('tnx*.csv'))
+                #Convert files to binary hourly files, reset nexus input information
+                qlat_input_folder, forcing_glob_filter = nex_files_to_binary(qlat_files_list, binary_folder)
+                forcing_parameters["qlat_input_folder"] = qlat_input_folder
+                forcing_parameters["qlat_file_pattern_filter"] = forcing_glob_filter
+
+            else:
+                all_files = sorted(qlat_input_folder.glob(forcing_glob_filter))
+                final_timestamp = pd.read_csv(all_files[0], header=None, index_col=[0]).tail(1).iloc[0,0]
+                final_timestamp = datetime.strptime(final_timestamp.strip(), "%Y-%m-%d %H:%M:%S")
+                
+                all_files = [os.path.basename(f) for f in all_files]
+                
+                run_sets = [
+                    {
+                        'qlat_files': all_files,
+                        'nts': nts,
+                        'final_timestamp': final_timestamp
+                    }
+                ]
             
         # TODO: Throw errors if insufficient input data are available
         elif run_sets:        

--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -918,7 +918,11 @@ class HYFeaturesNetwork(AbstractNetwork):
             'gages': self._gages,
             'usgs_lake_gage_crosswalk': self._usgs_lake_gage_crosswalk,
             'usace_lake_gage_crosswalk': self._usace_lake_gage_crosswalk,
-            'rfc_lake_gage_crosswalk': self._rfc_lake_gage_crosswalk
+            'rfc_lake_gage_crosswalk': self._rfc_lake_gage_crosswalk,
+            'duplicate_ids_ds': self._duplicate_ids_df,
+            'gl_climatology_df': self._gl_climatology_df,
+            'poi_nex_dict': self._poi_nex_dict,
+            'nexus_dict': self._nexus_dict
         }
         np.save(
             Path(destination_folder).joinpath(output_filename),
@@ -948,6 +952,10 @@ class HYFeaturesNetwork(AbstractNetwork):
             self._usgs_lake_gage_crosswalk = inputs.get('usgs_lake_gage_crosswalk',None)
             self._usace_lake_gage_crosswalk = inputs.get('usace_lake_gage_crosswalk',None)
             self._rfc_lake_gage_crosswalk = inputs.get('rfc_lake_gage_crosswalk',None)
+            self._duplicate_ids_df = inputs.get('duplicate_ids_df',None)
+            self._gl_climatology_df = inputs.get('gl_climatology_df',None)
+            self._poi_nex_dict = inputs.get('poi_nex_dict',None)
+            self._nexus_dict = inputs.get('nexus_dict',None)
 
 
 def read_file(file_name):

--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -87,23 +87,27 @@ def read_geopkg(file_path, compute_parameters, waterbody_parameters, cpu_pool):
     # Handle different key column names between flowpaths and flowpath_attributes
     flowpaths_df = table_dict.get('flowpaths', pd.DataFrame())
     flowpath_attributes_df = table_dict.get('flowpath_attributes', pd.DataFrame())
-
-    # Check if 'link' column exists and rename it to 'id'
+    
+    # Check if 'link' column exists; drop existing 'id' col; rename 'link' to 'id'
     if 'link' in flowpath_attributes_df.columns:
-        flowpath_attributes_df.rename(columns={'link': 'id'}, inplace=True) 
-     
+        # In HF 2.2, a 'link' field was introduced. The field is identical to
+        # previous version's 'id' field, but it preferred moving forwards.
+        flowpath_attributes_df.drop(columns=['id'], errors='ignore', inplace=True)
+        flowpath_attributes_df.rename(columns={'link': 'id'}, inplace=True)
+        
     # Merge flowpaths and flowpath_attributes 
     flowpaths = pd.merge(
         flowpaths_df, 
         flowpath_attributes_df, 
         on='id', 
-        how='inner'
+        how='inner',
+        suffixes=("", "_flowpath_attributes"),
     )
 
     lakes = table_dict.get('lakes', pd.DataFrame())
     network = table_dict.get('network', pd.DataFrame())
     nexus = table_dict.get('nexus', pd.DataFrame())
-
+    
     return flowpaths, lakes, network, nexus
 
 def read_json(file_path, edge_list):
@@ -457,14 +461,13 @@ class HYFeaturesNetwork(AbstractNetwork):
         # If waterbodies are being simulated, create waterbody dataframes and dictionaries
         if not lakes.empty:
             self._waterbody_df = (
-                lakes[['hl_link','ifd','LkArea','LkMxE','OrificeA',
-                       'OrificeC','OrificeE','WeirC','WeirE','WeirL','id']]
-                .rename(columns={'hl_link': 'lake_id'})
+                lakes[['lake_id','ifd','LkArea','LkMxE','OrificeA',
+                       'OrificeC','OrificeE','WeirC','WeirE','WeirL']]
                 )
             
-            id = self.waterbody_dataframe['id'].str.split('-', expand=True).iloc[:,1]
-            self._waterbody_df['id'] = id
-            self._waterbody_df['id'] = self._waterbody_df.id.astype(float).astype(int)
+            # id = self.waterbody_dataframe['id'].str.split('-', expand=True).iloc[:,1]
+            # self._waterbody_df['id'] = id
+            # self._waterbody_df['id'] = self._waterbody_df.id.astype(float).astype(int)
             self._waterbody_df['lake_id'] = self.waterbody_dataframe.lake_id.astype(float).astype(int)
             self._waterbody_df = self.waterbody_dataframe.set_index('lake_id').drop_duplicates().sort_index()
             
@@ -480,31 +483,33 @@ class HYFeaturesNetwork(AbstractNetwork):
             })
             update_dict = dict(self._duplicate_ids_df[['lake_id','synthetic_ids']].values)
             
-            tmp_wbody_conn = self.dataframe[['waterbody']].dropna()
-            tmp_wbody_conn = (
-                tmp_wbody_conn['waterbody']
-                .str.split(',',expand=True)
-                .reset_index()
-                .melt(id_vars='key')
-                .drop('variable', axis=1)
-                .dropna()
-                .astype(int)
-                )
-            tmp_wbody_conn = tmp_wbody_conn[tmp_wbody_conn['value'].isin(self.waterbody_dataframe.index)]
-            self._dataframe = (
-                self.dataframe
-                .reset_index()
-                .merge(tmp_wbody_conn, how='left', on='key')
-                .drop('waterbody', axis=1)
-                .rename(columns={'value': 'waterbody'})
-                .set_index('key')
-            )
+            # tmp_wbody_conn = self.dataframe[['waterbody']].dropna()
+            # tmp_wbody_conn = (
+            #     tmp_wbody_conn['waterbody']
+            #     .str.split(',',expand=True)
+            #     .reset_index()
+            #     .melt(id_vars='key')
+            #     .drop('variable', axis=1)
+            #     .dropna()
+            #     .astype(int)
+            #     )
+            # tmp_wbody_conn = tmp_wbody_conn[tmp_wbody_conn['value'].isin(self.waterbody_dataframe.index)]
+            # import pdb; pdb.set_trace()
+            # self._dataframe = (
+            #     self.dataframe
+            #     .reset_index()
+            #     .merge(tmp_wbody_conn, how='left', on='key')
+            #     .drop('waterbody', axis=1)
+            #     .rename(columns={'value': 'waterbody'})
+            #     .set_index('key')
+            # )
 
             self._waterbody_df = self.waterbody_dataframe.rename(index=update_dict).sort_index()
+            self._dataframe['waterbody'] = self.dataframe.waterbody.astype(pd.Int64Dtype())
             self._dataframe = self.dataframe.replace({'waterbody': update_dict})
             
             #FIXME temp solution for missing waterbody info in hydrofabric
-            self.bandaid()
+            # self.bandaid()
             
             wbody_conn = self.dataframe[['waterbody']].dropna().astype(int).reset_index()
             
@@ -546,8 +551,12 @@ class HYFeaturesNetwork(AbstractNetwork):
                 self._waterbody_df['crs'] = np.nan
                 
             # Add the Great Lakes to the connections dictionary and waterbody dataframe
-            nexus['WBOut_id'] = nexus['hl_uri'].str.extract(r'WBOut-(\d+)').astype(float)
-            great_lakes_df = nexus[nexus['WBOut_id'].isin([4800002,4800004,4800006,4800007])][['WBOut_id','toid']]
+            # nexus['WBOut_id'] = nexus['hl_uri'].str.extract(r'WBOut-(\d+)').astype(float)
+            # great_lakes_df = nexus[nexus['WBOut_id'].isin([4800002,4800004,4800006,4800007])][['WBOut_id','toid']]
+            
+            #NOTE: Great Lakes seem to not be available in v2.2 of hydrofabric...
+            great_lakes_df = pd.DataFrame()
+            
             if not great_lakes_df.empty:
                 great_lakes_df['toid'] = great_lakes_df['toid'].str.extract(r'wb-(\d+)').astype(float)
                 great_lakes_df = great_lakes_df.astype(int)
@@ -601,7 +610,7 @@ class HYFeaturesNetwork(AbstractNetwork):
             self._duplicate_ids_df = pd.DataFrame()
             self._gl_climatology_df = pd.DataFrame()
 
-        self._dataframe = self.dataframe.drop('waterbody', axis=1).drop_duplicates()
+        self._dataframe = self.dataframe.drop('waterbody', axis=1, errors='ignore').drop_duplicates()
 
     def preprocess_data_assimilation(self, network):
         if not network.empty:

--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -919,7 +919,7 @@ class HYFeaturesNetwork(AbstractNetwork):
             'usgs_lake_gage_crosswalk': self._usgs_lake_gage_crosswalk,
             'usace_lake_gage_crosswalk': self._usace_lake_gage_crosswalk,
             'rfc_lake_gage_crosswalk': self._rfc_lake_gage_crosswalk,
-            'duplicate_ids_ds': self._duplicate_ids_df,
+            'duplicate_ids_df': self._duplicate_ids_df,
             'gl_climatology_df': self._gl_climatology_df,
             'poi_nex_dict': self._poi_nex_dict,
             'nexus_dict': self._nexus_dict

--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -733,9 +733,13 @@ class HYFeaturesNetwork(AbstractNetwork):
                 qlat_df = ds_slice['runoff_rate'].transpose("feature_id", "time").to_pandas()
                 qlat_df.columns = qlat_df.columns.strftime('%Y%m%d%H%M')
                 
-                # Take flowpath ids entering NEXUS and replace NEXUS ids by the upstream flowpath ids
-                qlats_df = qlat_df.rename(index=self.downstream_flowpath_dict)
-                qlats_df = qlats_df[qlats_df.index.isin(self.segment_index)]
+                # Drop 'tnx-' rows if present, and drop 'nex-' prefixes if present.
+                # NOTE: this drops terminal nexus points. Should t-route handle this differently (accumulate at tnx points)?
+                if pd.api.types.is_string_dtype(qlat_df.index):
+                    qlat_df = qlat_df[~qlat_df.index.astype(str).str.startswith('tnx-')]
+                    qlat_df.index = qlat_df.index.astype(str).str.replace(r'^[a-zA-Z-]+', '', regex=True).astype(int)
+                # qlats_df = qlat_df.rename(index=self.downstream_flowpath_dict)
+                qlats_df = qlat_df[qlat_df.index.isin(self.segment_index)]
                 
                 all_df = pd.DataFrame( np.zeros( (len(self.segment_index), len(qlats_df.columns)) ), index=self.segment_index,
                     columns=qlats_df.columns )

--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -468,6 +468,7 @@ class HYFeaturesNetwork(AbstractNetwork):
             # id = self.waterbody_dataframe['id'].str.split('-', expand=True).iloc[:,1]
             # self._waterbody_df['id'] = id
             # self._waterbody_df['id'] = self._waterbody_df.id.astype(float).astype(int)
+            self._waterbody_df = self._waterbody_df.copy()
             self._waterbody_df['lake_id'] = self.waterbody_dataframe.lake_id.astype(float).astype(int)
             self._waterbody_df = self.waterbody_dataframe.set_index('lake_id').drop_duplicates().sort_index()
             
@@ -533,8 +534,7 @@ class HYFeaturesNetwork(AbstractNetwork):
             # Add lat, lon, and crs columns for LAKEOUT files:
             lakeout = self.output_parameters.get("lakeout_output", None)
             if lakeout:
-                lat_lon_crs = lakes[['hl_link','hl_reference','geometry']].rename(columns={'hl_link': 'lake_id'})
-                lat_lon_crs = lat_lon_crs[lat_lon_crs['hl_reference']=='WBOut']
+                lat_lon_crs = lakes[['lake_id','geometry']]
                 lat_lon_crs['lake_id'] = lat_lon_crs.lake_id.astype(float).astype(int)
                 lat_lon_crs = lat_lon_crs.set_index('lake_id').drop_duplicates().sort_index()
                 lat_lon_crs = lat_lon_crs[lat_lon_crs.index.isin(self.waterbody_dataframe.index)]

--- a/src/troute-network/troute/HYFeaturesNetwork.py
+++ b/src/troute-network/troute/HYFeaturesNetwork.py
@@ -245,7 +245,7 @@ class HYFeaturesNetwork(AbstractNetwork):
     """
     
     """
-    __slots__ = ["_upstream_terminal", "_nexus_latlon", "_duplicate_ids_df",]
+    __slots__ = ["_upstream_terminal", "_nexus_latlon", "_duplicate_ids_df", "_ds"]
 
     def __init__(self, 
                  supernetwork_parameters, 
@@ -717,90 +717,114 @@ class HYFeaturesNetwork(AbstractNetwork):
         nts = run.get("nts", 1)
         qlat_input_folder = run.get("qlat_input_folder", None)
         qlat_input_file = run.get("qlat_input_file", None)
-
+        
+        if qlat_input_file:
+            _, ql_file_extension = os.path.splitext(qlat_input_file)
+        
         if qlat_input_folder:
-            qlat_input_folder = Path(qlat_input_folder)
-            if "qlat_files" in run:
-                qlat_files = run.get("qlat_files")
-                qlat_files = [qlat_input_folder.joinpath(f) for f in qlat_files]
-            elif "qlat_file_pattern_filter" in run:
-                qlat_file_pattern_filter = run.get(
-                    "qlat_file_pattern_filter", "*CHRT_OUT*"
-                )
-                qlat_files = sorted(qlat_input_folder.glob(qlat_file_pattern_filter))
-            
-            dfs=[]
-            
-            #FIXME Temporary solution to allow t-route to use ngen nex-* output files as forcing files
-            # This capability should be here, but we need to think through how to handle all of this 
-            # data in memory for large domains and many timesteps... - shorvath, Feb 28, 2024
-            qlat_file_pattern_filter = self.forcing_parameters.get("qlat_file_pattern_filter", None)
-            if qlat_file_pattern_filter=="nex-*":
-                for f in qlat_files:
-                    df = pd.read_csv(f, names=['timestamp', 'qlat'], index_col=[0])
-                    df['timestamp'] = pd.to_datetime(df['timestamp']).dt.strftime('%Y%m%d%H%M')
-                    df = df.set_index('timestamp')
-                    df = df.T
-                    df.index = [int(os.path.basename(f).split('-')[1].split('_')[0])]
-                    df = df.rename_axis(None, axis=1)
-                    df.index.name = 'feature_id'
-                    dfs.append(df)
+            if qlat_input_file and ql_file_extension=='.nc':
+                start_dt, end_dt = run.get('timestamps')
                 
-                # lateral flows [m^3/s] are stored at NEXUS points with NEXUS ids
-                nexuses_lateralflows_df = pd.concat(dfs, axis=0) 
+                # Open the file
+                ds = xr.open_dataset(os.path.join(qlat_input_folder, Path(qlat_input_file)))
+                ds_slice = ds.sel({'time': slice(start_dt, end_dt)})
+                ds.close()
+                
+                qlat_df = ds_slice['runoff_rate'].transpose("feature_id", "time").to_pandas()
+                qlat_df.columns = qlat_df.columns.strftime('%Y%m%d%H%M')
+                
+                # Take flowpath ids entering NEXUS and replace NEXUS ids by the upstream flowpath ids
+                qlats_df = qlat_df.rename(index=self.downstream_flowpath_dict)
+                qlats_df = qlats_df[qlats_df.index.isin(self.segment_index)]
+                
+                all_df = pd.DataFrame( np.zeros( (len(self.segment_index), len(qlats_df.columns)) ), index=self.segment_index,
+                    columns=qlats_df.columns )
+                all_df.loc[ qlats_df.index ] = qlats_df
+                qlats_df = all_df.sort_index()
+                
             else:
-                for f in qlat_files:
-                    df = read_file(f)
-                    df['feature_id'] = df['feature_id'].map(lambda x: int(str(x).removeprefix('nex-')) if str(x).startswith('nex') else int(x))
-                    assert df[
-                        "feature_id"
-                    ].is_unique, f"'feature_id's must be unique. '{f!s}' contains duplicate 'feature_id's: {pformat(df.loc[df['feature_id'].duplicated(), 'feature_id'].to_list())}"
-                    df = df.set_index('feature_id')
-                    dfs.append(df)
-            
-                # lateral flows [m^3/s] are stored at NEXUS points with NEXUS ids
-                nexuses_lateralflows_df = pd.concat(dfs, axis=1) 
-            
-            # Take flowpath ids entering NEXUS and replace NEXUS ids by the upstream flowpath ids
-            qlats_df = nexuses_lateralflows_df.rename(index=self.downstream_flowpath_dict)
-            qlats_df = qlats_df[qlats_df.index.isin(self.segment_index)]
+                qlat_input_folder = Path(qlat_input_folder)
+                if "qlat_files" in run:
+                    qlat_files = run.get("qlat_files")
+                    qlat_files = [qlat_input_folder.joinpath(f) for f in qlat_files]
+                elif "qlat_file_pattern_filter" in run:
+                    qlat_file_pattern_filter = run.get(
+                        "qlat_file_pattern_filter", "*CHRT_OUT*"
+                    )
+                    qlat_files = sorted(qlat_input_folder.glob(qlat_file_pattern_filter))
+                
+                dfs=[]
+                
+                #FIXME Temporary solution to allow t-route to use ngen nex-* output files as forcing files
+                # This capability should be here, but we need to think through how to handle all of this 
+                # data in memory for large domains and many timesteps... - shorvath, Feb 28, 2024
+                qlat_file_pattern_filter = self.forcing_parameters.get("qlat_file_pattern_filter", None)
+                if qlat_file_pattern_filter=="nex-*":
+                    for f in qlat_files:
+                        df = pd.read_csv(f, names=['timestamp', 'qlat'], index_col=[0])
+                        df['timestamp'] = pd.to_datetime(df['timestamp']).dt.strftime('%Y%m%d%H%M')
+                        df = df.set_index('timestamp')
+                        df = df.T
+                        df.index = [int(os.path.basename(f).split('-')[1].split('_')[0])]
+                        df = df.rename_axis(None, axis=1)
+                        df.index.name = 'feature_id'
+                        dfs.append(df)
+                    
+                    # lateral flows [m^3/s] are stored at NEXUS points with NEXUS ids
+                    nexuses_lateralflows_df = pd.concat(dfs, axis=0) 
+                else:
+                    for f in qlat_files:
+                        df = read_file(f)
+                        df['feature_id'] = df['feature_id'].map(lambda x: int(str(x).removeprefix('nex-')) if str(x).startswith('nex') else int(x))
+                        assert df[
+                            "feature_id"
+                        ].is_unique, f"'feature_id's must be unique. '{f!s}' contains duplicate 'feature_id's: {pformat(df.loc[df['feature_id'].duplicated(), 'feature_id'].to_list())}"
+                        df = df.set_index('feature_id')
+                        dfs.append(df)
+                
+                    # lateral flows [m^3/s] are stored at NEXUS points with NEXUS ids
+                    nexuses_lateralflows_df = pd.concat(dfs, axis=1) 
+                
+                # Take flowpath ids entering NEXUS and replace NEXUS ids by the upstream flowpath ids
+                qlats_df = nexuses_lateralflows_df.rename(index=self.downstream_flowpath_dict)
+                qlats_df = qlats_df[qlats_df.index.isin(self.segment_index)]
+                
+                '''
+                #For a terminal nexus, we want to include the lateral flow from the catchment contributing to that nexus
+                #one way to do that is to cheat and put that lateral flow at the upstream...this is probably the simplest way
+                #right now.  The other is to create a virtual channel segment downstream to "route" i.e accumulate into
+                #but it isn't clear right now how to do that with flow/velocity/depth requirements
+                #find the terminal nodes
+                for tnx, test_up in self._upstream_terminal.items():
+                    #first need to ensure there is an upstream location to dump to
+                    pdb.set_trace()
+                    for nex in test_up:
+                        try:
+                            #FIXME if multiple upstreams exist in this case then a choice is to be made as to which it goes into
+                            #some cases the choice is easy cause the upstream doesn't exist, but in others, it may not be so simple
+                            #in such cases where multiple valid upstream nexuses exist, perhaps the mainstem should be used?
+                            pdb.set_trace()
+                            qlats_df.loc[up] += nexuses_lateralflows_df.loc[tnx]
+                            break #flow added, don't add it again!
+                        except KeyError:
+                            #this upstream doesn't actually exist on the network (maybe it is a headwater?)
+                            #or perhaps the output file doesnt exist?  If this is the case, this isn't a good trap
+                            #but for now, add the flow to a known good nexus upstream of the terminal
+                            continue
+                        #TODO what happens if can't put the qlat anywhere?  Right now this silently ignores the issue...
+                    qlats_df.drop(tnx, inplace=True)
+                '''
 
-            '''
-            #For a terminal nexus, we want to include the lateral flow from the catchment contributing to that nexus
-            #one way to do that is to cheat and put that lateral flow at the upstream...this is probably the simplest way
-            #right now.  The other is to create a virtual channel segment downstream to "route" i.e accumulate into
-            #but it isn't clear right now how to do that with flow/velocity/depth requirements
-            #find the terminal nodes
-            for tnx, test_up in self._upstream_terminal.items():
-                #first need to ensure there is an upstream location to dump to
-                pdb.set_trace()
-                for nex in test_up:
-                    try:
-                        #FIXME if multiple upstreams exist in this case then a choice is to be made as to which it goes into
-                        #some cases the choice is easy cause the upstream doesn't exist, but in others, it may not be so simple
-                        #in such cases where multiple valid upstream nexuses exist, perhaps the mainstem should be used?
-                        pdb.set_trace()
-                        qlats_df.loc[up] += nexuses_lateralflows_df.loc[tnx]
-                        break #flow added, don't add it again!
-                    except KeyError:
-                        #this upstream doesn't actually exist on the network (maybe it is a headwater?)
-                        #or perhaps the output file doesnt exist?  If this is the case, this isn't a good trap
-                        #but for now, add the flow to a known good nexus upstream of the terminal
-                        continue
-                    #TODO what happens if can't put the qlat anywhere?  Right now this silently ignores the issue...
-                qlats_df.drop(tnx, inplace=True)
-            '''
-
-            # The segment_index has the full network set of segments/flowpaths. 
-            # Whereas the set of flowpaths that are downstream of nexuses is a 
-            # subset of the segment_index. Therefore, all of the segments/flowpaths
-            # that are not accounted for in the set of flowpaths downstream of
-            # nexuses need to be added to the qlateral dataframe and padded with
-            # zeros.
-            all_df = pd.DataFrame( np.zeros( (len(self.segment_index), len(qlats_df.columns)) ), index=self.segment_index,
-                columns=qlats_df.columns )
-            all_df.loc[ qlats_df.index ] = qlats_df
-            qlats_df = all_df.sort_index()
+                # The segment_index has the full network set of segments/flowpaths. 
+                # Whereas the set of flowpaths that are downstream of nexuses is a 
+                # subset of the segment_index. Therefore, all of the segments/flowpaths
+                # that are not accounted for in the set of flowpaths downstream of
+                # nexuses need to be added to the qlateral dataframe and padded with
+                # zeros.
+                all_df = pd.DataFrame( np.zeros( (len(self.segment_index), len(qlats_df.columns)) ), index=self.segment_index,
+                    columns=qlats_df.columns )
+                all_df.loc[ qlats_df.index ] = qlats_df
+                qlats_df = all_df.sort_index()
 
         elif qlat_input_file:
             qlats_df = nhd_io.get_ql_from_csv(qlat_input_file)

--- a/src/troute-network/troute/nhd_io.py
+++ b/src/troute-network/troute/nhd_io.py
@@ -2337,6 +2337,9 @@ def updated_flowveldepth(flowveldepth, nex_id, seg_id, mask_list):
         # Set the new 'Type' column as an index
         all_nex_data = all_nex_data.set_index('Type', append=True)
         
+        # Reindex to (n, f), (n, v), (n, d), ...
+        all_nex_data = all_nex_data.reindex(flowveldepth.columns, axis=1)
+        
     else:
         all_nex_data = pd.DataFrame()
     

--- a/src/troute-nwm/src/nwm_routing/__main__.py
+++ b/src/troute-nwm/src/nwm_routing/__main__.py
@@ -144,7 +144,8 @@ def main_v04(argv):
 
     # Initialize the output NetCDF file if user specified
     netcdf_stream_output = output_parameters.get('netcdf_stream_output', {})
-    if netcdf_stream_output.get('output_path', None):
+    writer = None
+    if netcdf_stream_output and netcdf_stream_output.get('output_path', None):
         writer = NetCDFStreamWriter()
         writer.initialize(
             config = netcdf_stream_output,

--- a/src/troute-nwm/src/nwm_routing/__main__.py
+++ b/src/troute-nwm/src/nwm_routing/__main__.py
@@ -54,6 +54,7 @@ def main_v04(argv):
         output_parameters,
         parity_parameters,
         data_assimilation_parameters,
+        config_dict,
     ) = _input_handler_v04(args)
     
     run_parameters = {
@@ -148,12 +149,14 @@ def main_v04(argv):
     output_writer = None
     if netcdf_output and netcdf_output.get('output_path', None):
         output_writer = OutputWriter(
-            cfg = netcdf_output,
-            all_network_ids = network.dataframe.index.to_numpy(),
+            cfg = config_dict,
+            output_cfg = netcdf_output,
+            all_network_ids = network.segment_index.to_numpy(),
             total_sim_seconds = run_parameters['dt'] * run_parameters['nts'],
             start_time = network.t0,
             dt = run_parameters['dt'],
             rconn = network.reverse_network,
+            q0 = network.q0,
             waterbody_df = network.waterbody_dataframe,
             waterbody_types_df = network.waterbody_types_dataframe,
         )

--- a/src/troute-nwm/src/nwm_routing/__main__.py
+++ b/src/troute-nwm/src/nwm_routing/__main__.py
@@ -22,7 +22,7 @@ from .preprocess import (
     unpack_nwm_preprocess_data,
 )
 from .output import nwm_output_generator
-from .output_nextgen import NetCDFStreamWriter
+from .output_nextgen import OutputWriter
 from .log_level_set import log_level_set
 from troute.routing.compute import compute_nhd_routing_v02, compute_diffusive_routing, compute_log_mc, compute_log_diff
 
@@ -144,17 +144,18 @@ def main_v04(argv):
 
     # Initialize the output NetCDF file if user specified
     output_start_time = time.time()
-    netcdf_stream_output = output_parameters.get('netcdf_stream_output', {})
-    writer = None
-    if netcdf_stream_output and netcdf_stream_output.get('output_path', None):
-        writer = NetCDFStreamWriter()
-        writer.initialize(
-            config = netcdf_stream_output,
+    netcdf_output = output_parameters.get('netcdf_output', {})
+    output_writer = None
+    if netcdf_output and netcdf_output.get('output_path', None):
+        output_writer = OutputWriter(
+            cfg = netcdf_output,
             all_network_ids = network.dataframe.index.to_numpy(),
             total_sim_seconds = run_parameters['dt'] * run_parameters['nts'],
             start_time = network.t0,
             dt = run_parameters['dt'],
-            rconn = network.reverse_network
+            rconn = network.reverse_network,
+            waterbody_df = network.waterbody_dataframe,
+            waterbody_types_df = network.waterbody_types_dataframe,
         )
     output_end_time = time.time()
     task_times['output_time'] += output_end_time - output_start_time
@@ -273,7 +274,6 @@ def main_v04(argv):
         subnetwork_list = run_results[1]
         run_results = run_results[0]
 
-        
         route_end_time = time.time()
         task_times['route_time'] += route_end_time - route_start_time
 
@@ -318,6 +318,8 @@ def main_v04(argv):
 
         output_start_time = time.time()  
         
+        LOG.info(f"Handling output ...")
+        
         #TODO Update this to work with either network type...
         nwm_output_generator(
             run,
@@ -343,21 +345,23 @@ def main_v04(argv):
         )
         
         # Write single NetCDF file output method:
-        if writer:
-            writer.write_step(
+        if output_writer:
+            output_writer.write_step(
                 run_results = run_results,
                 current_chunk_start_time = t0
             )
         
         output_end_time = time.time()
         task_times['output_time'] += output_end_time - output_start_time
-    
+
+        LOG.debug("output complete in %s seconds." % (time.time() - output_start_time))
+
         firstRun = False
     
     # end of for run_set_iterator, run in enumerate(run_sets):
     
     output_start_time = time.time()
-    writer.close() if writer else None
+    output_writer.close() if output_writer else None
     output_end_time = time.time()
     task_times['output_time'] += output_end_time - output_start_time
     

--- a/src/troute-nwm/src/nwm_routing/__main__.py
+++ b/src/troute-nwm/src/nwm_routing/__main__.py
@@ -22,6 +22,7 @@ from .preprocess import (
     unpack_nwm_preprocess_data,
 )
 from .output import nwm_output_generator
+from .output_nextgen import NetCDFStreamWriter
 from .log_level_set import log_level_set
 from troute.routing.compute import compute_nhd_routing_v02, compute_diffusive_routing, compute_log_mc, compute_log_diff
 
@@ -141,6 +142,18 @@ def main_v04(argv):
     forcing_end_time = time.time()
     task_times['forcing_time'] += forcing_end_time - network_end_time
 
+    # Initialize the output NetCDF file if user specified
+    netcdf_stream_output = output_parameters.get('netcdf_stream_output', {})
+    if netcdf_stream_output.get('output_path', None):
+        writer = NetCDFStreamWriter()
+        writer.initialize(
+            config = netcdf_stream_output,
+            all_network_ids = network.dataframe.index.to_numpy(),
+            total_sim_seconds = run_parameters['dt'] * run_parameters['nts'],
+            start_time = network.t0,
+            dt = run_parameters['dt']
+        )
+    
     parallel_compute_method = compute_parameters.get("parallel_compute_method", None)
     subnetwork_target_size = compute_parameters.get("subnetwork_target_size", 1)
     qts_subdivisions = forcing_parameters.get("qts_subdivisions", 1)
@@ -324,7 +337,13 @@ def main_v04(argv):
             logFileName            
         )
         
-
+        # Write single NetCDF file output method:
+        if writer:
+            writer.write_step(
+                run_results = run_results,
+                current_chunk_start_time = t0
+            )
+        
         output_end_time = time.time()
         task_times['output_time'] += output_end_time - output_start_time
     
@@ -332,6 +351,7 @@ def main_v04(argv):
     
     # end of for run_set_iterator, run in enumerate(run_sets):
     
+    writer.close() if writer else None
     
     task_times['total_time'] = time.time() - main_start_time
 

--- a/src/troute-nwm/src/nwm_routing/__main__.py
+++ b/src/troute-nwm/src/nwm_routing/__main__.py
@@ -143,6 +143,7 @@ def main_v04(argv):
     task_times['forcing_time'] += forcing_end_time - network_end_time
 
     # Initialize the output NetCDF file if user specified
+    output_start_time = time.time()
     netcdf_stream_output = output_parameters.get('netcdf_stream_output', {})
     writer = None
     if netcdf_stream_output and netcdf_stream_output.get('output_path', None):
@@ -154,6 +155,8 @@ def main_v04(argv):
             start_time = network.t0,
             dt = run_parameters['dt']
         )
+    output_end_time = time.time()
+    task_times['output_time'] += output_end_time - output_start_time
     
     parallel_compute_method = compute_parameters.get("parallel_compute_method", None)
     subnetwork_target_size = compute_parameters.get("subnetwork_target_size", 1)
@@ -352,7 +355,10 @@ def main_v04(argv):
     
     # end of for run_set_iterator, run in enumerate(run_sets):
     
+    output_start_time = time.time()
     writer.close() if writer else None
+    output_end_time = time.time()
+    task_times['output_time'] += output_end_time - output_start_time
     
     task_times['total_time'] = time.time() - main_start_time
 

--- a/src/troute-nwm/src/nwm_routing/__main__.py
+++ b/src/troute-nwm/src/nwm_routing/__main__.py
@@ -153,7 +153,8 @@ def main_v04(argv):
             all_network_ids = network.dataframe.index.to_numpy(),
             total_sim_seconds = run_parameters['dt'] * run_parameters['nts'],
             start_time = network.t0,
-            dt = run_parameters['dt']
+            dt = run_parameters['dt'],
+            rconn = network.reverse_network
         )
     output_end_time = time.time()
     task_times['output_time'] += output_end_time - output_start_time

--- a/src/troute-nwm/src/nwm_routing/input.py
+++ b/src/troute-nwm/src/nwm_routing/input.py
@@ -74,6 +74,7 @@ def _input_handler_v04(args):
         output_parameters,
         parity_parameters,
         data_assimilation_parameters,
+        config_dict,
     )
 
 def _input_handler_v03(args):

--- a/src/troute-nwm/src/nwm_routing/output.py
+++ b/src/troute-nwm/src/nwm_routing/output.py
@@ -174,10 +174,6 @@ def nwm_output_generator(
         )
 
     ################### Output Handling
-    
-    start_time = time.time()
-
-    LOG.info(f"Handling output ...")
 
     csv_output = output_parameters.get("csv_output", None)
     csv_output_folder = None
@@ -590,8 +586,6 @@ def nwm_output_generator(
 
     # if 'flowveldepth' in locals():
     #    LOG.debug(flowveldepth)
-
-    LOG.debug("output complete in %s seconds." % (time.time() - start_time))
 
     ################### Parity Check
 

--- a/src/troute-nwm/src/nwm_routing/output_nextgen.py
+++ b/src/troute-nwm/src/nwm_routing/output_nextgen.py
@@ -53,19 +53,19 @@ class NetCDFStreamWriter(AbstractOutputWriter):
 
         LOG.info(f"Initializing NetCDF Stream Output: {output_path}")
 
-        # 1. Calculate Total Output Steps
+        # Calculate Total Output Steps
         self.total_steps = int(total_sim_seconds // output_interval)
         
-        # 2. Setup ID Indexing
+        # Setup ID Indexing
         self._setup_indexing(all_network_ids)
 
-        # 3. Create NetCDF
+        # Create NetCDF
         self.nc = nc.Dataset(output_path, "w", format="NETCDF4")
         self.nc.createDimension("time", self.total_steps)
         self.nc.createDimension("feature_id", len(self.output_ids))
         self.nc.createDimension("reference_time", 1)
 
-        # 4. Coordinates
+        # Coordinates
         v_id = self.nc.createVariable("feature_id", "i4", ("feature_id",))
         v_id[:] = self.output_ids
 
@@ -74,7 +74,7 @@ class NetCDFStreamWriter(AbstractOutputWriter):
         v_time.calendar = "standard"
         v_time.long_name = "valid output time"
         
-        # 5. Data Variables
+        # Data Variables
         # Chunking Strategy: Optimize for writing one full timestep at a time (1 x N)
         chunk_dims = (1, len(self.output_ids))
         comp_args = {'zlib': True, 'complevel': 2, 'fill_value': np.nan, 'chunksizes': chunk_dims}
@@ -113,7 +113,7 @@ class NetCDFStreamWriter(AbstractOutputWriter):
     def write_step(self, run_results: List[Tuple], current_chunk_start_time: datetime):
         if self.nc is None or not run_results: return
         
-        # 1. Determine dimensions
+        # Determine dimensions
         sample_r = run_results[0]
         if sample_r[1] is None: return 
         ncols = sample_r[1].shape[1]
@@ -121,7 +121,7 @@ class NetCDFStreamWriter(AbstractOutputWriter):
         
         output_interval = self.cfg['output_interval']
         
-        # 2. Iterate through internal timesteps
+        # Iterate through internal timesteps
         for i in range(1, nts_chunk + 1):
             step_time = current_chunk_start_time + timedelta(seconds=i * self.dt)
             time_since_start = (step_time - self.global_start_time).total_seconds()
@@ -169,7 +169,7 @@ class NetCDFStreamWriter(AbstractOutputWriter):
             # Extract Data
             for var_name in variables:
                 if var_name == 'nudge':
-                    #TODO: Update to include nudge values. Skipping for now.
+                    #TODO: Update to include nudge values.
                     # Nudge Logic: Usually r[8]. Needs Mapping if Nudge IDs != Seg IDs
                     pass
                 elif var_name in self.var_offsets:

--- a/src/troute-nwm/src/nwm_routing/output_nextgen.py
+++ b/src/troute-nwm/src/nwm_routing/output_nextgen.py
@@ -2,18 +2,28 @@ import netCDF4 as nc
 import numpy as np
 import pandas as pd
 import yaml
-import time
 from datetime import datetime, timedelta
 from abc import ABC, abstractmethod
-from typing import List, Tuple, Dict, Optional, Any
+from typing import List, Tuple, Dict, Set, Optional, Any
 import logging
 
-LOG = logging.getLogger(__name__)
+LOG = logging.getLogger("")
 
+_FVD_POSITIONS = {'streamflow': 0, 'velocity': 1, 'depth': 2}
+_VAR_ATTRS = {
+    'streamflow': ('m3 s-1', 'Streamflow'),
+    'velocity':   ('m s-1',  'Velocity'),
+    'depth':      ('m',      'Depth'),
+    'nudge':      ('m3 s-1', 'Data assimilation nudge applied to streamflow'),
+}
+
+
+# Abstract Class for Output Writing Methods (Stream output, Reservoir output, etc.)
 class AbstractOutputWriter(ABC):
     @abstractmethod
     def initialize(self, config: Any, all_network_ids: np.ndarray, 
-                   total_sim_seconds: float, start_time: datetime, dt: float):
+                   total_sim_seconds: float, start_time: datetime, dt: float,
+                   rconn: Dict[int, List[int]]):
         pass
 
     @abstractmethod
@@ -25,166 +35,279 @@ class AbstractOutputWriter(ABC):
     def close(self):
         pass
 
+
+# Stream output class
 class NetCDFStreamWriter(AbstractOutputWriter):
     def __init__(self):
-        self.nc = None
-        self.cfg = None
-        self.sorter = None
-        self.output_ids = None
-        self.total_steps = 0
-        self.dt = 300.0  
-        self.global_start_time = None 
-        
-        # Offsets for standard variables in the r[1] array
-        self.var_offsets = {
-            'streamflow': 0, 'velocity': 1, 'depth': 2
-        }
+        self._nc = None
+        self._cfg = None
+        self._total_steps = 0
+        self._dt = 300.0
+        self._global_start_time = None
+ 
+        # Ordered arrays of integer IDs and type labels ('wb' or 'nex'),
+        # one entry per row in the NetCDF feature_id dimension.
+        self._output_ids = None 
+        self._output_types = None 
+
+        # Crosswalks
+        self._wb_id_to_pos:  Dict[int, int] = {}
+        self._nex_id_to_pos: Dict[int, int] = {}
+        self._nex_upstream:  Dict[int, List[int]] = {}
 
     def initialize(self, config: Any, all_network_ids: np.ndarray, 
-                   total_sim_seconds: float, start_time: datetime, dt: float):
+                   total_sim_seconds: float, start_time: datetime, dt: float,
+                   rconn: Dict[int, List[int]]):
         
-        self.cfg = config
-        self.dt = float(dt)
-        self.global_start_time = start_time
+        self._cfg = config
+        self._dt = float(dt)
+        self._global_start_time = start_time
+        self._total_steps = int(total_sim_seconds // config['output_interval'])
         
-        output_path = self.cfg['output_path']
-        output_interval = self.cfg['output_interval']
-        variables = self.cfg['variables']
+        self.build_id_index(all_network_ids, rconn)
+        self.create_netcdf(config['output_path'], config['variables'], start_time)
 
-        LOG.info(f"Initializing NetCDF Stream Output: {output_path}")
-
-        # Calculate Total Output Steps
-        self.total_steps = int(total_sim_seconds // output_interval)
+    def write_step(self, run_results: List[Tuple],
+                   current_chunk_start_time: datetime):
+        if self._nc is None or not run_results:
+            return
         
-        # Setup ID Indexing
-        self._setup_indexing(all_network_ids)
-
-        # Create NetCDF
-        self.nc = nc.Dataset(output_path, "w", format="NETCDF4")
-        self.nc.createDimension("time", self.total_steps)
-        self.nc.createDimension("feature_id", len(self.output_ids))
-        self.nc.createDimension("reference_time", 1)
-
-        # Coordinates
-        v_id = self.nc.createVariable("feature_id", "i4", ("feature_id",))
-        v_id[:] = self.output_ids
-
-        v_time = self.nc.createVariable("time", "i4", ("time",), fill_value=-9999)
-        v_time.units = f"minutes since {start_time.strftime('%Y-%m-%d %H:%M:%S')}"
-        v_time.calendar = "standard"
-        v_time.long_name = "valid output time"
+        fvd_sample = run_results[0][1]
+        nts_chunk = fvd_sample.shape[1] // 3
+        output_interval = self._cfg['output_interval']
         
-        # Data Variables
-        # Chunking Strategy: Optimize for writing one full timestep at a time (1 x N)
-        chunk_dims = (1, len(self.output_ids))
-        comp_args = {'zlib': True, 'complevel': 2, 'fill_value': np.nan, 'chunksizes': chunk_dims}
-        
-        for var_name in variables:
-            self.nc.createVariable(var_name, "f4", ("time", "feature_id"), **comp_args)
-
-    def _setup_indexing(self, all_network_ids: np.ndarray):
-        subset_ids = None
-        subset_file = self.cfg.get('subset_file')
-
-        if subset_file:
-            try:
-                with open(subset_file, 'r') as f:
-                    data = yaml.safe_load(f)
-                    if isinstance(data, dict):
-                        # Try common keys
-                        subset_ids = data.get('flowpath_ids') or data.get('link_ids') or list(data.values())[0]
-                    elif isinstance(data, list):
-                        subset_ids = data
-                    
-                    if subset_ids: 
-                        subset_ids = np.array(subset_ids)
-            except Exception as e:
-                LOG.error(f"Failed to read subset file: {e}")
-                raise
-
-        if subset_ids is not None:
-            valid_subset = np.intersect1d(all_network_ids, subset_ids)
-            self.output_ids = np.sort(valid_subset)
-        else:
-            self.output_ids = np.sort(all_network_ids)
-        
-        self.sorter = np.argsort(self.output_ids) 
-
-    def write_step(self, run_results: List[Tuple], current_chunk_start_time: datetime):
-        if self.nc is None or not run_results: return
-        
-        # Determine dimensions
-        sample_r = run_results[0]
-        if sample_r[1] is None: return 
-        ncols = sample_r[1].shape[1]
-        nts_chunk = ncols // 3
-        
-        output_interval = self.cfg['output_interval']
-        
-        # Iterate through internal timesteps
         for i in range(1, nts_chunk + 1):
-            step_time = current_chunk_start_time + timedelta(seconds=i * self.dt)
-            time_since_start = (step_time - self.global_start_time).total_seconds()
-            
-            # Check alignment
-            if abs(time_since_start % output_interval) < 0.1:
-                nc_time_idx = int(round((time_since_start - output_interval) / output_interval))
-                
-                if 0 <= nc_time_idx < self.total_steps:
-                    self._write_single_frame(run_results, step_time, i-1, nc_time_idx)
-
-    def _write_single_frame(self, run_results: List[Tuple], absolute_time: datetime, 
-                            step_index: int, nc_time_idx: int):
-        
-        # Write Time Value
-        elapsed_minutes = int((absolute_time - self.global_start_time).total_seconds() / 60)
-        self.nc.variables['time'][nc_time_idx] = elapsed_minutes
-        
-        base_col = step_index * 3
-        
-        variables = self.cfg['variables']
-
-        # Allocate full domain arrays filled with NaN
-        data_buffers = {}
-        for var in variables:
-            data_buffers[var] = np.full(len(self.output_ids), np.nan, dtype=np.float32)
-        
-        # Fill buffers
-        for r in run_results:
-            chunk_ids = r[0]
-            if chunk_ids is None or len(chunk_ids) == 0: continue
-
-            # Index Lookup
-            idx_in_nc = np.searchsorted(self.output_ids, chunk_ids, sorter=self.sorter)
-            
-            # Mask Validation
-            in_bounds = idx_in_nc < len(self.output_ids)
-            valid_mask = np.zeros_like(in_bounds, dtype=bool)
-            valid_mask[in_bounds] = (self.output_ids[idx_in_nc[in_bounds]] == chunk_ids[in_bounds])
-
-            if not np.any(valid_mask): continue
-            
-            target_indices = idx_in_nc[valid_mask]
-
-            # Extract Data
-            for var_name in variables:
-                if var_name == 'nudge':
-                    #TODO: Update to include nudge values.
-                    # Nudge Logic: Usually r[8]. Needs Mapping if Nudge IDs != Seg IDs
-                    pass
-                elif var_name in self.var_offsets:
-                    offset = self.var_offsets[var_name]
-                    target_col = base_col + offset
-                    
-                    # Fill Buffer
-                    data_buffers[var_name][target_indices] = r[1][:, target_col][valid_mask]
-
-        # Write to disk
-        for var_name, data_array in data_buffers.items():
-            self.nc.variables[var_name][nc_time_idx, :] = data_array
-
+            step_time = current_chunk_start_time + timedelta(seconds=i * self._dt)
+            elapsed   = (step_time - self._global_start_time).total_seconds()
+ 
+            if abs(elapsed % output_interval) < 0.1:
+                nc_idx = int(round(elapsed / output_interval)) - 1
+                if 0 <= nc_idx < self._total_steps:
+                    self.write_frame(run_results, step_time, i - 1, nc_idx)
+ 
     def close(self):
-        if self.nc:
-            self.nc.sync()
-            self.nc.close()
-            self.nc = None
+        if self._nc:
+            self._nc.sync()
+            self._nc.close()
+            self._nc = None
+
+
+    # Helper Functions
+    def build_id_index(self, all_network_ids: np.ndarray,
+                       rconn: Dict[int, List[int]]):
+        """
+        Parse the subset file (if any) and build all internal lookup
+        structures.  Rows are ordered: sorted wb reaches first, then
+        sorted nexus rows.
+        """
+        wb_ids, nex_ids = self.load_subset(all_network_ids)
+ 
+        # Find the upstream connections for each requested nexus.
+        all_set = set(all_network_ids.tolist())
+        nex_upstream = {}
+        
+        for nid in sorted(nex_ids):
+            upstream = [u for u in rconn.get(nid, []) if u in all_set]
+            nex_upstream[nid] = upstream
+ 
+        wb_sorted = np.sort(np.array(list(wb_ids),  dtype=np.int64))
+        nex_sorted = np.sort(np.array(list(nex_ids), dtype=np.int64))
+ 
+        self._output_ids = np.concatenate([wb_sorted, nex_sorted])
+        self._output_types = np.array(
+            ['wb'] * len(wb_sorted) + ['nex'] * len(nex_sorted),
+            dtype='U3'
+        )
+ 
+        offset = len(wb_sorted)
+        self._wb_id_to_pos = {int(fid): i for i, fid in enumerate(wb_sorted)}
+        self._nex_id_to_pos = {int(nid): offset + i
+                               for i, nid in enumerate(nex_sorted)}
+        self._nex_upstream = nex_upstream
+        
+        self._nex_upstream_ids: frozenset = frozenset(
+            uid for upstream in nex_upstream.values() for uid in upstream
+        )
+ 
+    def load_subset(self, all_network_ids: np.ndarray
+                     ) -> Tuple[Set[int], Set[int]]:
+        """
+        Return (wb_ids, nex_ids) as sets of integers.
+ 
+        If no subset file is configured, wb_ids contains all network IDs
+        and nex_ids is empty.
+        """
+        subset_file = self._cfg.get('subset_file')
+        if not subset_file:
+            return set(all_network_ids.tolist()), set()
+ 
+        with open(subset_file) as fh:
+            data = yaml.safe_load(fh)
+
+        raw_wb, raw_nex = [], []
+        raw_wb  = data.get('feature_ids', [])
+        raw_nex = data.get('nexuses', [])
+
+        wb_ids  = self.remove_prefix(raw_wb)
+        nex_ids = self.remove_prefix(raw_nex)
+ 
+        all_set = set(all_network_ids.tolist())
+        invalid_wb = wb_ids - all_set
+        if invalid_wb:
+            LOG.warning("%d requested feature_ids not found in network and "
+                        "will be skipped", len(invalid_wb))
+        wb_ids &= all_set
+ 
+        if not wb_ids and not nex_ids:
+            LOG.warning("subset_file produced no usable IDs; "
+                        "writing all network IDs as wb reaches")
+            return all_set, set()
+        
+        return wb_ids, nex_ids
+ 
+    @staticmethod
+    def remove_prefix(raw: list) -> Set[int]:
+        out = set([int(float(s.split('-', 1)[-1])) for s in raw])
+        return out
+ 
+    def create_netcdf(self, output_path: str, variables: List[str],
+                       start_time: datetime):
+        nfeatures = len(self._output_ids)
+ 
+        self._nc = nc.Dataset(output_path, 'w', format='NETCDF4')
+        self._nc.createDimension('time', self._total_steps)
+        self._nc.createDimension('feature_id', nfeatures)
+ 
+        v_id = self._nc.createVariable('feature_id', 'i4', ('feature_id',))
+        v_id.long_name = 'Reach or nexus integer ID'
+        # v_id.cf_role = 'timeseries_id' TODO: DELETE
+        v_id[:] = self._output_ids.astype(np.int32)
+ 
+        # 'wb' for flowpath reaches, 'nex' for nexus aggregation rows
+        v_type = self._nc.createVariable('feature_type', str, ('feature_id',))
+        v_type.long_name = ('Feature type: "wb" = flowpath reach, "nex" = nexus point')
+        v_type[:] = self._output_types
+        
+        v_time = self._nc.createVariable('time', 'i4', ('time',), fill_value=-9999)
+        v_time.units = 'minutes since {}'.format(start_time.strftime('%Y-%m-%d %H:%M:%S'))
+        v_time.calendar = 'standard'
+        v_time.long_name = 'valid output time'
+ 
+        chunk_dims = (1, nfeatures)
+        comp_args = dict(zlib=True, complevel=2, fill_value=np.nan,
+                         chunksizes=chunk_dims)
+ 
+        for var_name in variables:
+            units, long_name = _VAR_ATTRS.get(var_name, ('', var_name))
+            v = self._nc.createVariable(var_name, 'f4', ('time', 'feature_id'), **comp_args)
+            v.units = units
+            v.long_name = long_name
+ 
+        self._nc.featureType = 'timeSeries'
+        self._nc.Conventions = 'CF-1.8'
+ 
+        LOG.info("NetCDF stream output initialised: %s  "
+                 "(%d wb reaches, %d nexus points, %d timesteps)",
+                 output_path, len(self._wb_id_to_pos),
+                 len(self._nex_id_to_pos), self._total_steps)
+
+    def write_frame(self, run_results: List[Tuple], abs_time: datetime,
+                     step_index: int, nc_time_idx: int):
+        elapsed_min = int((abs_time - self._global_start_time).total_seconds() / 60)
+        self._nc.variables['time'][nc_time_idx] = elapsed_min
+ 
+        base_col = step_index * 3
+        variables = self._cfg['variables']
+        nout = len(self._output_ids)
+ 
+        output_dict = {v: np.full(nout, np.nan, dtype=np.float32) for v in variables}
+        
+        # Dictionaries for nexus aggregation: seg_id -> value this timestep.
+        seg_flow = {}  # populated when streamflow or nexus rows are needed
+        seg_nudge = {}  # populated when nudge is requested
+ 
+        need_nexus_sums = bool(self._nex_id_to_pos) and 'streamflow' in variables
+        need_nudge_sums = bool(self._nex_id_to_pos) and 'nudge' in variables
+        
+        # Loop through results list and save needed output values
+        for r in run_results:
+            seg_ids = r[0]
+            fvd = r[1]
+ 
+            if seg_ids is None or len(seg_ids) == 0 or fvd is None:
+                continue
+            
+            seg_ids = np.asarray(seg_ids, dtype=np.int64)
+            wb_pos = np.array([self._wb_id_to_pos.get(int(s), -1)
+                               for s in seg_ids], dtype=np.intp)
+            wb_mask = wb_pos >= 0
+ 
+            if wb_mask.any():
+                valid_pos = wb_pos[wb_mask]
+                for var in variables:
+                    if var in _FVD_POSITIONS:
+                        col = base_col + _FVD_POSITIONS[var]
+                        output_dict[var][valid_pos] = fvd[wb_mask, col]
+ 
+            # Save nexus upstream flows for aggregation
+            if need_nexus_sums:
+                flow_col = base_col + _FVD_POSITIONS['streamflow']
+                flow_vals = fvd[:, flow_col]
+                for sid, val in zip(seg_ids, flow_vals):
+                    sid = int(sid)
+                    if sid in self._nex_upstream_ids:
+                        seg_flow[int(sid)] = float(val)
+ 
+            if need_nudge_sums or ('nudge' in variables and self._wb_id_to_pos):
+                self._collect_nudge(r, step_index, seg_nudge)
+ 
+        # Write nudge to wb rows
+        if 'nudge' in variables:
+            #TODO: Validate that this works...
+            for sid, val in seg_nudge.items():
+                pos = self._wb_id_to_pos.get(sid)
+                if pos is not None:
+                    output_dict['nudge'][pos] = val
+        
+        # Aggregate for nexus rows
+        for nid, pos in self._nex_id_to_pos.items():
+            upstream = self._nex_upstream.get(nid, [])
+            if not upstream:
+                continue
+ 
+            if 'streamflow' in variables:
+                vals = [seg_flow[u] for u in upstream if u in seg_flow]
+                if vals:
+                    output_dict['streamflow'][pos] = sum(vals)
+ 
+            if 'nudge' in variables:
+                vals = [seg_nudge[u] for u in upstream if u in seg_nudge]
+                if vals:
+                    output_dict['nudge'][pos] = sum(vals)
+        
+        # Write to file
+        for var, data in output_dict.items():
+            self._nc.variables[var][nc_time_idx, :] = data
+ 
+    def collect_nudge(self, r: Tuple, step_index: int,
+                       seg_nudge: Dict[int, float]):
+        """
+        Pull nudge values for this timestep from r[8] into seg_nudge.
+ 
+        r[8] is expected to be a pandas DataFrame indexed by segment ID
+        with one column per internal timestep.  Only gaged reaches appear;
+        un-gaged ones are simply absent from the DataFrame.
+        """
+        if len(r) <= 8:
+            return
+ 
+        nudge_df = r[8]
+        if nudge_df is None or not isinstance(nudge_df, pd.DataFrame):
+            return
+        if nudge_df.empty or step_index >= len(nudge_df.columns):
+            return
+ 
+        col = nudge_df.iloc[:, step_index]
+        for sid, val in col.items():
+            if not np.isnan(val):
+                seg_nudge[int(sid)] = float(val)

--- a/src/troute-nwm/src/nwm_routing/output_nextgen.py
+++ b/src/troute-nwm/src/nwm_routing/output_nextgen.py
@@ -3,311 +3,496 @@ import numpy as np
 import pandas as pd
 import yaml
 from datetime import datetime, timedelta
-from abc import ABC, abstractmethod
-from typing import List, Tuple, Dict, Set, Optional, Any
+from itertools import chain
+from typing import Dict, List, Optional, Set, Tuple
 import logging
 
 LOG = logging.getLogger("")
 
-_FVD_POSITIONS = {'streamflow': 0, 'velocity': 1, 'depth': 2}
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Column offsets within r[1] (flowpath and reservoir results)
+_Q_COL = 0 # streamflow / reservoir outflow
+_V_COL = 1 # velocity (flowpath) / unused (reservoir)
+_D_COL = 2 # depth (flowpath) / water surface elevation (reservoir)
+
 _VAR_ATTRS = {
     'streamflow': ('m3 s-1', 'Streamflow'),
-    'velocity':   ('m s-1',  'Velocity'),
-    'depth':      ('m',      'Depth'),
-    'nudge':      ('m3 s-1', 'Data assimilation nudge applied to streamflow'),
+    'velocity': ('m s-1', 'Flow velocity'),
+    'depth': ('m', 'Flow depth'),
+    'nudge': ('m3 s-1', 'Data assimilation nudge applied to streamflow'),
+    'inflow': ('m3 s-1', 'Reservoir inflow'),
+    'outflow': ('m3 s-1', 'Reservoir outflow'),
+    'water_sfc_elev': ('m', 'Reservoir water surface elevation'),
+    'reservoir_assimilated_value': ('m3 s-1', 'Reservoir data assimilation value'),
 }
 
-
-# Abstract Class for Output Writing Methods (Stream output, Reservoir output, etc.)
-class AbstractOutputWriter(ABC):
-    @abstractmethod
-    def initialize(self, config: Any, all_network_ids: np.ndarray, 
-                   total_sim_seconds: float, start_time: datetime, dt: float,
-                   rconn: Dict[int, List[int]]):
-        pass
-
-    @abstractmethod
-    def write_step(self, run_results: List[Tuple], 
-                   current_chunk_start_time: datetime):
-        pass
-
-    @abstractmethod
-    def close(self):
-        pass
-
-
-# Stream output class
-class NetCDFStreamWriter(AbstractOutputWriter):
-    def __init__(self):
-        self._nc = None
-        self._cfg = None
-        self._total_steps = 0
-        self._dt = 300.0
-        self._global_start_time = None
- 
-        # Ordered arrays of integer IDs and type labels ('wb' or 'nex'),
-        # one entry per row in the NetCDF feature_id dimension.
-        self._output_ids = None 
-        self._output_types = None 
-
-        # Crosswalks
-        self._wb_id_to_pos:  Dict[int, int] = {}
-        self._nex_id_to_pos: Dict[int, int] = {}
-        self._nex_upstream:  Dict[int, List[int]] = {}
-
-    def initialize(self, config: Any, all_network_ids: np.ndarray, 
-                   total_sim_seconds: float, start_time: datetime, dt: float,
-                   rconn: Dict[int, List[int]]):
+# ---------------------------------------------------------------------------
+# OutputWriter
+# ---------------------------------------------------------------------------
+class OutputWriter:
+    """
+    Writes t-route model output to a single pre-allocated NetCDF file.
+    
+    Handles three feature types in the same file under separate dimensions:
+      - flowpath_id : individual reach outputs (streamflow, velocity, depth, nudge)
+      - nexus_id    : nexus aggregation points (streamflow, nudge only — additive)
+      - lake_id     : reservoir outputs (inflow, outflow, water_sfc_elev)
+    """
+    
+    def __init__(self, cfg: Dict, all_network_ids: np.ndarray,
+                 total_sim_seconds: float, start_time: datetime, dt: float,
+                 rconn: Dict[int, List[int]],
+                 waterbody_df: Optional[pd.DataFrame] = None,
+                 waterbody_types_df: Optional[pd.DataFrame] = None):
         
-        self._cfg = config
+        self._cfg = cfg
         self._dt = float(dt)
-        self._global_start_time = start_time
-        self._total_steps = int(total_sim_seconds // config['output_interval'])
+        self._start_time = start_time
+        self._output_interval = cfg['output_interval']
+        self._total_steps = int(total_sim_seconds // self._output_interval)
+        self._stream_vars = cfg['variables']['stream']
+        self._reservoir_vars = cfg['variables']['reservoir']
         
-        self.build_id_index(all_network_ids, rconn)
-        self.create_netcdf(config['output_path'], config['variables'], start_time)
+        # Reservoir domain (excluded from flowpaths)
+        reservoir_ids: Set[int] = (set(waterbody_df.index.tolist()) if waterbody_df is not None else set())
+        self._write_reservoirs = (
+            bool(self._reservoir_vars)
+            and waterbody_df is not None
+            and not waterbody_df.empty
+        )
+        
+        # Flowpath index
+        self._wb_ids, self._wb_id_to_pos = self._build_flowpath_index(all_network_ids, reservoir_ids)
+        
+        # Nexus index
+        self._nex_ids, self._nex_id_to_pos, self._nex_upstream, self._nex_upstream_ids = self._build_nexus_index(all_network_ids, rconn)
+        
+        # Reservoir index
+        if self._write_reservoirs:
+            self._lake_ids = np.sort(waterbody_df.index.to_numpy().astype(np.int64))
+            self._lake_id_to_pos = {int(lid): i for i, lid in enumerate(self._lake_ids)}
+            self._lake_ids_array = self._lake_ids
+        else:
+            self._lake_ids = np.array([], dtype=np.int64)
+            self._lake_id_to_pos = {}
+            self._lake_ids_array = np.array([], dtype=np.int64)
+        
+        # Initialize output arrays
+        num_ids = len(self._wb_ids)
+        self._buf_flow = np.full(num_ids, np.nan, dtype=np.float32)
+        self._buf_vel = np.full(num_ids, np.nan, dtype=np.float32)
+        self._buf_depth = np.full(num_ids, np.nan, dtype=np.float32)
+        
+        # Flag for nexus aggregation
+        self._need_nex_flow = bool(self._nex_upstream_ids) and 'streamflow' in self._stream_vars
+        
+        # Open and pre-allocate NetCDF
+        self._nc = self._create_netcdf(cfg['output_path'], start_time)
+        
+        LOG.info(
+            "OutputWriter ready: %s  "
+            "(%d flowpath, %d nexus, %d reservoir, %d timesteps)",
+            cfg['output_path'], num_ids, len(self._nex_ids),
+            len(self._lake_ids), self._total_steps,
+        )
+        
+    # ------------------------------------------------------------------
+    # Index builders
+    # ------------------------------------------------------------------
+    def _build_flowpath_index(self, all_network_ids: np.ndarray,
+                               reservoir_ids: Set[int]
+                               ) -> Tuple[np.ndarray, Dict[int, int]]:
+        """
+        Build the sorted flowpath ID array and its position lookup dict.
+        
+        Reservoir segment IDs are excluded from the flowpath domain so they
+        don't appear as regular reaches in the output.  If a subset_file is
+        configured with a 'feature_ids' key, only those IDs are written;
+        if none match the network the full domain is used as a fallback.
+        """
+        subset_ids = self._load_subset_ids('feature_ids')
+        all_fp = set(all_network_ids.tolist()) - reservoir_ids
+        
+        if subset_ids is not None:
+            valid = subset_ids & all_fp
+            if not valid:
+                LOG.warning("subset_file feature_ids had no matches; "
+                            "writing all flowpath IDs")
+                valid = all_fp
+        else:
+            valid = all_fp
+            
+        ids = np.sort(np.array(list(valid), dtype=np.int64))
+        return ids, {int(fid): i for i, fid in enumerate(ids)}
+    
+    def _build_nexus_index(self, all_network_ids: np.ndarray,
+                            rconn: Dict[int, List[int]]
+                            ) -> Tuple[np.ndarray, Dict[int, int],
+                                       Dict[int, List[int]], Set[int]]:
+        """
+        Build the nexus index from the 'nexuses' key in the subset_file.
+        
+        For each requested nexus ID, rconn is queried to find its immediate
+        upstream flowpath IDs.
+        
+        Returns empty structures when no nexus subset is configured.
+        """
+        nex_ids = self._load_subset_ids('nexuses')
+        if not nex_ids:
+            empty: np.ndarray = np.array([], dtype=np.int64)
+            return empty, {}, {}, frozenset()
+        
+        all_set = set(all_network_ids.tolist())
+        nex_upstream = {}
+        for nid in sorted(nex_ids):
+            upstream = [u for u in rconn.get(nid, []) if u in all_set]
+            if not upstream:
+                LOG.warning("Nexus %d has no resolvable upstream reaches", nid)
+            nex_upstream[nid] = upstream
+            
+        ids = np.sort(np.array(list(nex_ids), dtype=np.int64))
+        id_to_pos = {int(nid): i for i, nid in enumerate(ids)}
+        upstream_ids = set(chain.from_iterable(nex_upstream.values()))
+        return ids, id_to_pos, nex_upstream, upstream_ids
+    
+    def _load_subset_ids(self, key: str) -> Optional[Set[int]]:
+        """
+        Read feature_ids or nexuses from the subset_file YAML.
+        Returns None if no subset file is configured or the key is absent.
+        TODO: Add reservoir filtering too?
+        """
+        subset_file = self._cfg.get('subset_file')
+        if not subset_file:
+            return None
+        with open(subset_file) as fh:
+            data = yaml.safe_load(fh)
+        raw = data.get(key, []) if isinstance(data, dict) else []
+        return _parse_int_ids(raw) if raw else None
+    
+    # ------------------------------------------------------------------
+    # NetCDF creation
+    # ------------------------------------------------------------------
+    def _create_netcdf(self, output_path: str, start_time: datetime) -> nc.Dataset:
+        """
+        Create and pre-allocate the output NetCDF file.
+        
+        All dimensions, coordinate variables, and data variables are created
+        here before the simulation loop begins, so each write_step call only
+        needs to fill pre-existing variable slices rather than modify file
+        structure.  The three feature types share the same file but use
+        separate dimensions (flowpath_id, nexus_id, lake_id).
+        """
+        ds = nc.Dataset(output_path, 'w', format='NETCDF4')
+        
+        # time dimension
+        ds.createDimension('time', self._total_steps)
+        
+        # ID dimensions
+        if len(self._wb_ids):
+            ds.createDimension('flowpath_id', len(self._wb_ids))
+        if len(self._nex_ids):
+            ds.createDimension('nexus_id', len(self._nex_ids))
+        if len(self._lake_ids):
+            ds.createDimension('lake_id', len(self._lake_ids))
+            
+        # time
+        vt = ds.createVariable('time', 'i4', ('time',), fill_value=-9999)
+        vt.units = 'minutes since {}'.format(start_time.strftime('%Y-%m-%d %H:%M:%S'))
+        vt.calendar = 'standard'
+        vt.long_name = 'valid output time'
+        
+        # coordinate variables
+        if len(self._wb_ids):
+            v = ds.createVariable('flowpath_id', 'i4', ('flowpath_id',))
+            v.long_name = 'Flowpath integer ID'
+            v[:] = self._wb_ids.astype(np.int32)
+            
+        if len(self._nex_ids):
+            v = ds.createVariable('nexus_id', 'i4', ('nexus_id',))
+            v.long_name = 'Nexus integer ID'
+            v[:] = self._nex_ids.astype(np.int32)
+            
+        if len(self._lake_ids):
+            v = ds.createVariable('lake_id', 'i4', ('lake_id',))
+            v.long_name = 'Reservoir (lake) integer ID'
+            v[:] = self._lake_ids.astype(np.int32)
+            
+        # data variables
+        comp = dict(zlib=True, complevel=2, fill_value=np.nan)
+        
+        if len(self._wb_ids):
+            for var in self._stream_vars:
+                units, long_name = _VAR_ATTRS.get(var, ('', var))
+                v = ds.createVariable(var, 'f4', ('time', 'flowpath_id'),
+                                      chunksizes=(1, len(self._wb_ids)), **comp)
+                v.units = units
+                v.long_name = long_name
+                
+        if len(self._nex_ids):
+            for var in self._stream_vars:
+                if var =='streamflow':
+                    units, long_name = _VAR_ATTRS.get(var, ('', var))
+                    v = ds.createVariable('nex_' + var, 'f4', ('time', 'nexus_id'),
+                                          chunksizes=(1, len(self._nex_ids)), **comp)
+                    v.units = units
+                    v.long_name = long_name + ' (nexus aggregation)'
+                    
+        if len(self._lake_ids):
+            for var in self._reservoir_vars:
+                units, long_name = _VAR_ATTRS.get(var, ('', var))
+                v = ds.createVariable(var, 'f4', ('time', 'lake_id'),
+                                      chunksizes=(1, len(self._lake_ids)), **comp)
+                v.units = units
+                v.long_name = long_name
+                
+        ds.Conventions = 'CF-1.8'
+        return ds
 
+    # ------------------------------------------------------------------
+    # Write data to file
+    # ------------------------------------------------------------------
     def write_step(self, run_results: List[Tuple],
                    current_chunk_start_time: datetime):
-        if self._nc is None or not run_results:
+        """
+        Called once per routing chunk.  Identifies all output-aligned timesteps
+        within this chunk, then loops run_results to extract data
+        for all of them before writing.
+        """
+        if not run_results:
             return
-        
-        fvd_sample = run_results[0][1]
+        fvd_sample = next((r[1] for r in run_results if r[1] is not None), None)
+        if fvd_sample is None:
+            return
+
         nts_chunk = fvd_sample.shape[1] // 3
-        output_interval = self._cfg['output_interval']
-        
+
+        # Find which internal step indices align with output_interval
+        output_steps = []
         for i in range(1, nts_chunk + 1):
             step_time = current_chunk_start_time + timedelta(seconds=i * self._dt)
-            elapsed   = (step_time - self._global_start_time).total_seconds()
- 
-            if abs(elapsed % output_interval) < 0.1:
-                nc_idx = int(round(elapsed / output_interval)) - 1
+            elapsed   = (step_time - self._start_time).total_seconds()
+            if abs(elapsed % self._output_interval) < 0.1:
+                nc_idx = int(round(elapsed / self._output_interval)) - 1
                 if 0 <= nc_idx < self._total_steps:
-                    self.write_frame(run_results, step_time, i - 1, nc_idx)
- 
+                    output_steps.append((i - 1, nc_idx, step_time))
+
+        if not output_steps:
+            return
+
+        # Write time coordinate for each output step
+        for step_index, nc_idx, step_time in output_steps:
+            elapsed_min = int((step_time - self._start_time).total_seconds() / 60)
+            self._nc.variables['time'][nc_idx] = elapsed_min
+
+        # Single pass over run_results, extracting all output timesteps at once
+        self._extract_and_write(run_results, output_steps)
+
+    def _extract_and_write(self, run_results: List[Tuple],
+                            output_steps: List[Tuple]):
+        """
+        Single pass over run_results. For each chunk, extracts all needed q/v/d columns at once, 
+        then places them into per-timestep output buffers.
+        """
+        n_steps = len(output_steps)
+        num_wb = len(self._wb_ids)
+        wb_sorted = self._wb_ids
+
+        # Pre-allocate per-timestep output buffers for all steps at once
+        flow_out = np.full((n_steps, num_wb), np.nan, dtype=np.float32)
+        vel_out = np.full((n_steps, num_wb), np.nan, dtype=np.float32)
+        depth_out = np.full((n_steps, num_wb), np.nan, dtype=np.float32)
+
+        # Reservoir and nudge remain per-step dicts
+        nudge_per_step  = [{} for _ in range(n_steps)]
+        res_out_per_step = res_elev_per_step = res_in_per_step = None
+        if self._write_reservoirs:
+            nlake = len(self._lake_ids)
+            res_out_per_step = np.full((n_steps, nlake), np.nan, dtype=np.float32)
+            res_elev_per_step = np.full((n_steps, nlake), np.nan, dtype=np.float32)
+            res_in_per_step = np.full((n_steps, nlake), np.nan, dtype=np.float32)
+
+        # Extract step_index -> column offset mapping
+        step_q_cols = [s * 3 + _Q_COL for s, _, _ in output_steps]
+        step_v_cols = [s * 3 + _V_COL for s, _, _ in output_steps]
+        step_d_cols = [s * 3 + _D_COL for s, _, _ in output_steps]
+
+        for r in run_results:
+            seg_ids = r[0]
+            fvd = r[1]
+            if seg_ids is None or len(seg_ids) == 0 or fvd is None:
+                continue
+            
+            # Split reservoir vs flowpath once for this chunk
+            if self._write_reservoirs:
+                res_mask = np.isin(seg_ids, self._lake_ids_array)
+                fp_mask = ~res_mask
+            else:
+                res_mask = np.zeros(len(seg_ids), dtype=bool)
+                fp_mask = np.ones(len(seg_ids), dtype=bool)
+            
+            # flowpaths
+            if fp_mask.any():
+                fp_ids = seg_ids[fp_mask]
+                pos = np.searchsorted(wb_sorted, fp_ids)
+                pos = np.clip(pos, 0, len(wb_sorted) - 1)
+                in_wb = wb_sorted[pos] == fp_ids
+                if in_wb.any():
+                    out_pos = pos[in_wb]
+                    # Extract all needed columns at once, then scatter
+                    fvd_wb = fvd[fp_mask][in_wb]
+                    for k, (qc, vc, dc) in enumerate(zip(step_q_cols, step_v_cols, step_d_cols)):
+                        flow_out[k, out_pos] = fvd_wb[:, qc]
+                        vel_out[k, out_pos] = fvd_wb[:, vc]
+                        depth_out[k, out_pos] = fvd_wb[:, dc]
+            
+            # reservoirs
+            if self._write_reservoirs and res_mask.any():
+                res_ids = seg_ids[res_mask]
+                res_pos = np.array([self._lake_id_to_pos.get(int(s), -1)
+                                    for s in res_ids], dtype=np.intp)
+                valid = res_pos >= 0
+                if valid.any():
+                    vpos = res_pos[valid]
+                    fvd_res = fvd[res_mask][valid]
+                    for k, (qc, dc) in enumerate(zip(step_q_cols, step_d_cols)):
+                        res_out_per_step[k, vpos] = fvd_res[:, qc]
+                        res_elev_per_step[k, vpos] = fvd_res[:, dc]
+
+                # inflow from r[6]
+                if r[6] is not None:
+                    inflow_data = r[6]
+                    inflow_res = inflow_data[res_mask][valid]
+                    for k, (step_index, _, _) in enumerate(output_steps):
+                        res_in_per_step[k, vpos] = inflow_res[:, step_index]
+            
+            # nudge
+            if 'nudge' in self._stream_vars:
+                for k, (step_index, _, _) in enumerate(output_steps):
+                    _collect_nudge(r, step_index, nudge_per_step[k])
+        
+        # Write all output timesteps to NetCDF
+        nc_vars = self._nc.variables
+        for k, (_, nc_idx, _) in enumerate(output_steps):
+            self._write_flowpath_frame(nc_vars, nc_idx,
+                                       flow_out[k], vel_out[k], depth_out[k],
+                                       nudge_per_step[k])
+            if len(self._nex_ids):
+                self._write_nexus_frame(nc_vars, nc_idx,
+                                        flow_out[k])
+            if self._write_reservoirs:
+                self._write_reservoir_frame(nc_vars, nc_idx,
+                                            res_out_per_step[k],
+                                            res_elev_per_step[k],
+                                            res_in_per_step[k])
+
+    def _write_flowpath_frame(self, nc_vars, nc_idx,
+                               flow, vel, depth, nudge_dict):
+        """
+        Write one timestep of flowpath output to the NetCDF file.
+        
+        flow, vel, and depth are pre-allocated numpy arrays already indexed
+        to the flowpath output domain (length = n_flowpath_ids), filled by
+        _extract_and_write. nudge is handled separately because it is sparse
+        so it is passed as a dict and scattered into a NaN buffer here.
+        """
+        buf_map = {'streamflow': flow, 'velocity': vel, 'depth': depth}
+        for var in self._stream_vars:
+            if var in buf_map:
+                nc_vars[var][nc_idx, :] = buf_map[var]
+            elif var == 'nudge':
+                buf = np.full(len(self._wb_ids), np.nan, dtype=np.float32)
+                for sid, val in nudge_dict.items():
+                    pos = self._wb_id_to_pos.get(sid)
+                    if pos is not None:
+                        buf[pos] = val
+                nc_vars[var][nc_idx, :] = buf
+
+    def _write_nexus_frame(self, nc_vars, nc_idx, flow_arr):
+        """
+        Write one timestep of nexus output to the NetCDF file. Only works
+        for streamflow variable, which is a sum of upstream flows.
+        """
+        for var in self._stream_vars:
+            if var != "streamflow":
+                continue
+            buf = np.full(len(self._nex_ids), np.nan, dtype=np.float32)
+            for nid, pos in self._nex_id_to_pos.items():
+                upstream = self._nex_upstream.get(nid, [])
+                if not upstream:
+                    continue
+                vals = []
+                for u in upstream:
+                    wb_pos = self._wb_id_to_pos.get(u)
+                    if wb_pos is not None:
+                        v = flow_arr[wb_pos]
+                        if not np.isnan(v):
+                            vals.append(v)
+                if vals:
+                    buf[pos] = sum(vals)
+                    
+            nc_vars["nex_" + var][nc_idx, :] = buf
+
+    def _write_reservoir_frame(self, nc_vars, nc_idx,
+                                outflow, elev, inflow):
+        """
+        Write one timestep of reservoir output to the NetCDF file.
+        
+        outflow and elev come from r[1] columns 0 and 2 respectively,
+        following the same layout as flowpath flow and depth.  inflow
+        comes from r[6].  All three are pre-indexed numpy arrays of length
+        n_lake_ids, filled by _extract_and_write.
+        """
+        # TODO: add reservoir assimilated values below...
+        src_map = {'inflow': inflow, 'outflow': outflow, 'water_sfc_elev': elev, 'reservoir_assimilated_value': None}
+        for var in self._reservoir_vars:
+            arr = src_map.get(var)
+            if arr is not None:
+                nc_vars[var][nc_idx, :] = arr
+            else:
+                nc_vars[var][nc_idx, :] = np.full(
+                    len(self._lake_ids), np.nan, dtype=np.float32)
+
     def close(self):
         if self._nc:
             self._nc.sync()
             self._nc.close()
             self._nc = None
 
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+def _parse_int_ids(raw: list) -> Set[int]:
+    """
+    Convert a raw yaml list to a set of integers. Strips prefix-dash strings
+    like 'nex-12345' or 'wb-12345' by taking everything after the last dash.
+    """
+    out = set()
+    for item in raw:
+        if isinstance(item, int):
+            out.add(item)
+            continue
+        s = str(item).strip()
+        if '-' in s:
+            s = s.rsplit('-', 1)[-1]
+        try:
+            out.add(int(s))
+        except ValueError:
+            LOG.warning("Could not parse ID %r as integer — skipping", item)
+    return out
 
-    # Helper Functions
-    def build_id_index(self, all_network_ids: np.ndarray,
-                       rconn: Dict[int, List[int]]):
-        """
-        Parse the subset file (if any) and build all internal lookup
-        structures.  Rows are ordered: sorted wb reaches first, then
-        sorted nexus rows.
-        """
-        wb_ids, nex_ids = self.load_subset(all_network_ids)
- 
-        # Find the upstream connections for each requested nexus.
-        all_set = set(all_network_ids.tolist())
-        nex_upstream = {}
-        
-        for nid in sorted(nex_ids):
-            upstream = [u for u in rconn.get(nid, []) if u in all_set]
-            nex_upstream[nid] = upstream
- 
-        wb_sorted = np.sort(np.array(list(wb_ids),  dtype=np.int64))
-        nex_sorted = np.sort(np.array(list(nex_ids), dtype=np.int64))
- 
-        self._output_ids = np.concatenate([wb_sorted, nex_sorted])
-        self._output_types = np.array(
-            ['wb'] * len(wb_sorted) + ['nex'] * len(nex_sorted),
-            dtype='U3'
-        )
- 
-        offset = len(wb_sorted)
-        self._wb_id_to_pos = {int(fid): i for i, fid in enumerate(wb_sorted)}
-        self._nex_id_to_pos = {int(nid): offset + i
-                               for i, nid in enumerate(nex_sorted)}
-        self._nex_upstream = nex_upstream
-        
-        self._nex_upstream_ids: frozenset = frozenset(
-            uid for upstream in nex_upstream.values() for uid in upstream
-        )
- 
-    def load_subset(self, all_network_ids: np.ndarray
-                     ) -> Tuple[Set[int], Set[int]]:
-        """
-        Return (wb_ids, nex_ids) as sets of integers.
- 
-        If no subset file is configured, wb_ids contains all network IDs
-        and nex_ids is empty.
-        """
-        subset_file = self._cfg.get('subset_file')
-        if not subset_file:
-            return set(all_network_ids.tolist()), set()
- 
-        with open(subset_file) as fh:
-            data = yaml.safe_load(fh)
-
-        raw_wb, raw_nex = [], []
-        raw_wb  = data.get('feature_ids', [])
-        raw_nex = data.get('nexuses', [])
-
-        wb_ids  = self.remove_prefix(raw_wb)
-        nex_ids = self.remove_prefix(raw_nex)
- 
-        all_set = set(all_network_ids.tolist())
-        invalid_wb = wb_ids - all_set
-        if invalid_wb:
-            LOG.warning("%d requested feature_ids not found in network and "
-                        "will be skipped", len(invalid_wb))
-        wb_ids &= all_set
- 
-        if not wb_ids and not nex_ids:
-            LOG.warning("subset_file produced no usable IDs; "
-                        "writing all network IDs as wb reaches")
-            return all_set, set()
-        
-        return wb_ids, nex_ids
- 
-    @staticmethod
-    def remove_prefix(raw: list) -> Set[int]:
-        out = set([int(float(s.split('-', 1)[-1])) for s in raw])
-        return out
- 
-    def create_netcdf(self, output_path: str, variables: List[str],
-                       start_time: datetime):
-        nfeatures = len(self._output_ids)
- 
-        self._nc = nc.Dataset(output_path, 'w', format='NETCDF4')
-        self._nc.createDimension('time', self._total_steps)
-        self._nc.createDimension('feature_id', nfeatures)
- 
-        v_id = self._nc.createVariable('feature_id', 'i4', ('feature_id',))
-        v_id.long_name = 'Reach or nexus integer ID'
-        # v_id.cf_role = 'timeseries_id' TODO: DELETE
-        v_id[:] = self._output_ids.astype(np.int32)
- 
-        # 'wb' for flowpath reaches, 'nex' for nexus aggregation rows
-        v_type = self._nc.createVariable('feature_type', str, ('feature_id',))
-        v_type.long_name = ('Feature type: "wb" = flowpath reach, "nex" = nexus point')
-        v_type[:] = self._output_types
-        
-        v_time = self._nc.createVariable('time', 'i4', ('time',), fill_value=-9999)
-        v_time.units = 'minutes since {}'.format(start_time.strftime('%Y-%m-%d %H:%M:%S'))
-        v_time.calendar = 'standard'
-        v_time.long_name = 'valid output time'
- 
-        chunk_dims = (1, nfeatures)
-        comp_args = dict(zlib=True, complevel=2, fill_value=np.nan,
-                         chunksizes=chunk_dims)
- 
-        for var_name in variables:
-            units, long_name = _VAR_ATTRS.get(var_name, ('', var_name))
-            v = self._nc.createVariable(var_name, 'f4', ('time', 'feature_id'), **comp_args)
-            v.units = units
-            v.long_name = long_name
- 
-        self._nc.featureType = 'timeSeries'
-        self._nc.Conventions = 'CF-1.8'
- 
-        LOG.info("NetCDF stream output initialised: %s  "
-                 "(%d wb reaches, %d nexus points, %d timesteps)",
-                 output_path, len(self._wb_id_to_pos),
-                 len(self._nex_id_to_pos), self._total_steps)
-
-    def write_frame(self, run_results: List[Tuple], abs_time: datetime,
-                     step_index: int, nc_time_idx: int):
-        elapsed_min = int((abs_time - self._global_start_time).total_seconds() / 60)
-        self._nc.variables['time'][nc_time_idx] = elapsed_min
- 
-        base_col = step_index * 3
-        variables = self._cfg['variables']
-        nout = len(self._output_ids)
- 
-        output_dict = {v: np.full(nout, np.nan, dtype=np.float32) for v in variables}
-        
-        # Dictionaries for nexus aggregation: seg_id -> value this timestep.
-        seg_flow = {}  # populated when streamflow or nexus rows are needed
-        seg_nudge = {}  # populated when nudge is requested
- 
-        need_nexus_sums = bool(self._nex_id_to_pos) and 'streamflow' in variables
-        need_nudge_sums = bool(self._nex_id_to_pos) and 'nudge' in variables
-        
-        # Loop through results list and save needed output values
-        for r in run_results:
-            seg_ids = r[0]
-            fvd = r[1]
- 
-            if seg_ids is None or len(seg_ids) == 0 or fvd is None:
-                continue
-            
-            seg_ids = np.asarray(seg_ids, dtype=np.int64)
-            wb_pos = np.array([self._wb_id_to_pos.get(int(s), -1)
-                               for s in seg_ids], dtype=np.intp)
-            wb_mask = wb_pos >= 0
- 
-            if wb_mask.any():
-                valid_pos = wb_pos[wb_mask]
-                for var in variables:
-                    if var in _FVD_POSITIONS:
-                        col = base_col + _FVD_POSITIONS[var]
-                        output_dict[var][valid_pos] = fvd[wb_mask, col]
- 
-            # Save nexus upstream flows for aggregation
-            if need_nexus_sums:
-                flow_col = base_col + _FVD_POSITIONS['streamflow']
-                flow_vals = fvd[:, flow_col]
-                for sid, val in zip(seg_ids, flow_vals):
-                    sid = int(sid)
-                    if sid in self._nex_upstream_ids:
-                        seg_flow[int(sid)] = float(val)
- 
-            if need_nudge_sums or ('nudge' in variables and self._wb_id_to_pos):
-                self._collect_nudge(r, step_index, seg_nudge)
- 
-        # Write nudge to wb rows
-        if 'nudge' in variables:
-            #TODO: Validate that this works...
-            for sid, val in seg_nudge.items():
-                pos = self._wb_id_to_pos.get(sid)
-                if pos is not None:
-                    output_dict['nudge'][pos] = val
-        
-        # Aggregate for nexus rows
-        for nid, pos in self._nex_id_to_pos.items():
-            upstream = self._nex_upstream.get(nid, [])
-            if not upstream:
-                continue
- 
-            if 'streamflow' in variables:
-                vals = [seg_flow[u] for u in upstream if u in seg_flow]
-                if vals:
-                    output_dict['streamflow'][pos] = sum(vals)
- 
-            if 'nudge' in variables:
-                vals = [seg_nudge[u] for u in upstream if u in seg_nudge]
-                if vals:
-                    output_dict['nudge'][pos] = sum(vals)
-        
-        # Write to file
-        for var, data in output_dict.items():
-            self._nc.variables[var][nc_time_idx, :] = data
- 
-    def collect_nudge(self, r: Tuple, step_index: int,
-                       seg_nudge: Dict[int, float]):
-        """
-        Pull nudge values for this timestep from r[8] into seg_nudge.
- 
-        r[8] is expected to be a pandas DataFrame indexed by segment ID
-        with one column per internal timestep.  Only gaged reaches appear;
-        un-gaged ones are simply absent from the DataFrame.
-        """
-        if len(r) <= 8:
-            return
- 
-        nudge_df = r[8]
-        if nudge_df is None or not isinstance(nudge_df, pd.DataFrame):
-            return
-        if nudge_df.empty or step_index >= len(nudge_df.columns):
-            return
- 
-        col = nudge_df.iloc[:, step_index]
-        for sid, val in col.items():
-            if not np.isnan(val):
-                seg_nudge[int(sid)] = float(val)
+def _collect_nudge(r: Tuple, step_index: int, seg_nudge: Dict[int, float]) -> None:
+    """
+    Pull nudge values for one timestep from r[8] into seg_nudge.
+    """
+    nudge_arr = r[8]
+    if not isinstance(nudge_arr, np.ndarray) or nudge_arr.shape[0]==0:
+        return
+    if step_index >= nudge_arr.shape[1]:
+        return
+    gauge_ids = r[3][0]
+    col = nudge_arr[:, step_index]
+    for gid, val in zip(gauge_ids, col):
+        seg_nudge[int(gid)] = float(val)

--- a/src/troute-nwm/src/nwm_routing/output_nextgen.py
+++ b/src/troute-nwm/src/nwm_routing/output_nextgen.py
@@ -1,0 +1,190 @@
+import netCDF4 as nc
+import numpy as np
+import pandas as pd
+import yaml
+import time
+from datetime import datetime, timedelta
+from abc import ABC, abstractmethod
+from typing import List, Tuple, Dict, Optional, Any
+import logging
+
+LOG = logging.getLogger(__name__)
+
+class AbstractOutputWriter(ABC):
+    @abstractmethod
+    def initialize(self, config: Any, all_network_ids: np.ndarray, 
+                   total_sim_seconds: float, start_time: datetime, dt: float):
+        pass
+
+    @abstractmethod
+    def write_step(self, run_results: List[Tuple], 
+                   current_chunk_start_time: datetime):
+        pass
+
+    @abstractmethod
+    def close(self):
+        pass
+
+class NetCDFStreamWriter(AbstractOutputWriter):
+    def __init__(self):
+        self.nc = None
+        self.cfg = None
+        self.sorter = None
+        self.output_ids = None
+        self.total_steps = 0
+        self.dt = 300.0  
+        self.global_start_time = None 
+        
+        # Offsets for standard variables in the r[1] array
+        self.var_offsets = {
+            'streamflow': 0, 'velocity': 1, 'depth': 2
+        }
+
+    def initialize(self, config: Any, all_network_ids: np.ndarray, 
+                   total_sim_seconds: float, start_time: datetime, dt: float):
+        
+        self.cfg = config
+        self.dt = float(dt)
+        self.global_start_time = start_time
+        
+        output_path = self.cfg['output_path']
+        output_interval = self.cfg['output_interval']
+        variables = self.cfg['variables']
+
+        LOG.info(f"Initializing NetCDF Stream Output: {output_path}")
+
+        # 1. Calculate Total Output Steps
+        self.total_steps = int(total_sim_seconds // output_interval)
+        
+        # 2. Setup ID Indexing
+        self._setup_indexing(all_network_ids)
+
+        # 3. Create NetCDF
+        self.nc = nc.Dataset(output_path, "w", format="NETCDF4")
+        self.nc.createDimension("time", self.total_steps)
+        self.nc.createDimension("feature_id", len(self.output_ids))
+        self.nc.createDimension("reference_time", 1)
+
+        # 4. Coordinates
+        v_id = self.nc.createVariable("feature_id", "i4", ("feature_id",))
+        v_id[:] = self.output_ids
+
+        v_time = self.nc.createVariable("time", "i4", ("time",), fill_value=-9999)
+        v_time.units = f"minutes since {start_time.strftime('%Y-%m-%d %H:%M:%S')}"
+        v_time.calendar = "standard"
+        v_time.long_name = "valid output time"
+        
+        # 5. Data Variables
+        # Chunking Strategy: Optimize for writing one full timestep at a time (1 x N)
+        chunk_dims = (1, len(self.output_ids))
+        comp_args = {'zlib': True, 'complevel': 2, 'fill_value': np.nan, 'chunksizes': chunk_dims}
+        
+        for var_name in variables:
+            self.nc.createVariable(var_name, "f4", ("time", "feature_id"), **comp_args)
+
+    def _setup_indexing(self, all_network_ids: np.ndarray):
+        subset_ids = None
+        subset_file = self.cfg.get('subset_file')
+
+        if subset_file:
+            try:
+                with open(subset_file, 'r') as f:
+                    data = yaml.safe_load(f)
+                    if isinstance(data, dict):
+                        # Try common keys
+                        subset_ids = data.get('flowpath_ids') or data.get('link_ids') or list(data.values())[0]
+                    elif isinstance(data, list):
+                        subset_ids = data
+                    
+                    if subset_ids: 
+                        subset_ids = np.array(subset_ids)
+            except Exception as e:
+                LOG.error(f"Failed to read subset file: {e}")
+                raise
+
+        if subset_ids is not None:
+            valid_subset = np.intersect1d(all_network_ids, subset_ids)
+            self.output_ids = np.sort(valid_subset)
+        else:
+            self.output_ids = np.sort(all_network_ids)
+        
+        self.sorter = np.argsort(self.output_ids) 
+
+    def write_step(self, run_results: List[Tuple], current_chunk_start_time: datetime):
+        if self.nc is None or not run_results: return
+        
+        # 1. Determine dimensions
+        sample_r = run_results[0]
+        if sample_r[1] is None: return 
+        ncols = sample_r[1].shape[1]
+        nts_chunk = ncols // 3
+        
+        output_interval = self.cfg['output_interval']
+        
+        # 2. Iterate through internal timesteps
+        for i in range(1, nts_chunk + 1):
+            step_time = current_chunk_start_time + timedelta(seconds=i * self.dt)
+            time_since_start = (step_time - self.global_start_time).total_seconds()
+            
+            # Check alignment
+            if abs(time_since_start % output_interval) < 0.1:
+                nc_time_idx = int(round((time_since_start - output_interval) / output_interval))
+                
+                if 0 <= nc_time_idx < self.total_steps:
+                    self._write_single_frame(run_results, step_time, i-1, nc_time_idx)
+
+    def _write_single_frame(self, run_results: List[Tuple], absolute_time: datetime, 
+                            step_index: int, nc_time_idx: int):
+        
+        # Write Time Value
+        elapsed_minutes = int((absolute_time - self.global_start_time).total_seconds() / 60)
+        self.nc.variables['time'][nc_time_idx] = elapsed_minutes
+        
+        base_col = step_index * 3
+        
+        variables = self.cfg['variables']
+
+        # Allocate full domain arrays filled with NaN
+        data_buffers = {}
+        for var in variables:
+            data_buffers[var] = np.full(len(self.output_ids), np.nan, dtype=np.float32)
+        
+        # Fill buffers
+        for r in run_results:
+            chunk_ids = r[0]
+            if chunk_ids is None or len(chunk_ids) == 0: continue
+
+            # Index Lookup
+            idx_in_nc = np.searchsorted(self.output_ids, chunk_ids, sorter=self.sorter)
+            
+            # Mask Validation
+            in_bounds = idx_in_nc < len(self.output_ids)
+            valid_mask = np.zeros_like(in_bounds, dtype=bool)
+            valid_mask[in_bounds] = (self.output_ids[idx_in_nc[in_bounds]] == chunk_ids[in_bounds])
+
+            if not np.any(valid_mask): continue
+            
+            target_indices = idx_in_nc[valid_mask]
+
+            # Extract Data
+            for var_name in variables:
+                if var_name == 'nudge':
+                    #TODO: Update to include nudge values. Skipping for now.
+                    # Nudge Logic: Usually r[8]. Needs Mapping if Nudge IDs != Seg IDs
+                    pass
+                elif var_name in self.var_offsets:
+                    offset = self.var_offsets[var_name]
+                    target_col = base_col + offset
+                    
+                    # Fill Buffer
+                    data_buffers[var_name][target_indices] = r[1][:, target_col][valid_mask]
+
+        # Write to disk
+        for var_name, data_array in data_buffers.items():
+            self.nc.variables[var_name][nc_time_idx, :] = data_array
+
+    def close(self):
+        if self.nc:
+            self.nc.sync()
+            self.nc.close()
+            self.nc = None

--- a/src/troute-nwm/src/nwm_routing/output_nextgen.py
+++ b/src/troute-nwm/src/nwm_routing/output_nextgen.py
@@ -37,7 +37,7 @@ class OutputWriter:
     Writes t-route model output to a single pre-allocated NetCDF file.
     
     Handles three feature types in the same file under separate dimensions:
-      - flowpath_id : individual reach outputs (streamflow, velocity, depth, nudge)
+      - feature_id  : individual reach outputs (streamflow, velocity, depth, nudge)
       - nexus_id    : nexus aggregation points (streamflow, nudge only — additive)
       - lake_id     : reservoir outputs (inflow, outflow, water_sfc_elev)
     """
@@ -218,7 +218,7 @@ class OutputWriter:
         here before the simulation loop begins, so each write_step call only
         needs to fill pre-existing variable slices rather than modify file
         structure.  The three feature types share the same file but use
-        separate dimensions (flowpath_id, nexus_id, lake_id).
+        separate dimensions (feature_id, nexus_id, lake_id).
         """
         ds = nc.Dataset(output_path, 'w', format='NETCDF4')
         
@@ -227,7 +227,7 @@ class OutputWriter:
         
         # ID dimensions
         if len(self._wb_ids):
-            ds.createDimension('flowpath_id', len(self._wb_ids))
+            ds.createDimension('feature_id', len(self._wb_ids))
         if len(self._nex_ids):
             ds.createDimension('nexus_id', len(self._nex_ids))
         if len(self._lake_ids):
@@ -241,7 +241,7 @@ class OutputWriter:
         
         # coordinate variables
         if len(self._wb_ids):
-            v = ds.createVariable('flowpath_id', 'i4', ('flowpath_id',))
+            v = ds.createVariable('feature_id', 'i4', ('feature_id',))
             v.long_name = 'Flowpath integer ID'
             v[:] = self._wb_ids.astype(np.int32)
             
@@ -261,7 +261,7 @@ class OutputWriter:
         if len(self._wb_ids):
             for var in self._stream_vars:
                 units, long_name = _VAR_ATTRS.get(var, ('', var))
-                v = ds.createVariable(var, 'f4', ('time', 'flowpath_id'),
+                v = ds.createVariable(var, 'f4', ('time', 'feature_id'),
                                       chunksizes=(1, len(self._wb_ids)), **comp)
                 v.units = units
                 v.long_name = long_name
@@ -433,7 +433,7 @@ class OutputWriter:
         Write one timestep of flowpath output to the NetCDF file.
         
         flow, vel, and depth are pre-allocated numpy arrays already indexed
-        to the flowpath output domain (length = n_flowpath_ids), filled by
+        to the flowpath output domain (length = n_feature_ids), filled by
         _extract_and_write. nudge is handled separately because it is sparse
         so it is passed as a dict and scattered into a NaN buffer here.
         """

--- a/src/troute-nwm/src/nwm_routing/output_nextgen.py
+++ b/src/troute-nwm/src/nwm_routing/output_nextgen.py
@@ -42,19 +42,19 @@ class OutputWriter:
       - lake_id     : reservoir outputs (inflow, outflow, water_sfc_elev)
     """
     
-    def __init__(self, cfg: Dict, all_network_ids: np.ndarray,
+    def __init__(self, cfg: Dict, output_cfg: Dict, all_network_ids: np.ndarray,
                  total_sim_seconds: float, start_time: datetime, dt: float,
-                 rconn: Dict[int, List[int]],
+                 rconn: Dict[int, List[int]], q0: pd.DataFrame,
                  waterbody_df: Optional[pd.DataFrame] = None,
-                 waterbody_types_df: Optional[pd.DataFrame] = None):
+                 waterbody_types_df: Optional[pd.DataFrame] = None,):
         
-        self._cfg = cfg
+        self._output_cfg = output_cfg
         self._dt = float(dt)
         self._start_time = start_time
-        self._output_interval = cfg['output_interval']
-        self._total_steps = int(total_sim_seconds // self._output_interval)
-        self._stream_vars = cfg['variables']['stream']
-        self._reservoir_vars = cfg['variables']['reservoir']
+        self._output_interval = output_cfg['output_interval']
+        self._total_steps = int(total_sim_seconds // self._output_interval) + 1
+        self._stream_vars = output_cfg['variables']['stream']
+        self._reservoir_vars = output_cfg['variables']['reservoir']
         
         # Reservoir domain (excluded from flowpaths)
         reservoir_ids: Set[int] = (set(waterbody_df.index.tolist()) if waterbody_df is not None else set())
@@ -90,15 +90,50 @@ class OutputWriter:
         self._need_nex_flow = bool(self._nex_upstream_ids) and 'streamflow' in self._stream_vars
         
         # Open and pre-allocate NetCDF
-        self._nc = self._create_netcdf(cfg['output_path'], start_time)
+        self._nc = self._create_netcdf(output_cfg['output_path'], start_time, cfg)
+        
+        # Write initial conditions to file
+        self._write_initial_conditions(q0)
         
         LOG.info(
             "OutputWriter ready: %s  "
             "(%d flowpath, %d nexus, %d reservoir, %d timesteps)",
-            cfg['output_path'], num_ids, len(self._nex_ids),
+            output_cfg['output_path'], num_ids, len(self._nex_ids),
             len(self._lake_ids), self._total_steps,
         )
+    
+    # ------------------------------------------------------------------
+    # Write initial conditions
+    # ------------------------------------------------------------------
+    def _write_initial_conditions(self, q0: pd.DataFrame):
+        """Extracts t=0 state from q0 and writes to the first NetCDF index."""
+        self._nc.variables['time'][0] = 0 # 0 minutes elapsed
         
+        # Flowpaths
+        if len(self._wb_ids):
+            # Intersect q0 with valid flowpaths
+            valid_fps = q0.index.intersection(self._wb_ids)
+            q0_fp = q0.loc[valid_fps]
+            
+            # Map q0 columns to netcdf variables (qu0 -> streamflow, qd0 -> velocity, h0 -> depth)
+            if 'streamflow' in self._stream_vars and 'qu0' in q0_fp.columns:
+                flow_buf = np.full(len(self._wb_ids), np.nan, dtype=np.float32)
+                pos = [self._wb_id_to_pos[fid] for fid in valid_fps]
+                flow_buf[pos] = q0_fp['qu0'].values
+                self._nc.variables['streamflow'][0, :] = flow_buf
+            
+            if 'velocity' in self._stream_vars and 'qd0' in q0_fp.columns:
+                flow_buf = np.full(len(self._wb_ids), np.nan, dtype=np.float32)
+                pos = [self._wb_id_to_pos[fid] for fid in valid_fps]
+                flow_buf[pos] = q0_fp['qd0'].values
+                self._nc.variables['velocity'][0, :] = flow_buf
+                
+            if 'depth' in self._stream_vars and 'h0' in q0_fp.columns:
+                depth_buf = np.full(len(self._wb_ids), np.nan, dtype=np.float32)
+                pos = [self._wb_id_to_pos[fid] for fid in valid_fps]
+                depth_buf[pos] = q0_fp['h0'].values
+                self._nc.variables['depth'][0, :] = depth_buf
+    
     # ------------------------------------------------------------------
     # Index builders
     # ------------------------------------------------------------------
@@ -164,7 +199,7 @@ class OutputWriter:
         Returns None if no subset file is configured or the key is absent.
         TODO: Add reservoir filtering too?
         """
-        subset_file = self._cfg.get('subset_file')
+        subset_file = self._output_cfg.get('subset_file')
         if not subset_file:
             return None
         with open(subset_file) as fh:
@@ -175,7 +210,7 @@ class OutputWriter:
     # ------------------------------------------------------------------
     # NetCDF creation
     # ------------------------------------------------------------------
-    def _create_netcdf(self, output_path: str, start_time: datetime) -> nc.Dataset:
+    def _create_netcdf(self, output_path: str, start_time: datetime, full_config: Optional[Dict] = None) -> nc.Dataset:
         """
         Create and pre-allocate the output NetCDF file.
         
@@ -249,6 +284,10 @@ class OutputWriter:
                 v.long_name = long_name
                 
         ds.Conventions = 'CF-1.8'
+        
+        if full_config:
+            ds.model_configuration = yaml.dump(full_config, default_flow_style=False)
+        
         return ds
 
     # ------------------------------------------------------------------
@@ -275,7 +314,7 @@ class OutputWriter:
             step_time = current_chunk_start_time + timedelta(seconds=i * self._dt)
             elapsed   = (step_time - self._start_time).total_seconds()
             if abs(elapsed % self._output_interval) < 0.1:
-                nc_idx = int(round(elapsed / self._output_interval)) - 1
+                nc_idx = int(round(elapsed / self._output_interval))
                 if 0 <= nc_idx < self._total_steps:
                     output_steps.append((i - 1, nc_idx, step_time))
 


### PR DESCRIPTION
Updates to handle reading NextGen forcing data from a single netcdf file of q_lateral values (rather than from multiple files). There is also a new output writing method that puts all t-route outputs (stream flow, velocity, and depth, and lake inflow, outflow, and water surface elevation) into a single netcdf output file. 

Methods for also writing stream nudge values and reservoir assimilated values are outlined, but need further testing/verification.

This also includes an update from @jduckerOWP to t-route's makefile to handle netcdf-fortrain compiling issues.

This PR also incorporates updates to run on the hydrofabric v2.2.

## Additions

- Read single netcdf input file containing q_lateral data produced by NextGen
- Write single netcdf output file containing all t-route outputs

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
